### PR TITLE
Brewing Editor Invalid Initial State When Editing Saved Recipe

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/BrewingGUICache.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/BrewingGUICache.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.data.cache;
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.Pair;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -29,6 +30,7 @@ import org.bukkit.potion.PotionEffectType;
 public class BrewingGUICache {
 
     private String option;
+    private NamespacedKey parsedOptionKey;
 
     int page;
 
@@ -41,6 +43,7 @@ public class BrewingGUICache {
     public BrewingGUICache() {
         this.page = 0;
         this.option = "";
+        this.parsedOptionKey = null;
         this.potionEffectAddition = null;
         this.replacePotionEffectAddition = false;
         this.upgradePotionEffectType = null;
@@ -61,6 +64,14 @@ public class BrewingGUICache {
 
     public void setOption(String option) {
         this.option = option;
+    }
+
+    public NamespacedKey getParsedOptionKey() {
+        return parsedOptionKey;
+    }
+
+    public void setParsedOptionKey(NamespacedKey parsedOptionKey) {
+        this.parsedOptionKey = parsedOptionKey;
     }
 
     public boolean isReplacePotionEffectAddition() {

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorBrewing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorBrewing.java
@@ -58,8 +58,6 @@ public class RecipeCreatorBrewing extends RecipeCreator {
     private static final String DURATION_CHANGE = "duration_change";
     private static final String AMPLIFIER_CHANGE = "amplifier_change";
 
-    private NamespacedKey parsedOptionRecipe;
-
     public RecipeCreatorBrewing(GuiCluster<CCCache> cluster, CustomCrafting customCrafting) {
         super(cluster, "brewing_stand", 54, customCrafting);
     }
@@ -462,12 +460,12 @@ public class RecipeCreatorBrewing extends RecipeCreator {
         // Ignore cache and parse option from the saved recipe if we're loading it fresh
         if (
             brewingRecipe.isSaved() &&
-            parsedOptionRecipe != brewingRecipe.getKey()
+            brewingGUICache.getParsedOptionKey() != brewingRecipe.getKey()
         ) {
             String option = parseOption(brewingRecipe);
 
             brewingGUICache.setOption(option);
-            parsedOptionRecipe = brewingRecipe.getKey();
+            brewingGUICache.setParsedOptionKey(brewingRecipe.getKey());
 
             return option;
         }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorBrewing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorBrewing.java
@@ -25,7 +25,9 @@ package me.wolfyscript.customcrafting.gui.recipe_creator;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.data.CCPlayerData;
+import me.wolfyscript.customcrafting.data.cache.BrewingGUICache;
 import me.wolfyscript.customcrafting.data.cache.potions.PotionEffects;
+import me.wolfyscript.customcrafting.data.cache.recipe_creator.RecipeCacheBrewing;
 import me.wolfyscript.customcrafting.gui.potion_creator.ClusterPotionCreator;
 import me.wolfyscript.customcrafting.utils.PlayerUtil;
 import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
@@ -55,6 +57,8 @@ public class RecipeCreatorBrewing extends RecipeCreator {
     private static final String ALLOWED_ITEMS = "allowed_items";
     private static final String DURATION_CHANGE = "duration_change";
     private static final String AMPLIFIER_CHANGE = "amplifier_change";
+
+    private NamespacedKey parsedOptionRecipe;
 
     public RecipeCreatorBrewing(GuiCluster<CCCache> cluster, CustomCrafting customCrafting) {
         super(cluster, "brewing_stand", 54, customCrafting);
@@ -390,7 +394,7 @@ public class RecipeCreatorBrewing extends RecipeCreator {
         update.setButton(16, "effect_upgrades.option");
         update.setButton(17, "required_effects.option");
 
-        switch (brewingGUICache.getOption()) {
+        switch (getOption(brewingGUICache, brewingRecipe)) {
             case "result":
                 update.setButton(32, "recipe.result");
                 update.setButton(34, "result.info");
@@ -430,4 +434,44 @@ public class RecipeCreatorBrewing extends RecipeCreator {
         update.setButton(53, ClusterRecipeCreator.SAVE_AS);
     }
 
+    private static String parseOption(RecipeCacheBrewing brewingRecipe) {
+        if (!brewingRecipe.getResult().isEmpty()) {
+            return "result";
+        }
+
+        if (!brewingRecipe.getEffectRemovals().isEmpty()) {
+            return "effect_removals";
+        }
+
+        if (!brewingRecipe.getEffectAdditions().isEmpty()) {
+            return "effect_additions";
+        }
+
+        if (!brewingRecipe.getEffectUpgrades().isEmpty()) {
+            return "effect_upgrades";
+        }
+
+        if (!brewingRecipe.getRequiredEffects().isEmpty()) {
+            return "required_effects";
+        }
+
+        return "";
+    }
+
+    private String getOption(BrewingGUICache brewingGUICache, RecipeCacheBrewing brewingRecipe) {
+        // Ignore cache and parse option from the saved recipe if we're loading it fresh
+        if (
+            brewingRecipe.isSaved() &&
+            parsedOptionRecipe != brewingRecipe.getKey()
+        ) {
+            String option = parseOption(brewingRecipe);
+
+            brewingGUICache.setOption(option);
+            parsedOptionRecipe = brewingRecipe.getKey();
+
+            return option;
+        }
+
+        return brewingGUICache.getOption();
+    }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorBrewing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorBrewing.java
@@ -254,7 +254,7 @@ public class RecipeCreatorBrewing extends RecipeCreator {
         registerButton(new ActionButton<>("effect_additions.remove", Material.RED_CONCRETE, (cache, guiHandler, player, inventory, i, event) -> {
             var brewingRecipe = cache.getRecipeCreatorCache().getBrewingCache();
             var potionEffectCache = cache.getPotionEffectCache();
-            potionEffectCache.setApplyPotionEffectType((cache1, potionEffectType) -> brewingRecipe.getEffectAdditions().remove(potionEffectType));
+            potionEffectCache.setApplyPotionEffectType((cache1, potionEffectType) -> brewingRecipe.getEffectAdditions().keySet().removeIf(potionEffect -> potionEffect.getType().equals(potionEffectType)));
             potionEffectCache.setOpenedFrom(ClusterRecipeCreator.KEY, "brewing_stand");
             guiHandler.openWindow(ClusterPotionCreator.POTION_EFFECT_TYPE_SELECTION);
             return true;


### PR DESCRIPTION
When initially editing a saved brewing recipe we need to ignore the cached editor `option` and parse a value from the recipe values. Following GUI updates should then only use the cache value as it may have changed.
Comparison against the stored `parsedOptionRecipe` value is required as the editor is reused between different recipes.

Also includes a fix for the remove effect button not working for `effect_additions`