### PR TITLE
PtrotocolLib integration to block recipes from being send to clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
             <id>wolfyscript-private</id>
             <url>https://maven.wolfyscript.com/repository/private/</url>
         </repository>
+        <repository>
+            <id>dmulloy2-repo</id>
+            <url>https://repo.dmulloy2.net/repository/public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -83,6 +87,11 @@
             <scope>provided</scope>
         </dependency>
         <!-- Plugin dependencies -->
+        <dependency>
+            <groupId>com.comphenix.protocol</groupId>
+            <artifactId>ProtocolLib</artifactId>
+            <version>4.7.0</version>
+        </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>

--- a/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
@@ -156,7 +156,6 @@ public class CustomCrafting extends JavaPlugin {
     public void onLoad() {
         getLogger().info("WolfyUtilities API: " + Bukkit.getPluginManager().getPlugin("WolfyUtilities"));
         getLogger().info("Environment: " + WolfyUtilities.getENVIRONMENT());
-        this.otherPlugins.init();
 
         getLogger().info("Registering custom data");
         Registry.CUSTOM_ITEM_DATA.register(new EliteWorkbenchData.Provider());
@@ -203,6 +202,8 @@ public class CustomCrafting extends JavaPlugin {
         writeBanner();
         writePatreonCredits();
         writeSeparator();
+
+        this.otherPlugins.init();
 
         configHandler = new ConfigHandler(this);
         configHandler.loadRecipeBookConfig();

--- a/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
@@ -53,6 +53,7 @@ import me.wolfyscript.customcrafting.recipes.items.target.MergeAdapter;
 import me.wolfyscript.customcrafting.recipes.items.target.adapters.*;
 import me.wolfyscript.customcrafting.utils.*;
 import me.wolfyscript.customcrafting.utils.cooking.CookingManager;
+import me.wolfyscript.customcrafting.utils.other_plugins.OtherPlugins;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.chat.Chat;
 import me.wolfyscript.utilities.api.inventory.gui.InventoryAPI;
@@ -116,6 +117,7 @@ public class CustomCrafting extends JavaPlugin {
 
     private DisableRecipesHandler disableRecipesHandler;
 
+    private final OtherPlugins otherPlugins;
     private final boolean isPaper;
 
     public CustomCrafting() {
@@ -123,6 +125,7 @@ public class CustomCrafting extends JavaPlugin {
         instance = this;
         currentVersion = getDescription().getVersion();
         this.version = WUVersion.parse(currentVersion.split("-")[0]);
+        this.otherPlugins = new OtherPlugins(this);
         isPaper = WolfyUtilities.hasClass("com.destroystokyo.paper.utils.PaperPluginLogger");
         api = WolfyUtilities.get(this, false);
         this.chat = api.getChat();
@@ -153,6 +156,8 @@ public class CustomCrafting extends JavaPlugin {
     public void onLoad() {
         getLogger().info("WolfyUtilities API: " + Bukkit.getPluginManager().getPlugin("WolfyUtilities"));
         getLogger().info("Environment: " + WolfyUtilities.getENVIRONMENT());
+        this.otherPlugins.init();
+
         getLogger().info("Registering custom data");
         Registry.CUSTOM_ITEM_DATA.register(new EliteWorkbenchData.Provider());
         Registry.CUSTOM_ITEM_DATA.register(new RecipeBookData.Provider());

--- a/src/main/java/me/wolfyscript/customcrafting/utils/other_plugins/OtherPlugins.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/other_plugins/OtherPlugins.java
@@ -1,0 +1,43 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.utils.other_plugins;
+
+import me.wolfyscript.customcrafting.CustomCrafting;
+import org.bukkit.Bukkit;
+
+public class OtherPlugins {
+
+    private final CustomCrafting plugin;
+
+    private ProtocolLib protocolLib = null;
+
+    public OtherPlugins(CustomCrafting plugin) {
+        this.plugin = plugin;
+    }
+
+    public void init() {
+        if (Bukkit.getPluginManager().getPlugin("ProtocolLib") != null) {
+            this.protocolLib = new ProtocolLib(plugin);
+        }
+    }
+}

--- a/src/main/java/me/wolfyscript/customcrafting/utils/other_plugins/OtherPlugins.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/other_plugins/OtherPlugins.java
@@ -37,6 +37,7 @@ public class OtherPlugins {
 
     public void init() {
         if (Bukkit.getPluginManager().getPlugin("ProtocolLib") != null) {
+            plugin.getLogger().info("Detected ProtocolLib... initiating additional features.");
             this.protocolLib = new ProtocolLib(plugin);
         }
     }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/other_plugins/ProtocolLib.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/other_plugins/ProtocolLib.java
@@ -30,6 +30,7 @@ import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.reflect.FieldUtils;
+import com.comphenix.protocol.reflect.StructureModifier;
 import com.comphenix.protocol.wrappers.MinecraftKey;
 import me.wolfyscript.customcrafting.CCRegistry;
 import me.wolfyscript.customcrafting.CustomCrafting;
@@ -72,28 +73,13 @@ public class ProtocolLib {
             @Override
             public void onPacketSending(PacketEvent event) {
                 PacketContainer packet = event.getPacket();
-                List<MinecraftKey> recipes = null;
-                List<MinecraftKey> highlightedRecipes = null;
-                try {
-                    recipes = (List<MinecraftKey>) FieldUtils.readField(packet.getHandle(), "b", true);
-                    highlightedRecipes = (List<MinecraftKey>) FieldUtils.readField(packet.getHandle(), "c", true);
-                } catch (IllegalAccessException e) {
-                    e.printStackTrace();
-                }
-                if(recipes != null) {
-                    try {
-                        FieldUtils.writeField(packet.getHandle(), "b", recipes.stream().filter(recipeFilter::apply).collect(Collectors.toList()));
-                    } catch (IllegalAccessException e) {
-                        e.printStackTrace();
-                    }
-                }
-                if(highlightedRecipes != null) {
-                    try {
-                        FieldUtils.writeField(packet.getHandle(), "c", highlightedRecipes.stream().filter(recipeFilter::apply).collect(Collectors.toList()));
-                    } catch (IllegalAccessException e) {
-                        e.printStackTrace();
-                    }
-                }
+                StructureModifier<List<MinecraftKey>> lists = packet.getLists(MinecraftKey.getConverter());
+                lists.modify(0, input -> { //Modify the recipes
+                    return input.stream().filter(recipeFilter::apply).collect(Collectors.toList());
+                });
+                lists.modify(1, input -> { //Modify Highlighted recipes
+                    return input.stream().filter(recipeFilter::apply).collect(Collectors.toList());
+                });
             }
         });
 

--- a/src/main/java/me/wolfyscript/customcrafting/utils/other_plugins/ProtocolLib.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/other_plugins/ProtocolLib.java
@@ -1,0 +1,103 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.utils.other_plugins;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.reflect.FieldUtils;
+import com.comphenix.protocol.wrappers.MinecraftKey;
+import me.wolfyscript.customcrafting.CCRegistry;
+import me.wolfyscript.customcrafting.CustomCrafting;
+import me.wolfyscript.customcrafting.recipes.CustomRecipe;
+import me.wolfyscript.customcrafting.recipes.ICustomVanillaRecipe;
+import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ProtocolLib {
+
+    private final CustomCrafting plugin;
+    private final ProtocolManager protocolManager;
+
+    public ProtocolLib(CustomCrafting plugin) {
+        this.plugin = plugin;
+        this.protocolManager = ProtocolLibrary.getProtocolManager();
+        init();
+    }
+
+    private void init() {
+        registerServerSide();
+    }
+
+    private void registerServerSide() {
+        Function<MinecraftKey, Boolean> recipeFilter = minecraftKey -> {
+            if (minecraftKey.getPrefix().equals(NamespacedKeyUtils.NAMESPACE)) {
+                CustomRecipe<?> recipe = CCRegistry.RECIPES.get(NamespacedKeyUtils.toInternal(NamespacedKey.of(minecraftKey.getFullKey())));
+                if (recipe instanceof ICustomVanillaRecipe<?> vanillaRecipe && vanillaRecipe.isVisibleVanillaBook()) {
+                    return !recipe.isHidden() && !recipe.isDisabled();
+                }
+                return false;
+            }
+            return true;
+        };
+        protocolManager.addPacketListener(new PacketAdapter(plugin, ListenerPriority.HIGH, PacketType.Play.Server.RECIPES) {
+            @Override
+            public void onPacketSending(PacketEvent event) {
+                PacketContainer packet = event.getPacket();
+                List<MinecraftKey> recipes = null;
+                List<MinecraftKey> highlightedRecipes = null;
+                try {
+                    recipes = (List<MinecraftKey>) FieldUtils.readField(packet.getHandle(), "b", true);
+                    highlightedRecipes = (List<MinecraftKey>) FieldUtils.readField(packet.getHandle(), "c", true);
+                } catch (IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+                if(recipes != null) {
+                    try {
+                        FieldUtils.writeField(packet.getHandle(), "b", recipes.stream().filter(recipeFilter::apply).collect(Collectors.toList()));
+                    } catch (IllegalAccessException e) {
+                        e.printStackTrace();
+                    }
+                }
+                if(highlightedRecipes != null) {
+                    try {
+                        FieldUtils.writeField(packet.getHandle(), "c", highlightedRecipes.stream().filter(recipeFilter::apply).collect(Collectors.toList()));
+                    } catch (IllegalAccessException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        });
+
+
+    }
+
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,5 +4,5 @@ main: me.wolfyscript.customcrafting.CustomCrafting
 version: ${project.version}
 api-version: "1.16"
 depend: [ WolfyUtilities ]
-softdepend: [ MythicMobs, Oraxen, ItemsAdder, PlaceholderAPI ]
+softdepend: [ ProtocolLib, MythicMobs, Oraxen, ItemsAdder, PlaceholderAPI ]
 description: Create your own custom recipes for workbenches and furnaces. Disable Vanilla recipes and more.


### PR DESCRIPTION
This integration fixes the issue caused by too many recipes (or using items with too much nbt data). See https://bugs.mojang.com/browse/MC-185901  

If ProtocolLib is detected it will prevent recipes from being sent to the clients. 
That means your players won't be able to all view your recipes with mods like JEI.  
Of course the recipes you enable for the vanilla recipe book will still be sent and players can see them.