### PR TITLE
Fixed Crafting recipe saving issue

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/commands/cc_subcommands/DataBaseSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/cc_subcommands/DataBaseSubCommand.java
@@ -25,6 +25,7 @@ package me.wolfyscript.customcrafting.commands.cc_subcommands;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.commands.AbstractSubCommand;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
@@ -50,7 +51,7 @@ public class DataBaseSubCommand extends AbstractSubCommand {
             var chat = api.getChat();
             if (ChatUtils.checkPerm(p, "customcrafting.cmd.database")) {
                 if (customCrafting.getDataHandler().getDatabaseLoader() != null) {
-                    chat.sendMessage(p, "&4No Database found!");
+                    chat.sendMessage(p, ChatColor.RED + "Couldn't find any Database!");
                     return true;
                 }
                 if (args.length >= 1) {

--- a/src/main/java/me/wolfyscript/customcrafting/commands/cc_subcommands/HelpSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/cc_subcommands/HelpSubCommand.java
@@ -29,6 +29,7 @@ import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.chat.ClickData;
 import me.wolfyscript.utilities.api.chat.ClickEvent;
 import me.wolfyscript.utilities.api.chat.HoverEvent;
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -59,7 +60,7 @@ public class HelpSubCommand extends AbstractSubCommand {
     public void printHelp(Player p) {
         WolfyUtilities api = customCrafting.getApi();
         var chat = api.getChat();
-        chat.sendMessage(p, "———————— &3&lCustomCrafting &7————————");
+        chat.sendMessage(p, "———————— " + ChatColor.DARK_AQUA + ChatColor.BOLD + "CustomCrafting" + ChatColor.GRAY + " ————————");
         chat.sendMessage(p, "");
         List<String> help = api.getLanguageAPI().replaceKey("commands.help");
         for (String line : help) {

--- a/src/main/java/me/wolfyscript/customcrafting/commands/cc_subcommands/ReloadSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/cc_subcommands/ReloadSubCommand.java
@@ -30,6 +30,7 @@ import me.wolfyscript.customcrafting.gui.recipebook.MenuRecipeBook;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.gui.InventoryAPI;
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -40,6 +41,8 @@ import java.util.List;
 
 public class ReloadSubCommand extends AbstractSubCommand {
 
+    private static final String COMPLETE_MSG = "  - " + ChatColor.GREEN + "Complete";
+
     public ReloadSubCommand(CustomCrafting customCrafting) {
         super("reload", new ArrayList<>(), customCrafting);
     }
@@ -49,24 +52,25 @@ public class ReloadSubCommand extends AbstractSubCommand {
         WolfyUtilities api = customCrafting.getApi();
         if (sender instanceof Player p && ChatUtils.checkPerm(p, "customcrafting.cmd.reload")) {
             InventoryAPI<CCCache> invAPI = api.getInventoryAPI(CCCache.class);
-            api.getChat().sendMessage(p, "&eReloading Config!");
+            api.getChat().sendMessage(p, ChatColor.YELLOW + "Reloading Config!");
             customCrafting.getConfigHandler().getConfig().load();
-            api.getChat().sendMessage(p, "  - &aComplete");
-            api.getChat().sendMessage(p, "&eReloading Languages!");
+            api.getChat().sendMessage(p, COMPLETE_MSG);
+            api.getChat().sendMessage(p, ChatColor.YELLOW + "Reloading Languages!");
             customCrafting.getApi().getLanguageAPI().unregisterLanguages();
             customCrafting.getConfigHandler().loadLang();
-            api.getChat().sendMessage(p, "  - &aComplete");
-            api.getChat().sendMessage(p, "&eReloading Recipes/Items!");
+            api.getChat().sendMessage(p, COMPLETE_MSG);
+            api.getChat().sendMessage(p, ChatColor.YELLOW + "Reloading Recipes/Items!");
             customCrafting.getConfigHandler().loadRecipeBookConfig();
             var dataHandler = customCrafting.getDataHandler();
             dataHandler.initCategories();
             dataHandler.load();
             dataHandler.getCategories().index(customCrafting);
-            api.getChat().sendMessage(p, "  - &aComplete");
+            api.getChat().sendMessage(p, COMPLETE_MSG);
             api.getChat().sendMessage(p, "&eReloading GUIs");
             ((MenuRecipeBook) invAPI.getGuiWindow(ClusterRecipeBook.RECIPE_BOOK)).reset();
             invAPI.reset();
-            api.getChat().sendMessage(p, "  - &aComplete");
+            api.getChat().sendMessage(p, COMPLETE_MSG);
+            api.getChat().sendMessage(p, ChatColor.GREEN + "Reload done!");
         }
         return true;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/MenuItemCreator.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/MenuItemCreator.java
@@ -49,6 +49,7 @@ import me.wolfyscript.utilities.compatibility.plugins.oraxen.OraxenRef;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import me.wolfyscript.utilities.util.inventory.PlayerHeadUtils;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -214,7 +215,7 @@ public class MenuItemCreator extends CCWindow {
             items.setNamespacedKey(namespacedKey);
             sendMessage(player, "save.success");
             var internalKey = NamespacedKeyUtils.toInternal(namespacedKey);
-            api.getChat().sendMessage(player, "&6" + internalKey.getNamespace() + "/items/" + internalKey.getKey());
+            api.getChat().sendMessage(player, ChatColor.YELLOW + internalKey.getNamespace() + "/items/" + internalKey.getKey());
         }
         return true;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
@@ -23,6 +23,7 @@
 package me.wolfyscript.customcrafting.recipes;
 
 import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
+import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.type.TypeReference;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
@@ -43,6 +44,7 @@ import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
 import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
 import me.wolfyscript.utilities.api.nms.network.MCByteBuf;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.jetbrains.annotations.Nullable;
@@ -227,4 +229,17 @@ public abstract class CraftingRecipe<C extends CraftingRecipe<C, S>, S extends C
         byteBuf.writeCollection(ingredients, (buf, ingredient) -> buf.writeCollection(ingredient.getChoices(), (buf1, customItem) -> buf1.writeItemStack(customItem.create())));
     }
 
+    @Override
+    public boolean save(@Nullable Player player) {
+        boolean saveSuccessful = super.save(player);
+        if (saveSuccessful) {
+            //We need to delete the old recipe when the type changes between shapeless and shaped, because else it is present in two different folders!
+            CustomRecipe<?> oldRecipe = CustomCrafting.inst().getRegistries().getRecipes().get(getNamespacedKey());
+            if (oldRecipe instanceof CraftingRecipe<?,?> oldCraftingRecipe && oldCraftingRecipe.isShapeless() != isShapeless()) {
+                getAPI().getChat().sendMessage(player, ChatColor.YELLOW + "Recipe Type changed... deleting old recipe!");
+                oldCraftingRecipe.delete(player);
+            }
+        }
+        return saveSuccessful;
+    }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -48,6 +48,7 @@ import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -276,10 +277,10 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     public boolean delete(@Nullable Player player) {
         Bukkit.getScheduler().runTask(CustomCrafting.inst(), () -> CustomCrafting.inst().getRegistries().getRecipes().remove(getNamespacedKey()));
         if (CustomCrafting.inst().getDataHandler().getActiveLoader().delete(this)) {
-            getAPI().getChat().sendMessage(player, "§aRecipe deleted!");
+            getAPI().getChat().sendMessage(player, ChatColor.GREEN + "Recipe deleted!");
             return true;
         }
-        getAPI().getChat().sendMessage(player, "&cCouldn't delete recipe file!");
+        getAPI().getChat().sendMessage(player, ChatColor.RED + "Couldn't delete recipe file!");
         return false;
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/utils/ChatUtils.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/ChatUtils.java
@@ -30,6 +30,7 @@ import me.wolfyscript.utilities.api.chat.ClickEvent;
 import me.wolfyscript.utilities.api.chat.HoverEvent;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.Pair;
+import org.bukkit.ChatColor;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.command.CommandSender;
@@ -113,7 +114,7 @@ public class ChatUtils {
                 i++;
             }
         } else {
-            api.getChat().sendMessage(player, "&l&cNo Description set yet!");
+            api.getChat().sendMessage(player, ChatColor.BOLD.toString() + ChatColor.RED + "No Description set yet!");
         }
         api.getChat().sendMessage(player, "");
         api.getChat().sendMessage(player, "-------------------------------------------------");
@@ -142,7 +143,7 @@ public class ChatUtils {
                 i++;
             }
         } else {
-            api.getChat().sendMessage(player, "&l&cNo Lore set yet!");
+            api.getChat().sendMessage(player, ChatColor.BOLD.toString() + ChatColor.RED + "No Lore set yet!");
         }
         api.getChat().sendMessage(player, "");
         api.getChat().sendMessage(player, "-------------------------------------------------");
@@ -177,7 +178,7 @@ public class ChatUtils {
                     );
                 }
             } else {
-                api.getChat().sendMessage(player, "&cNo attributes set yet!");
+                api.getChat().sendMessage(player, ChatColor.RED + "No attributes set yet!");
             }
         }
         api.getChat().sendMessage(player, "");


### PR DESCRIPTION
When changing the type of a CraftingRecipe (Shapeless to Shaped or other way around) will leave the previous recipe file inside the type specific folder.
This PR fixes that by deleting the previous file if and only if the type has changed.