### PR TITLE
EnchantMergeAdapter Existing Enchant Level Increase

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/EnchantMergeAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/EnchantMergeAdapter.java
@@ -70,7 +70,12 @@ public class EnchantMergeAdapter extends MergeAdapter {
         for (IngredientData data : recipeData.getBySlots(slots)) {
             var item = data.itemStack();
             item.getEnchantments().forEach((enchantment, level) -> {
-                if (!blackListedEnchants.contains(enchantment) && !result.containsEnchantment(enchantment) && result.getEnchantmentLevel(enchantment) < level) {
+                if (
+                    !blackListedEnchants.contains(enchantment) && (
+                        !result.containsEnchantment(enchantment) ||
+                        result.getEnchantmentLevel(enchantment) < level
+                    )
+                ) {
                     var meta = result.getItemMeta();
                     if (meta != null && meta.addEnchant(enchantment, level, ignoreEnchantLimit)) {
                         result.setItemMeta(meta);


### PR DESCRIPTION
Update EnchantMergeAdapter merge logic to work with increasing the level of an existing enchant.
The existing `and` check never allowed overwriting an existing enchant of a lower level as the first `!result.containsEnchantment()` check would not pass if the result already had the enchant.