### PR TITLE
Fix Stonecutter recipes not showing with ProtocolLib present

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
@@ -145,7 +145,8 @@ public class CustomRecipeStonecutter extends CustomRecipe<CustomRecipeStonecutte
 
     @Override
     public boolean isVisibleVanillaBook() {
-        return vanillaBook;
+        // Always return true as the Stonecutter GUI requires clients have the recipe to display in the list
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Override isVisibleVanillaBook return value for CustomRecipeStonecutter.
Resolves Stonecutter recipes not being sent to the client when ProtocolLib is present.