### PR TITLE
Recipe Discovery & Recipe Book Improvements

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/listeners/CraftListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/CraftListener.java
@@ -41,10 +41,12 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerRecipeDiscoverEvent;
 import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 public class CraftListener implements Listener {
@@ -141,5 +143,20 @@ public class CraftListener implements Listener {
                 event.setCancelled(true);
             }
         }
+    }
+
+    /**
+     * Automatically discovers available custom recipes for players.
+     *
+     */
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        var player = event.getPlayer();
+        List<org.bukkit.NamespacedKey> discoveredCustomRecipes = player.getDiscoveredRecipes().stream().filter(namespacedKey -> namespacedKey.getNamespace().equals(NamespacedKeyUtils.NAMESPACE)).toList();
+        customCrafting.getRegistries().getRecipes().getAvailable(player).stream()
+                .filter(recipe -> recipe instanceof ICustomVanillaRecipe<?>)
+                .map(recipe -> recipe.getNamespacedKey().toBukkit(customCrafting))
+                .filter(namespacedKey -> !discoveredCustomRecipes.contains(namespacedKey))
+                .forEach(player::discoverRecipe);
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/registry/RegistryRecipes.java
+++ b/src/main/java/me/wolfyscript/customcrafting/registry/RegistryRecipes.java
@@ -163,7 +163,7 @@ public final class RegistryRecipes extends RegistrySimple<CustomRecipe<?>> {
 
     @SuppressWarnings("unchecked")
     public <T extends CustomRecipe<?>> List<T> get(Class<T> type) {
-        return (List<T>) BY_CLASS_TYPE.computeIfAbsent(type, aClass -> (List<CustomRecipe<?>>) values().stream().filter(aClass::isInstance).map(aClass::cast).collect(Collectors.toList()));
+        return (List<T>) BY_CLASS_TYPE.computeIfAbsent(type, aClass -> values().stream().filter(aClass::isInstance).map(recipe -> ((Class<T>) aClass).cast(recipe)).collect(Collectors.toList()));
     }
 
     /**


### PR DESCRIPTION
Custom Recipes are discovered automatically when the player joins now. It will only include the recipes the player has permission to and only those that aren't enabled.

Additionally, the new listener, which is available when you have ProtocolLib installed, will prevent spam clicks in the recipe book and therefor lag caused by autoclickers.