### PR TITLE
Prevent the usage of "minecaft" namespaces for recipes

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCache.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCache.java
@@ -174,24 +174,27 @@ public abstract class RecipeCache<R extends CustomRecipe<?>> {
         WolfyUtilities api = customCrafting.getApi();
         try {
             CustomRecipe<?> recipe = constructRecipe();
-            recipe.save(player);
-            customCrafting.getRegistries().getRecipes().register(recipe);
-            Bukkit.getScheduler().runTask(customCrafting, () -> {
-                if (player != null) {
-                    api.getChat().sendKey(player, ClusterRecipeCreator.KEY, "loading.success");
-                }
-                if (customCrafting.getConfigHandler().getConfig().isResetCreatorAfterSave()) {
-                    guiHandler.getCustomCache().getRecipeCreatorCache().reset();
-                }
-            });
+            if (recipe.save(player)) {
+                customCrafting.getRegistries().getRecipes().register(recipe);
+                Bukkit.getScheduler().runTask(customCrafting, () -> {
+                    if (player != null) {
+                        api.getChat().sendKey(player, ClusterRecipeCreator.KEY, "loading.success");
+                    }
+                    if (customCrafting.getConfigHandler().getConfig().isResetCreatorAfterSave()) {
+                        guiHandler.getCustomCache().getRecipeCreatorCache().reset();
+                    }
+                });
+                return true;
+            }
+            api.getChat().sendMessage(player, "&cError saving recipe! Failed to save recipe.");
+            return false;
         } catch (IllegalArgumentException ex) {
             //Invalid recipe values!
-            api.getChat().sendMessage(player, "&cError saving recipe!");
+            api.getChat().sendMessage(player, "&cError saving recipe! " + ex.getMessage());
             return false;
         } catch (Exception ex) {
             ex.printStackTrace();
             return false;
         }
-        return true;
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/MenuItemCreator.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/MenuItemCreator.java
@@ -203,7 +203,7 @@ public class MenuItemCreator extends CCWindow {
     }
 
     private boolean saveItem(Items items, Player player, NamespacedKey namespacedKey) {
-        if (namespacedKey != null) {
+        if (namespacedKey != null && !namespacedKey.getNamespace().equalsIgnoreCase("minecraft")) {
             var customItem = items.getItem();
             if (customItem.getApiReference() instanceof WolfyUtilitiesRef wolfyUtilitiesRef && wolfyUtilitiesRef.getNamespacedKey().equals(namespacedKey)) {
                 api.getChat().sendMessage(player, "&cError saving item! Cannot override original CustomItem &4" + namespacedKey + "&c! Save it under another NamespacedKey or Edit the original!");

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/ClusterRecipeCreator.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/ClusterRecipeCreator.java
@@ -172,7 +172,7 @@ public class ClusterRecipeCreator extends CCCluster {
                 });
                 recipeCreator.openChat(guiHandler.getInvAPI().getGuiCluster(KEY), "save.input", guiHandler, (guiHandler1, player1, s, args) -> {
                     var namespacedKey = ChatUtils.getInternalNamespacedKey(player1, s, args);
-                    if (namespacedKey != null) {
+                    if (namespacedKey != null && !namespacedKey.getNamespace().equalsIgnoreCase("minecraft")) {
                         cache.getRecipeCreatorCache().getRecipeCache().setKey(namespacedKey);
                         if (!cache.getRecipeCreatorCache().getRecipeCache().save(customCrafting, player, guiHandler)) {
                             guiHandler.getApi().getChat().sendKey(player, KEY, "save.empty");

--- a/src/main/java/me/wolfyscript/customcrafting/registry/RegistryRecipes.java
+++ b/src/main/java/me/wolfyscript/customcrafting/registry/RegistryRecipes.java
@@ -23,6 +23,7 @@
 package me.wolfyscript.customcrafting.registry;
 
 
+import com.google.common.base.Preconditions;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.CraftingRecipe;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
@@ -97,7 +98,9 @@ public final class RegistryRecipes extends RegistrySimple<CustomRecipe<?>> {
 
     @Override
     public void register(NamespacedKey namespacedKey, CustomRecipe<?> value) {
-        remove(Objects.requireNonNull(namespacedKey, "Not a valid key! The key cannot be null!"));
+        Preconditions.checkArgument(namespacedKey != null, "Invalid NamespacedKey! The namespaced key cannot be null!");
+        Preconditions.checkArgument(!namespacedKey.getNamespace().equalsIgnoreCase("minecraft"), "Invalid NamespacedKey! Cannot register recipe under minecraft namespace!");
+        remove(namespacedKey);
         super.register(namespacedKey, value);
         if (value instanceof ICustomVanillaRecipe vanillaRecipe && !value.isDisabled()) {
             try {

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -1947,7 +1947,7 @@
         "save": {
           "input": "&eType in the namespaced key! Use &6/wui &efor better input!",
           "key": {
-            "invalid": "&cThe input is not a valid namespaced key! \nMake sure it only contains: \n - lowercase letters,\n - numbers,\n - underscores, \n - or dashes!\n&cUse &e/wui &cto get input assistance, like tab completion!"
+            "invalid": "&cThe input is not a valid namespaced key! \nMake sure it only contains: \n - lowercase letters,\n - numbers,\n - underscores, \n - or dashes!\n - You cannot use the minecraft namespace!\n&cUse &e/wui &cto get input assistance, like tab completion!"
           },
           "empty": "&cCannot save a empty recipe! Check the Result and the source/ingredients",
           "success": "&aRecipe successfully saved to:"


### PR DESCRIPTION
The "minecraft" should not be used to save recipes, as that will cause issues.
That's why the registry will no longer accept such recipes and the namespaced key inputs will print an updated error message.