### PR TITLE
Implemented bulk crafting for ResultExtensions

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/handlers/ConfigHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/ConfigHandler.java
@@ -30,10 +30,7 @@ import me.wolfyscript.customcrafting.recipes.CraftingRecipeShaped;
 import me.wolfyscript.customcrafting.recipes.CraftingRecipeShapeless;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
 import me.wolfyscript.customcrafting.recipes.items.Result;
-import me.wolfyscript.customcrafting.recipes.items.extension.CommandResultExtension;
-import me.wolfyscript.customcrafting.recipes.items.extension.MythicMobResultExtension;
-import me.wolfyscript.customcrafting.recipes.items.extension.ResultExtensionAdvancement;
-import me.wolfyscript.customcrafting.recipes.items.extension.SoundResultExtension;
+import me.wolfyscript.customcrafting.recipes.items.extension.*;
 import me.wolfyscript.customcrafting.utils.ItemLoader;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.utilities.api.WolfyUtilities;
@@ -143,7 +140,9 @@ public class ConfigHandler {
             Result result = workbenchCraft.getResult();
             result.put(0, CustomItem.with(new WolfyUtilitiesRef(CustomCrafting.INTERNAL_ADVANCED_CRAFTING_TABLE)));
             if (WolfyUtilities.isDevEnv()) {
-                result.addExtension(new CommandResultExtension(Arrays.asList("say hi %player%", "effect give %player% minecraft:strength 100 100"), new ArrayList<>(), true, true));
+                var commandExecution = new CommandResultExtension(Arrays.asList("say hi %player%", "effect give %player% minecraft:strength 100 100"), new ArrayList<>(), true, true);
+                commandExecution.setExecutionType(ExecutionType.BULK);
+                result.addExtension(commandExecution);
                 result.addExtension(new SoundResultExtension(Sound.BLOCK_ANVIL_USE));
                 result.addExtension(new MythicMobResultExtension("SkeletalKnight", 1));
                 result.addExtension(new ResultExtensionAdvancement(NamespacedKey.minecraft("husbandry/tactical_fishing"), false, null, false, false));

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/CommandResultExtension.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/CommandResultExtension.java
@@ -23,7 +23,7 @@
 package me.wolfyscript.customcrafting.recipes.items.extension;
 
 import me.clip.placeholderapi.PlaceholderAPI;
-import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.Bukkit;
@@ -44,7 +44,7 @@ public class CommandResultExtension extends ResultExtension {
     private boolean nearWorkstation = false;
 
     public CommandResultExtension() {
-        super(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "command"));
+        super(new NamespacedKey(CustomCrafting.inst(), "command"));
     }
 
     public CommandResultExtension(CommandResultExtension extension) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/ExecutionType.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/ExecutionType.java
@@ -1,0 +1,30 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes.items.extension;
+
+public enum ExecutionType {
+
+    BULK,
+    ONCE
+
+}

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/ExecutionType.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/ExecutionType.java
@@ -22,9 +22,20 @@
 
 package me.wolfyscript.customcrafting.recipes.items.extension;
 
+/**
+ * Defines the way a {@link ResultExtension} will be executed in recipes.
+ */
 public enum ExecutionType {
 
+    /**
+     * If possible the extension will be executed in bulk.<br>
+     * e.g. in crafting recipes.
+     */
     BULK,
+    /**
+     * The default value.<br>
+     * The extension will always be executed once.
+     */
     ONCE
 
 }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/MythicMobResultExtension.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/MythicMobResultExtension.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.recipes.items.extension;
 
+import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.compatibility.plugins.MythicMobsIntegration;
@@ -42,7 +43,7 @@ public class MythicMobResultExtension extends ResultExtension {
     private Vector offset = new Vector(0.5, 1, 0.5);
 
     public MythicMobResultExtension() {
-        super(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "mythicmobs/mob_spawn"));
+        super(new NamespacedKey(CustomCrafting.inst(), "mythicmobs/mob_spawn"));
     }
 
     public MythicMobResultExtension(MythicMobResultExtension extension) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/ResultExtension.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/ResultExtension.java
@@ -50,19 +50,21 @@ import java.util.stream.Collectors;
 @JsonPropertyOrder(value = {"key", "outerRadius", "innerRadius"})
 public abstract class ResultExtension implements Keyed {
 
-    protected @JsonIgnore
-    Material icon = Material.CHAIN_COMMAND_BLOCK;
-    protected @JsonIgnore
-    String title = "&6&lExtension";
-    protected @JsonIgnore
-    List<String> description;
+    @JsonIgnore
+    protected Material icon = Material.CHAIN_COMMAND_BLOCK;
+    @JsonIgnore
+    protected String title = "&6&lExtension";
+    @JsonIgnore
+    protected List<String> description;
 
     @JsonProperty(value = "key")
+    @JsonInclude
     private final NamespacedKey namespacedKey;
     @JsonAlias(value = "outer_radius")
     protected Vector outerRadius = new Vector(0, 0, 0);
     @JsonAlias(value = "inner_radius")
     protected Vector innerRadius = new Vector(0, 0, 0);
+    protected ExecutionType executionType = ExecutionType.ONCE;
 
     protected ResultExtension(ResultExtension extension) {
         this.namespacedKey = extension.namespacedKey;
@@ -71,6 +73,7 @@ public abstract class ResultExtension implements Keyed {
         this.description = extension.description;
         this.outerRadius = extension.outerRadius;
         this.innerRadius = extension.innerRadius;
+        this.executionType = extension.executionType;
     }
 
     protected ResultExtension(NamespacedKey namespacedKey) {
@@ -157,12 +160,20 @@ public abstract class ResultExtension implements Keyed {
         this.outerRadius = outerRadius;
     }
 
+    public ExecutionType getExecutionType() {
+        return executionType;
+    }
+
+    public void setExecutionType(ExecutionType executionType) {
+        this.executionType = executionType;
+    }
+
     protected <E extends Entity> List<E> getEntitiesInRange(Class<E> entityType, Location location, Vector outerRadius, Vector innerRadius) {
         var world = location.getWorld();
         if (world != null) {
             List<E> outerEntities = world.getNearbyEntities(location, outerRadius.getX(), outerRadius.getZ(), outerRadius.getZ(), entityType::isInstance).stream().map(entityType::cast).collect(Collectors.toList());
             if (innerRadius.getX() != 0 || innerRadius.getY() != 0 || innerRadius.getZ() != 0) {
-                List<E> innerEntities = world.getNearbyEntities(location, innerRadius.getX(), innerRadius.getZ(), innerRadius.getZ(), entityType::isInstance).stream().map(entityType::cast).collect(Collectors.toList());
+                List<E> innerEntities = world.getNearbyEntities(location, innerRadius.getX(), innerRadius.getZ(), innerRadius.getZ(), entityType::isInstance).stream().map(entityType::cast).toList();
                 outerEntities.removeAll(innerEntities);
             }
             return outerEntities;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/ResultExtensionAdvancement.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/ResultExtensionAdvancement.java
@@ -24,7 +24,7 @@ package me.wolfyscript.customcrafting.recipes.items.extension;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
-import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.customcrafting.CustomCrafting;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
@@ -46,7 +46,7 @@ public class ResultExtensionAdvancement extends ResultExtension {
     private boolean nearWorkstation = false;
 
     public ResultExtensionAdvancement() {
-        super(new me.wolfyscript.utilities.util.NamespacedKey(NamespacedKeyUtils.NAMESPACE, "advancement"));
+        super(new me.wolfyscript.utilities.util.NamespacedKey(CustomCrafting.inst(), "advancement"));
     }
 
     public ResultExtensionAdvancement(ResultExtensionAdvancement extension) {
@@ -90,7 +90,7 @@ public class ResultExtensionAdvancement extends ResultExtension {
 
     @JsonGetter
     private String getAdvancement() {
-        return advancement.toString();
+        return this.advancement.toString();
     }
 
     @JsonSetter

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/SoundResultExtension.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/extension/SoundResultExtension.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.recipes.items.extension;
 
+import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.Location;
@@ -44,7 +45,7 @@ public class SoundResultExtension extends ResultExtension {
     private boolean onBlock = true;
 
     public SoundResultExtension() {
-        super(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "sound"));
+        super(new NamespacedKey(CustomCrafting.inst(), "sound"));
     }
 
     public SoundResultExtension(SoundResultExtension extension) {

--- a/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
@@ -116,7 +116,6 @@ public class CraftManager {
                 Result recipeResult = craftingData.getResult();
                 editStatistics(player, inventory, recipe);
                 setPlayerCraftTime(player, recipe);
-                recipeResult.executeExtensions(inventory.getLocation() == null ? event.getWhoClicked().getLocation() : inventory.getLocation(), inventory.getLocation() != null, (Player) event.getWhoClicked());
                 calculateClick(player, event, craftingData, recipe, recipeResult);
             }
             remove(event.getWhoClicked().getUniqueId());
@@ -143,9 +142,11 @@ public class CraftManager {
     }
 
     private void calculateClick(Player player, InventoryClickEvent event, CraftingData craftingData, CraftingRecipe<?, ?> recipe, Result recipeResult) {
-        ItemStack result = recipeResult.getItem(craftingData, player, null);
+        var result = recipeResult.getItem(craftingData, player, null);
+        var inventory = event.getClickedInventory();
         int possible = event.isShiftClick() ? Math.min(InventoryUtils.getInventorySpace(player.getInventory(), result) / result.getAmount(), recipe.getAmountCraftable(craftingData)) : 1;
         recipe.removeMatrix(player, event.getClickedInventory(), possible, craftingData);
+        recipeResult.executeExtensions(inventory.getLocation() == null ? event.getWhoClicked().getLocation() : inventory.getLocation(), inventory.getLocation() != null, (Player) event.getWhoClicked(), possible);
         if (event.isShiftClick()) {
             if (possible > 0) {
                 RandomCollection<CustomItem> results = recipeResult.getRandomChoices(player);


### PR DESCRIPTION
Adds a new optional property to the ResultExtension called `executionType`.
Property:
`"ONCE"` (default) - The extension is always executed just once per completed craft.
`"BULK"` - The extension might be called multiple times in a row. E.g. shift crafting in the crafting table.

Resolves  #35 - Bulk-Crafting should behave differently with Extensions