### PR TITLE
Craft Remains support stacked items now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.wolfyscript.wolfyutilities</groupId>
             <artifactId>wolfyutilities</artifactId>
-            <version>1.7.8.1</version>
+            <version>1.8.0.0</version>
             <scope>provided</scope>
         </dependency>
         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.wolfyscript.wolfyutilities</groupId>
             <artifactId>wolfyutilities</artifactId>
-            <version>1.7.6.0</version>
+            <version>1.7.8.1</version>
             <scope>provided</scope>
         </dependency>
         <!--

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
@@ -43,7 +43,10 @@ import me.wolfyscript.utilities.libraries.com.fasterxml.jackson.core.type.TypeRe
 import me.wolfyscript.utilities.libraries.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.utilities.libraries.com.fasterxml.jackson.databind.SerializerProvider;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -140,10 +143,14 @@ public abstract class CraftingRecipe<C extends CraftingRecipe<C, S>, S extends C
     }
 
     public void removeMatrix(Inventory inventory, int totalAmount, CraftingData craftingData) {
+        removeMatrix(null, inventory, totalAmount, craftingData);
+    }
+
+    public void removeMatrix(@Nullable Player player, @Nullable Inventory inventory, int totalAmount, CraftingData craftingData) {
         craftingData.getIndexedBySlot().forEach((slot, data) -> {
             var item = data.customItem();
             if (item != null) {
-                item.remove(data.itemStack(), totalAmount, inventory, null, data.ingredient().isReplaceWithRemains());
+                item.remove(data.itemStack(), totalAmount, inventory, player, player != null ? player.getLocation() : null, data.ingredient().isReplaceWithRemains());
             }
         });
     }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
@@ -118,7 +118,7 @@ public class CraftManager {
                 editStatistics(player, inventory, recipe);
                 setPlayerCraftTime(player, recipe);
                 recipeResult.executeExtensions(inventory.getLocation() == null ? event.getWhoClicked().getLocation() : inventory.getLocation(), inventory.getLocation() != null, (Player) event.getWhoClicked());
-                calculateClick(player, event, craftingData, recipe, recipeResult, result);
+                calculateClick(player, event, craftingData, recipe, recipeResult);
             }
             remove(event.getWhoClicked().getUniqueId());
         }
@@ -143,7 +143,8 @@ public class CraftManager {
         }
     }
 
-    private void calculateClick(Player player, InventoryClickEvent event, CraftingData craftingData, CraftingRecipe<?, ?> recipe, Result recipeResult, ItemStack result) {
+    private void calculateClick(Player player, InventoryClickEvent event, CraftingData craftingData, CraftingRecipe<?, ?> recipe, Result recipeResult) {
+        ItemStack result = recipeResult.getItem(craftingData, player, null);
         int possible = event.isShiftClick() ? Math.min(InventoryUtils.getInventorySpace(player.getInventory(), result) / result.getAmount(), recipe.getAmountCraftable(craftingData)) : 1;
         recipe.removeMatrix(player, event.getClickedInventory(), possible, craftingData);
         if (event.isShiftClick()) {

--- a/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
@@ -152,7 +152,13 @@ public class CraftManager {
                 for (int i = 0; i < possible; i++) {
                     var customItem = results.next();
                     if (customItem != null) {
-                        player.getInventory().addItem(recipeResult.getItem(craftingData, customItem, player, null));
+                        var item = recipeResult.getItem(craftingData, customItem, player, null);
+                        if (InventoryUtils.hasInventorySpace(player, item)) {
+                            player.getInventory().addItem(item);
+                        } else {
+                            var loc = player.getLocation();
+                            loc.getWorld().dropItem(loc, item);
+                        }
                     }
                 }
             }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
@@ -145,7 +145,7 @@ public class CraftManager {
 
     private void calculateClick(Player player, InventoryClickEvent event, CraftingData craftingData, CraftingRecipe<?, ?> recipe, Result recipeResult, ItemStack result) {
         int possible = event.isShiftClick() ? Math.min(InventoryUtils.getInventorySpace(player.getInventory(), result) / result.getAmount(), recipe.getAmountCraftable(craftingData)) : 1;
-        recipe.removeMatrix(event.getClickedInventory(), possible, craftingData);
+        recipe.removeMatrix(player, event.getClickedInventory(), possible, craftingData);
         if (event.isShiftClick()) {
             if (possible > 0) {
                 RandomCollection<CustomItem> results = recipeResult.getRandomChoices(player);


### PR DESCRIPTION
They did support it before, but there were some issues if you had used an un-stackable item as an ingredient. The item wouldn't be detected as stackable and therefor if you somehow used that item in your recipe the whole stack would be converted.

From now on, if the the item used inside the crafting table is has craft remains and it's stacksize is bigger than 1 it will put the remains into the players inventory. If there is no space, they will be dropped on the ground.

- Added Player parameter to CraftingRecipe.removeMatrix.
- CraftManager#calculateClick no longer uses the result ItemStack from the CraftingInventory.
- Fixed - If an item with craft remain (bucket, bowl, etc.) is stacked, the material of the whole stack is edited.