### PR TITLE
Improvements to commands and config

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/DeleteSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/DeleteSubCommand.java
@@ -26,6 +26,7 @@ import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.commands.AbstractSubCommand;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
+import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.chat.ClickData;
 import me.wolfyscript.utilities.api.chat.ClickEvent;
@@ -39,7 +40,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class DeleteSubCommand extends AbstractSubCommand {
 
@@ -55,10 +60,21 @@ public class DeleteSubCommand extends AbstractSubCommand {
             if (key != null) {
                 CustomRecipe<?> customRecipe = customCrafting.getRegistries().getRecipes().get(key);
                 if (customRecipe != null) {
-                    api.getChat().sendMessage(player, "$msg.gui.recipe_editor.delete.confirm$", new Pair<>("%RECIPE%", customRecipe.getNamespacedKey().toString()));
-                    api.getChat().sendActionMessage(player, new ClickData("$msg.gui.recipe_editor.delete.confirmed$", (wolfyUtilities, player1) -> Bukkit.getScheduler().runTask(customCrafting, () -> customRecipe.delete(player))), new ClickData("$msg.gui.recipe_editor.delete.declined$", (wolfyUtilities, player1) -> api.getChat().sendMessage(player1, "§cCancelled"), new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/recipes delete ")));
+                    api.getChat().sendMessage(player, "$commands.recipes.delete.confirm$", new Pair<>("%recipe%", customRecipe.getNamespacedKey().toString()));
+                    api.getChat().sendActionMessage(player,
+                            new ClickData("$commands.recipes.delete.confirmation$",
+                                    (wolfyUtilities, player1) -> Bukkit.getScheduler().runTask(customCrafting, () -> customRecipe.delete(player)),
+                                    true
+                            ),
+                            new ClickData(
+                                    "$commands.recipes.delete.cancel$",
+                                    (wolfyUtilities, player1) -> {},
+                                    true,
+                                    new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/recipes delete ")
+                            )
+                    );
                 } else {
-                    api.getChat().sendMessage((Player) sender, "$msg.gui.recipe_editor.not_existing$", new Pair<>("%RECIPE%", args[0] + ":" + args[1]));
+                    api.getChat().sendMessage((Player) sender, "$commands.recipes.invalid_recipe$", new Pair<>("%recipe%", args[0]));
                 }
             }
         }

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/DeleteSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/DeleteSubCommand.java
@@ -84,9 +84,6 @@ public class DeleteSubCommand extends AbstractSubCommand {
     @Override
     protected @Nullable
     List<String> onTabComplete(@NotNull CommandSender var1, @NotNull String var3, @NotNull String[] args) {
-        List<String> results = new ArrayList<>();
-        List<String> recipes = customCrafting.getRegistries().getRecipes().keySet().stream().map(NamespacedKey::toString).toList();
-        StringUtil.copyPartialMatches(args[args.length - 1], recipes, results);
-        return results;
+        return NamespacedKeyUtils.getPartialMatches(args[args.length - 1], customCrafting.getRegistries().getRecipes().keySet()).stream().map(NamespacedKey::toString).collect(Collectors.toList());
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/EditSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/EditSubCommand.java
@@ -82,8 +82,6 @@ public class EditSubCommand extends AbstractSubCommand {
     @Nullable
     @Override
     protected List<String> onTabComplete(@NotNull CommandSender var1, @NotNull String var3, @NotNull String[] args) {
-        List<String> results = new ArrayList<>();
-        StringUtil.copyPartialMatches(args[args.length - 1], customCrafting.getRegistries().getRecipes().keySet().stream().map(NamespacedKey::toString).toList(), results);
-        return results;
+        return NamespacedKeyUtils.getPartialMatches(args[args.length - 1], customCrafting.getRegistries().getRecipes().keySet()).stream().map(NamespacedKey::toString).collect(Collectors.toList());
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/EditSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/EditSubCommand.java
@@ -29,6 +29,7 @@ import me.wolfyscript.customcrafting.gui.Setting;
 import me.wolfyscript.customcrafting.gui.recipe_creator.ClusterRecipeCreator;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
+import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -36,12 +37,12 @@ import me.wolfyscript.utilities.util.Pair;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class EditSubCommand extends AbstractSubCommand {
 
@@ -67,10 +68,10 @@ public class EditSubCommand extends AbstractSubCommand {
                             creatorCache.loadRecipeIntoCache(customRecipe);
                             Bukkit.getScheduler().runTaskLater(customCrafting, () -> api.getInventoryAPI().openGui(player, new NamespacedKey(ClusterRecipeCreator.KEY, creatorCache.getRecipeType().getCreatorID())), 1);
                         } catch (IllegalArgumentException ex) {
-                            api.getChat().sendMessage((Player) sender, "$msg.gui.recipe_editor.not_existing$", new Pair<>("%RECIPE%", args[0] + ":" + args[1]));
+                            api.getChat().sendMessage((Player) sender, "$commands.recipes.invalid_recipe$", new Pair<>("%recipe%", args[0]));
                         }
                     } else {
-                        api.getChat().sendMessage((Player) sender, "$msg.gui.recipe_editor.not_existing$", new Pair<>("%RECIPE%", args[0] + ":" + args[1]));
+                        api.getChat().sendMessage((Player) sender, "$commands.recipes.invalid_recipe$", new Pair<>("%recipe%", args[0]));
                     }
                 }
             }

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/EditSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/EditSubCommand.java
@@ -68,7 +68,7 @@ public class EditSubCommand extends AbstractSubCommand {
                             creatorCache.loadRecipeIntoCache(customRecipe);
                             Bukkit.getScheduler().runTaskLater(customCrafting, () -> api.getInventoryAPI().openGui(player, new NamespacedKey(ClusterRecipeCreator.KEY, creatorCache.getRecipeType().getCreatorID())), 1);
                         } catch (IllegalArgumentException ex) {
-                            api.getChat().sendMessage((Player) sender, "$commands.recipes.invalid_recipe$", new Pair<>("%recipe%", args[0]));
+                            api.getChat().sendMessage((Player) sender, "$commands.recipes.edit.invalid_recipe$", new Pair<>("%recipe%", args[0]));
                         }
                     } else {
                         api.getChat().sendMessage((Player) sender, "$commands.recipes.invalid_recipe$", new Pair<>("%recipe%", args[0]));

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/ToggleSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/ToggleSubCommand.java
@@ -26,6 +26,7 @@ import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.commands.AbstractSubCommand;
 import me.wolfyscript.customcrafting.recipes.CraftingRecipe;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
+import me.wolfyscript.utilities.util.Pair;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -50,10 +51,10 @@ public class ToggleSubCommand extends AbstractSubCommand {
             if (id.contains(":")) {
                 var namespacedKey = me.wolfyscript.utilities.util.NamespacedKey.of(id);
                 if (customCrafting.getDisableRecipesHandler().getRecipes().contains(namespacedKey)) {
-                    sender.sendMessage("Enabled recipe " + id);
+                    api.getChat().sendMessage((Player) sender, "$commands.recipes.toggle.enabled$", new Pair<>("%recipe%", args[0]));
                     customCrafting.getDisableRecipesHandler().getRecipes().remove(namespacedKey);
                 } else {
-                    sender.sendMessage("Disabled recipe " + id);
+                    api.getChat().sendMessage((Player) sender, "$commands.recipes.toggle.disabled$", new Pair<>("%recipe%", args[0]));
                     customCrafting.getDisableRecipesHandler().getRecipes().add(namespacedKey);
                     if (namespacedKey != null) {
                         Bukkit.getOnlinePlayers().forEach(player -> player.undiscoverRecipe(namespacedKey.toBukkit(customCrafting)));

--- a/src/main/java/me/wolfyscript/customcrafting/configs/config.yml
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/config.yml
@@ -15,62 +15,87 @@
 #       - %customcrafting_recipe_permission_[namespaced_key]%   > If the recipe requires a permission
 #       - %customcrafting_recipe_available_[namespaced_key]%    > If the recipe is available for the player
 
-debug: false              # Debug should be disabled! That are a lot of Messages!
+# Debug should be disabled! That are a lot of Messages!
+debug: false
 
-language: en_US           # The language you want use. The context: <language>_<country> Available languages' en_US, de_DE, zh_CN.
+# The language you want use. The context: <language>_<country> Available languages' en_US, de_DE, zh_CN.
 # If you want to edit a language copy it and rename it.
 # After renaming you can just use your language file name instead, and it will also be available in the in-game settings.
 # If you have any language file you would like to add to this plugin, then feel free to contact me.
+language: en_US
 
 creator:
-  reset_after_save: true  # Configure if the stored values and items you put or configured in the GUI should be cleared after saving a recipe.
+  # Configure if the stored values and items you put or configured in the GUI should be cleared after saving a recipe.
+  reset_after_save: true
 
 commands:
-  alias: [ "cc" ]         # Aliases for the main command of the plugin.
+  # Aliases for the main command of the plugin.
   # This is often used to prevent incompatibility with other plugins that use the same alias as ChatClear, etc.
+  alias: [ "cc" ]
 
 local_storage:
-  load: true              # this should always be true if you don't use a database or want to export your data to the database.
+  # this should always be true if you don't use a database or want to export your data to the database.
   # If you use a database you can still load local data, but configure how it loads them with the following settings below.
-
-  before_database: true   # Specifies if the local storage should be loaded before or after the database.
-    # This is useful if you have items/recipes that depend on items in the database or other way around.
+  load: true
+  # Specifies if the local storage should be loaded before or after the database.
+  # This is useful if you have items/recipes that depend on items in the database or other way around.
   # Make sure that the dependencies of items and recipes are loaded in the correct order.
-
-  override_data: false    # Sets if already existing recipes/items with the same namespaced key should be replaced when registered.
-    # Useful if you want to override a database recipe/item with the one from local storage.
-    # Or when "before_database" enabled override local recipes/items with database data.
+  before_database: true
+  # Sets if already existing recipes/items with the same namespaced key should be replaced when registered.
+  # Useful if you want to override a database recipe/item with the one from local storage.
+  # Or when "before_database" enabled override local recipes/items with database data.
   # The recipes can only be replaced in Minecraft 1.15+, because the API pre 1.15 is unstable.
+  override_data: false
 database:
-  enabled: false          # If the database feature should be used or not.
-  type: MYSQL             # The type of the database. Currently, only MYSQL
-  host: "localhost"       # The ip or hostname of the data bank
-  port: 3306              # The port of the data bank
-  schema: "mc_plugins"    # The name of the schema
-  username: "minecraft"   # The username of the user to use for the connection.
-  password: ""            # The users password
+  # If the database feature should be used or not.
+  enabled: false
+  # The type of the database. Currently, only MYSQL
+  type: MYSQL
+  # The ip or hostname of the data bank
+  host: "localhost"
+  # The port of the data bank
+  port: 3306
+  # The name of the schema
+  schema: "mc_plugins"
+  # The username of the user to use for the connection.
+  username: "minecraft"
+  # The users password
+  password: ""
 
 crafting_table:
-  enable: true            # If the advanced crafting table is enabled or not.
-  reset: true             # If the crafting table item should be reset on each server start. This means the config is replaced with a new version.
+  # If the advanced crafting table is enabled or not.
+  enable: true
+  # If the crafting table item should be reset on each server start. This means the config is replaced with a new version.
+  reset: true
 
 recipe_book:
-  reset: true             # If the recipe book item should be reset on each server start. This means the config is replaced with a new version.
+  # If the recipe book item should be reset on each server start. This means the config is replaced with a new version.
+  reset: true
 
 custom_items:
-  update: true            # Use this option if you have saved CustomItems and your players got them in their inventory. Each time a Player joins the server it will try to update the CustomItems.
+  # Use this option if you have saved CustomItems and your players got them in their inventory. Each time a Player joins the server it will try to update the CustomItems.
+  update: true
 
 recipes:
-  brewing: false          # Toggle the Brewing Recipes. They are off by default to prevent possible duplication issues
-  lockdown: false         # Used to block any kind of custom recipe. If enabled no one will be able to craft any custom recipe anymore.
-  pretty_printing: true   # If the configs like items or recipes should be saved using formatting or just one continuous String.
-  disabled_recipes: [ ]   # The vanilla or custom recipes that are blocked from crafting.
+  # Toggle the Brewing Recipes. They are off by default to prevent possible duplication issues
+  brewing: false
+  # Used to block any kind of custom recipe. If enabled no one will be able to craft any custom recipe anymore.
+  lockdown: false
+  # If the configs like items or recipes should be saved using formatting or just one continuous String.
+  pretty_printing: true
+  # The vanilla or custom recipes that are blocked from crafting.
+  disabled_recipes: [ ]
 
 data:
-  print_stacktrace: false # Toggle if the stacktrace should be printed out if a recipe or item fails to load.
-  bukkit_version: 0              # Do not change this number! It is used for internal conversion of items between Bukkit versions to make sure they are up to date.
-  version: 0                     # Do not change this number! It is used to update configs of recipes and items to new formats!
+  # Toggle if the stacktrace should be printed out if a recipe or item fails to load.
+  print_stacktrace: false
+  # Do not change this number! It is used for internal conversion of items between Bukkit versions to make sure they are up-to-date.
+  bukkit_version: 0
+  # Do not change this number! It is used to update configs of recipes and items to new formats!
+  version: 0
   auto_save:
-    interval: 30          # Interval in minutes to save data.
+    # Interval in minutes to save data.
     # Currently, used to save the data of the placed cauldrons with campfires underneath and the contained items and recipes.
-    message: true         # Save message that is printed into the console.
+    interval: 30
+    # Save message that is printed into the console.
+    message: true

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
@@ -45,7 +45,9 @@ public class CustomRecipeBlasting extends CustomRecipeCooking<CustomRecipeBlasti
     @Override
     public BlastingRecipe getVanillaRecipe() {
         if (!getSource().isEmpty()) {
-            return new BlastingRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getChoices().get(0).create(), getRecipeChoice(), getExp(), getCookingTime());
+            var recipe = new BlastingRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getChoices().get(0).create(), getRecipeChoice(), getExp(), getCookingTime());
+            recipe.setGroup(group);
+            return recipe;
         }
         return null;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCampfire.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCampfire.java
@@ -45,7 +45,9 @@ public class CustomRecipeCampfire extends CustomRecipeCooking<CustomRecipeCampfi
     @Override
     public CampfireRecipe getVanillaRecipe() {
         if (!getSource().isEmpty()) {
-            return new CampfireRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            var recipe = new CampfireRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            recipe.setGroup(group);
+            return recipe;
         }
         return null;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
@@ -45,7 +45,9 @@ public class CustomRecipeFurnace extends CustomRecipeCooking<CustomRecipeFurnace
     @Override
     public FurnaceRecipe getVanillaRecipe() {
         if (!getSource().isEmpty()) {
-            return new FurnaceRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            var recipe = new FurnaceRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            recipe.setGroup(group);
+            return recipe;
         }
         return null;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
@@ -60,7 +60,9 @@ public class CustomRecipeSmoking extends CustomRecipeCooking<CustomRecipeSmoking
     @Override
     public SmokingRecipe getVanillaRecipe() {
         if (!getSource().isEmpty()) {
-            return new SmokingRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            var recipe = new SmokingRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            recipe.setGroup(group);
+            return recipe;
         }
         return null;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
@@ -136,7 +136,9 @@ public class CustomRecipeStonecutter extends CustomRecipe<CustomRecipeStonecutte
     public StonecuttingRecipe getVanillaRecipe() {
         if (!getResult().isEmpty() && !getSource().isEmpty()) {
             RecipeChoice choice = isExactMeta() ? new RecipeChoice.ExactChoice(getSource().getBukkitChoices()) : new RecipeChoice.MaterialChoice(getSource().getBukkitChoices().stream().map(ItemStack::getType).toList());
-            return new StonecuttingRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getChoices().get(0).create(), choice);
+            var recipe = new StonecuttingRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getChoices().get(0).create(), choice);
+            recipe.setGroup(group);
+            return recipe;
         }
         return null;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/NamespacedKeyUtils.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/NamespacedKeyUtils.java
@@ -67,10 +67,7 @@ public class NamespacedKeyUtils {
     }
 
     public static boolean partiallyMatches(String token, NamespacedKey namespacedKey) {
-        if (!token.contains(":")) {
-            return namespacedKey.getKey().startsWith(token);
-        }
-        return namespacedKey.toString().startsWith(token);
+        return (!token.contains(":") && namespacedKey.getKey().startsWith(token)) || namespacedKey.toString().startsWith(token);
     }
 
     public static List<NamespacedKey> getPartialMatches(String token, Collection<NamespacedKey> originals) {

--- a/src/main/java/me/wolfyscript/customcrafting/utils/NamespacedKeyUtils.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/NamespacedKeyUtils.java
@@ -30,6 +30,10 @@ import me.wolfyscript.utilities.util.world.WorldUtils;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class NamespacedKeyUtils {
 
     private NamespacedKeyUtils() {
@@ -60,6 +64,17 @@ public class NamespacedKeyUtils {
             }
         }
         return null;
+    }
+
+    public static boolean partiallyMatches(String token, NamespacedKey namespacedKey) {
+        if (!token.contains(":")) {
+            return namespacedKey.getKey().startsWith(token);
+        }
+        return namespacedKey.toString().startsWith(token);
+    }
+
+    public static List<NamespacedKey> getPartialMatches(String token, Collection<NamespacedKey> originals) {
+        return originals.stream().filter(nKey -> partiallyMatches(token, nKey)).collect(Collectors.toList());
     }
 
     public static CustomItem getCustomItem(Block block) {

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -137,15 +137,15 @@
     },
     "recipes": {
       "toggle": {
-        "enabled": "",
-        "disabled": ""
-      },
-      "edit": {
-        "invalid": ""
+        "enabled": "&eEnabled recipe &a%recipe%",
+        "disabled": "&eDisabled recipe &c%recipe%"
       },
       "delete": {
-        "invalid": ""
-      }
+        "confirm": "&eDo you really want to delete &6%recipe%&e? ",
+        "confirmation": "&7[&aYES&7] ",
+        "cancel": "&7[&cNO&7]"
+      },
+      "invalid_recipe": "&cThe recipe &e%recipe%&c does not exist!"
     },
     "database": {
       "invalid_usage": "&cInvalid Usage: &4/cc database <export_items | export_recipes>"

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -140,6 +140,9 @@
         "enabled": "&eEnabled recipe &a%recipe%",
         "disabled": "&eDisabled recipe &c%recipe%"
       },
+      "edit": {
+        "invalid_recipe": "&cUnsupported recipe type!"
+      },
       "delete": {
         "confirm": "&eDo you really want to delete &6%recipe%&e? ",
         "confirmation": "&7[&aYES&7] ",


### PR DESCRIPTION
Updated language keys and messages for Recipes delete/edit/toggle command.

Improved the tab completion of NamespacedKeys (If the input token doesn't contain a column it will be additionally matched to keys without their namespace)
- Added NamespacedKeyUtils#partiallyMatches and #getPartialMatches
Matches strings against namespaced keys. If the token doesn't contain a column it matches the keys too.

Fixed - Recipe group isn't applied to vanilla Cooking and Stonecutter recipe placeholders.

Improved the config.yml comments, which will keep the comments of all settings, when saved (only spigot 1.18+)