### PR TITLE
Fixed some 1.18 loading issues

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/CCRegistry.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CCRegistry.java
@@ -107,7 +107,7 @@ public interface CCRegistry<T extends me.wolfyscript.utilities.util.Keyed> exten
             if (value instanceof ICustomVanillaRecipe vanillaRecipe && !value.isDisabled()) {
                 try {
                     Bukkit.addRecipe(vanillaRecipe.getVanillaRecipe());
-                } catch (IllegalArgumentException ex) {
+                } catch (IllegalArgumentException | IllegalStateException ex) {
                     CustomCrafting.inst().getLogger().warning(String.format("Failed to add recipe '%s' to Bukkit: %s", namespacedKey, ex.getMessage()));
                 }
             }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
@@ -202,7 +202,7 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
         super.writeToJson(gen, serializerProvider);
         gen.writeObjectFieldStart("dropItems");
         gen.writeBooleanField("enabled", dropItems);
-        gen.writeObjectField("handItem", handItem.getApiReference());
+        gen.writeObjectField("handItem", handItem != null ? handItem.getApiReference() : null);
         gen.writeEndObject();
         gen.writeNumberField("exp", xp);
         gen.writeNumberField("cookingTime", cookingTime);


### PR DESCRIPTION
Fixed - If a custom recipe cannot be added to Bukkit it will crash the plugin. 

This was found to be the case in Spigot 1.18, as the Bukkit#removeRecipe method doesn't seem to work yet! In the Spigot 1.17 the recipe is correctly removed... just to be sure I added this check.