### PR TITLE
Restructuring Recipe data folders & serialization

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
@@ -47,6 +47,7 @@ import me.wolfyscript.customcrafting.handlers.DisableRecipesHandler;
 import me.wolfyscript.customcrafting.listeners.*;
 import me.wolfyscript.customcrafting.network.NetworkHandler;
 import me.wolfyscript.customcrafting.placeholderapi.PlaceHolder;
+import me.wolfyscript.customcrafting.recipes.RecipeType;
 import me.wolfyscript.customcrafting.recipes.conditions.*;
 import me.wolfyscript.customcrafting.recipes.items.extension.*;
 import me.wolfyscript.customcrafting.recipes.items.target.MergeAdapter;
@@ -202,6 +203,22 @@ public class CustomCrafting extends JavaPlugin {
         recipeConditions.register(WorldNameCondition.KEY, WorldNameCondition.class, new WorldNameCondition.GUIComponent());
         recipeConditions.register(WorldTimeCondition.KEY, WorldTimeCondition.class, new WorldTimeCondition.GUIComponent());
         recipeConditions.register(ConditionAdvancement.KEY, ConditionAdvancement.class, new ConditionAdvancement.GUIComponent());
+
+        var recipeTypes = getRegistries().getRecipeTypes();
+        recipeTypes.register(RecipeType.CRAFTING_SHAPED);
+        recipeTypes.register(RecipeType.CRAFTING_SHAPELESS);
+        recipeTypes.register(RecipeType.ELITE_CRAFTING_SHAPED);
+        recipeTypes.register(RecipeType.ELITE_CRAFTING_SHAPELESS);
+        recipeTypes.register(RecipeType.FURNACE);
+        recipeTypes.register(RecipeType.BLAST_FURNACE);
+        recipeTypes.register(RecipeType.SMOKER);
+        recipeTypes.register(RecipeType.CAMPFIRE);
+        recipeTypes.register(RecipeType.ANVIL);
+        recipeTypes.register(RecipeType.STONECUTTER);
+        recipeTypes.register(RecipeType.CAULDRON);
+        recipeTypes.register(RecipeType.GRINDSTONE);
+        recipeTypes.register(RecipeType.BREWING_STAND);
+        recipeTypes.register(RecipeType.SMITHING);
 
         KeyedTypeIdResolver.registerTypeRegistry(ResultExtension.class, resultExtensions);
         KeyedTypeIdResolver.registerTypeRegistry(MergeAdapter.class, resultMergeAdapters);

--- a/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
@@ -59,6 +59,7 @@ import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.customcrafting.utils.UpdateChecker;
 import me.wolfyscript.customcrafting.utils.cooking.CookingManager;
 import me.wolfyscript.customcrafting.utils.other_plugins.OtherPlugins;
+import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializationFeature;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.chat.Chat;
@@ -66,6 +67,7 @@ import me.wolfyscript.utilities.api.inventory.gui.InventoryAPI;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.Reflection;
 import me.wolfyscript.utilities.util.entity.CustomPlayerData;
+import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 import me.wolfyscript.utilities.util.json.jackson.KeyedTypeIdResolver;
 import me.wolfyscript.utilities.util.version.WUVersion;
 import org.bstats.bukkit.Metrics;
@@ -83,12 +85,13 @@ public class CustomCrafting extends JavaPlugin {
 
     //Only used for displaying which version it is.
     private static final boolean PREMIUM = true;
-
-    public static final NamespacedKey ADVANCED_CRAFTING_TABLE = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "advanced_crafting_table");
-    public static final NamespacedKey INTERNAL_ADVANCED_CRAFTING_TABLE = NamespacedKeyUtils.fromInternal(ADVANCED_CRAFTING_TABLE);
-    public static final NamespacedKey ELITE_CRAFTING_TABLE = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "elite_crafting_table");
-    public static final NamespacedKey RECIPE_BOOK = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "recipe_book");
-    public static final NamespacedKey CAULDRON = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "cauldron");
+    //CustomData keys
+    public static final NamespacedKey ELITE_CRAFTING_TABLE_DATA = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "elite_crafting_table");
+    public static final NamespacedKey RECIPE_BOOK_DATA = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "recipe_book");
+    public static final NamespacedKey CAULDRON_DATA = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "cauldron");
+    //Recipes & Items keys
+    public static final NamespacedKey ADVANCED_CRAFTING_TABLE = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "customcrafting/advanced_crafting_table");
+    public static final NamespacedKey RECIPE_BOOK = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "customcrafting/recipe_book");
     //Used for backwards compatibility
     public static final NamespacedKey ADVANCED_WORKBENCH = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "workbench");
 
@@ -134,6 +137,7 @@ public class CustomCrafting extends JavaPlugin {
         this.otherPlugins = new OtherPlugins(this);
         isPaper = WolfyUtilities.hasClass("com.destroystokyo.paper.utils.PaperPluginLogger");
         api = WolfyUtilCore.getInstance().getAPI(this, false);
+        JacksonUtil.getObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 
         this.registries = new CCRegistries(this, api.getCore());
 

--- a/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
@@ -48,6 +48,10 @@ import me.wolfyscript.customcrafting.listeners.*;
 import me.wolfyscript.customcrafting.network.NetworkHandler;
 import me.wolfyscript.customcrafting.placeholderapi.PlaceHolder;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
+import me.wolfyscript.customcrafting.recipes.anvil.RepairTask;
+import me.wolfyscript.customcrafting.recipes.anvil.RepairTaskDefault;
+import me.wolfyscript.customcrafting.recipes.anvil.RepairTaskDurability;
+import me.wolfyscript.customcrafting.recipes.anvil.RepairTaskResult;
 import me.wolfyscript.customcrafting.recipes.conditions.*;
 import me.wolfyscript.customcrafting.recipes.items.extension.*;
 import me.wolfyscript.customcrafting.recipes.items.target.MergeAdapter;
@@ -224,9 +228,15 @@ public class CustomCrafting extends JavaPlugin {
         recipeTypes.register(RecipeType.BREWING_STAND);
         recipeTypes.register(RecipeType.SMITHING);
 
+        var anvilRecipeRepairTasks = getRegistries().getAnvilRecipeRepairTasks();
+        anvilRecipeRepairTasks.register(RepairTaskDefault.KEY, RepairTaskDefault.class);
+        anvilRecipeRepairTasks.register(RepairTaskResult.KEY, RepairTaskResult.class);
+        anvilRecipeRepairTasks.register(RepairTaskDurability.KEY, RepairTaskDurability.class);
+
         KeyedTypeIdResolver.registerTypeRegistry(ResultExtension.class, resultExtensions);
         KeyedTypeIdResolver.registerTypeRegistry(MergeAdapter.class, resultMergeAdapters);
         KeyedTypeIdResolver.registerTypeRegistry((Class<Condition<?>>) (Object) Condition.class, recipeConditions);
+        KeyedTypeIdResolver.registerTypeRegistry(RepairTask.class, anvilRecipeRepairTasks);
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/commands/cc_subcommands/DataBaseSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/cc_subcommands/DataBaseSubCommand.java
@@ -50,11 +50,11 @@ public class DataBaseSubCommand extends AbstractSubCommand {
         if (sender instanceof Player p) {
             var chat = api.getChat();
             if (ChatUtils.checkPerm(p, "customcrafting.cmd.database")) {
-                if (customCrafting.getDataHandler().getDatabaseLoader() != null) {
-                    chat.sendMessage(p, ChatColor.RED + "Couldn't find any Database!");
-                    return true;
-                }
                 if (args.length >= 1) {
+                    if (customCrafting.getDataHandler().getDatabaseLoader() == null) {
+                        chat.sendMessage(p, ChatColor.RED + "Couldn't find any Database!");
+                        return true;
+                    }
                     switch (args[0]) {
                         case "export_recipes" -> {
                             chat.sendMessage(p, "Exporting recipes to Database...");

--- a/src/main/java/me/wolfyscript/customcrafting/configs/custom_data/CauldronData.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/custom_data/CauldronData.java
@@ -87,7 +87,7 @@ public class CauldronData extends CustomData implements Cloneable {
     public static class Provider extends CustomData.Provider<CauldronData> {
 
         public Provider() {
-            super(CustomCrafting.CAULDRON, CauldronData.class);
+            super(CustomCrafting.CAULDRON_DATA, CauldronData.class);
         }
 
     }

--- a/src/main/java/me/wolfyscript/customcrafting/configs/custom_data/EliteWorkbenchData.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/custom_data/EliteWorkbenchData.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.configs.custom_data;
 
+import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.DeserializationContext;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
@@ -35,6 +36,8 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class EliteWorkbenchData extends CustomData implements Cloneable {
+
+    public static final NamespacedKey KEY = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "elite_crafting_table");
 
     private boolean advancedRecipes;
     private boolean enabled;
@@ -151,7 +154,7 @@ public class EliteWorkbenchData extends CustomData implements Cloneable {
     public static class Provider extends CustomData.Provider<EliteWorkbenchData> {
 
         public Provider() {
-            super(CustomCrafting.ELITE_CRAFTING_TABLE, EliteWorkbenchData.class);
+            super(CustomCrafting.ELITE_CRAFTING_TABLE_DATA, EliteWorkbenchData.class);
         }
 
     }

--- a/src/main/java/me/wolfyscript/customcrafting/configs/custom_data/RecipeBookData.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/custom_data/RecipeBookData.java
@@ -87,7 +87,7 @@ public class RecipeBookData extends CustomData implements Cloneable {
     public static class Provider extends CustomData.Provider<RecipeBookData> {
 
         public Provider() {
-            super(CustomCrafting.RECIPE_BOOK, RecipeBookData.class);
+            super(CustomCrafting.RECIPE_BOOK_DATA, RecipeBookData.class);
         }
 
     }

--- a/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/CategorySettings.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/CategorySettings.java
@@ -139,7 +139,7 @@ public class CategorySettings {
     public ItemStack createItemStack(CustomCrafting customCrafting) {
         var categoryItem = new ItemStack(getIcon());
         var itemMeta = categoryItem.getItemMeta();
-        var languageAPI = WolfyUtilities.get(customCrafting).getLanguageAPI();
+        var languageAPI = customCrafting.getApi().getLanguageAPI();
         itemMeta.setDisplayName(languageAPI.replaceColoredKeys(getName()));
         itemMeta.setLore(languageAPI.replaceColoredKeys(getDescription()));
         categoryItem.setItemMeta(itemMeta);

--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCache.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCache.java
@@ -40,7 +40,7 @@ import org.bukkit.entity.Player;
 public abstract class RecipeCache<R extends CustomRecipe<?>> {
 
     protected NamespacedKey key;
-    protected boolean exactMeta;
+    protected boolean checkNBT;
     protected boolean hidden;
     protected boolean vanillaBook;
 
@@ -51,7 +51,7 @@ public abstract class RecipeCache<R extends CustomRecipe<?>> {
 
     protected RecipeCache() {
         this.key = null;
-        this.exactMeta = true;
+        this.checkNBT = true;
         this.hidden = false;
         this.vanillaBook = false;
         this.priority = RecipePriority.NORMAL;
@@ -62,7 +62,7 @@ public abstract class RecipeCache<R extends CustomRecipe<?>> {
 
     protected RecipeCache(R customRecipe) {
         this.key = customRecipe.getNamespacedKey();
-        this.exactMeta = customRecipe.isExactMeta();
+        this.checkNBT = customRecipe.isCheckNBT();
         this.hidden = customRecipe.isHidden();
         this.vanillaBook = customRecipe instanceof ICustomVanillaRecipe<?> vanillaRecipe && vanillaRecipe.isVisibleVanillaBook();
         this.priority = customRecipe.getPriority();
@@ -83,12 +83,22 @@ public abstract class RecipeCache<R extends CustomRecipe<?>> {
         this.key = key;
     }
 
+    @Deprecated
     public boolean isExactMeta() {
-        return exactMeta;
+        return checkNBT;
     }
 
-    public void setExactMeta(boolean exactMeta) {
-        this.exactMeta = exactMeta;
+    @Deprecated
+    public void setExactMeta(boolean checkNBT) {
+        this.checkNBT = checkNBT;
+    }
+
+    public void setCheckNBT(boolean checkNBT) {
+        this.checkNBT = checkNBT;
+    }
+
+    public boolean isCheckNBT() {
+        return checkNBT;
     }
 
     public boolean isHidden() {
@@ -160,7 +170,7 @@ public abstract class RecipeCache<R extends CustomRecipe<?>> {
         recipe.setConditions(conditions);
         recipe.setGroup(group);
         recipe.setHidden(hidden);
-        recipe.setExactMeta(exactMeta);
+        recipe.setCheckNBT(checkNBT);
         recipe.setPriority(priority);
         if (recipe instanceof ICustomVanillaRecipe<?> vanillaRecipe) {
             vanillaRecipe.setVisibleVanillaBook(vanillaBook);

--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCreatorCache.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCreatorCache.java
@@ -76,6 +76,7 @@ public class RecipeCreatorCache {
             case STONECUTTER -> stonecuttingCache;
             case BREWING_STAND -> brewingCache;
             case ELITE_CRAFTING_SHAPED, ELITE_CRAFTING_SHAPELESS -> eliteCraftingCache;
+            default -> null;
         };
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/data/cauldron/Cauldrons.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cauldron/Cauldrons.java
@@ -64,7 +64,7 @@ public class Cauldrons {
 
     public Cauldrons(CustomCrafting customCrafting) {
         this.customCrafting = customCrafting;
-        this.api = WolfyUtilities.get(customCrafting);
+        this.api = customCrafting.getApi();
         load();
         autosaveTask = Bukkit.getScheduler().scheduleSyncRepeatingTask(api.getPlugin(), this::save, customCrafting.getConfigHandler().getConfig().getAutosaveInterval() * 1200L, customCrafting.getConfigHandler().getConfig().getAutosaveInterval() * 1200L);
 

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabEliteCraftingTable.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabEliteCraftingTable.java
@@ -54,35 +54,35 @@ public class TabEliteCraftingTable extends ItemCreatorTab {
     public void register(MenuItemCreator creator, WolfyUtilities api) {
         creator.registerButton(new ButtonOption(Material.CRAFTING_TABLE, this));
         creator.registerButton(new DummyButton<>("elite_workbench.particles", Material.FIREWORK_ROCKET));
-        creator.registerButton(new MultipleChoiceButton<>("elite_workbench.grid_size", (cache, guiHandler, player, guiInventory, i) -> ((EliteWorkbenchData) cache.getItems().getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE)).getGridSize() - 3,
+        creator.registerButton(new MultipleChoiceButton<>("elite_workbench.grid_size", (cache, guiHandler, player, guiInventory, i) -> ((EliteWorkbenchData) cache.getItems().getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA)).getGridSize() - 3,
                 new ButtonState<>("elite_workbench.grid_size.size_3", PlayerHeadUtils.getViaURL("9e95293acbcd4f55faf5947bfc5135038b275a7ab81087341b9ec6e453e839"), (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-                    ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE)).setGridSize(4);
+                    ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA)).setGridSize(4);
                     return true;
                 }),
                 new ButtonState<>("elite_workbench.grid_size.size_4", PlayerHeadUtils.getViaURL("cbfb41f866e7e8e593659986c9d6e88cd37677b3f7bd44253e5871e66d1d424"), (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-                    ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE)).setGridSize(5);
+                    ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA)).setGridSize(5);
                     return true;
                 }),
                 new ButtonState<>("elite_workbench.grid_size.size_5", PlayerHeadUtils.getViaURL("14d844fee24d5f27ddb669438528d83b684d901b75a6889fe7488dfc4cf7a1c"), (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-                    ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE)).setGridSize(6);
+                    ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA)).setGridSize(6);
                     return true;
                 }),
                 new ButtonState<>("elite_workbench.grid_size.size_6", PlayerHeadUtils.getViaURL("faff2eb498e5c6a04484f0c9f785b448479ab213df95ec91176a308a12add70"), (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-                    ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE)).setGridSize(3);
+                    ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA)).setGridSize(3);
                     return true;
                 })));
-        creator.registerButton(new ToggleButton<>("elite_workbench.toggle", (cache, guiHandler, player, guiInventory, i) -> ((EliteWorkbenchData) cache.getItems().getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE)).isEnabled(), new ButtonState<>("elite_workbench.toggle.enabled", Material.GREEN_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-            ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE)).setEnabled(false);
+        creator.registerButton(new ToggleButton<>("elite_workbench.toggle", (cache, guiHandler, player, guiInventory, i) -> ((EliteWorkbenchData) cache.getItems().getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA)).isEnabled(), new ButtonState<>("elite_workbench.toggle.enabled", Material.GREEN_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
+            ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA)).setEnabled(false);
             return true;
         }), new ButtonState<>("elite_workbench.toggle.disabled", Material.RED_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-            ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE)).setEnabled(true);
+            ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA)).setEnabled(true);
             return true;
         })));
-        creator.registerButton(new ToggleButton<>("elite_workbench.advanced_recipes", (cache, guiHandler, player, guiInventory, i) -> ((EliteWorkbenchData) cache.getItems().getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE)).isAdvancedRecipes(), new ButtonState<>("elite_workbench.advanced_recipes.enabled", Material.GREEN_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-            ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE)).setAdvancedRecipes(false);
+        creator.registerButton(new ToggleButton<>("elite_workbench.advanced_recipes", (cache, guiHandler, player, guiInventory, i) -> ((EliteWorkbenchData) cache.getItems().getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA)).isAdvancedRecipes(), new ButtonState<>("elite_workbench.advanced_recipes.enabled", Material.GREEN_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
+            ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA)).setAdvancedRecipes(false);
             return true;
         }), new ButtonState<>("elite_workbench.advanced_recipes.disabled", Material.RED_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-            ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE)).setAdvancedRecipes(true);
+            ((EliteWorkbenchData) items.getItem().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA)).setAdvancedRecipes(true);
             return true;
         })));
     }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabRecipeBook.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabRecipeBook.java
@@ -50,11 +50,11 @@ public class TabRecipeBook extends ItemCreatorTab {
     @Override
     public void register(MenuItemCreator creator, WolfyUtilities api) {
         creator.registerButton(new ButtonOption(Material.KNOWLEDGE_BOOK, this));
-        creator.registerButton(new ToggleButton<>("knowledge_book.toggle", (cache, guiHandler, player, guiInventory, i) -> ((RecipeBookData) cache.getItems().getItem().getCustomData(CustomCrafting.RECIPE_BOOK)).isEnabled(), new ButtonState<>("knowledge_book.toggle.enabled", Material.GREEN_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-            ((RecipeBookData) items.getItem().getCustomData(CustomCrafting.RECIPE_BOOK)).setEnabled(false);
+        creator.registerButton(new ToggleButton<>("knowledge_book.toggle", (cache, guiHandler, player, guiInventory, i) -> ((RecipeBookData) cache.getItems().getItem().getCustomData(CustomCrafting.RECIPE_BOOK_DATA)).isEnabled(), new ButtonState<>("knowledge_book.toggle.enabled", Material.GREEN_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
+            ((RecipeBookData) items.getItem().getCustomData(CustomCrafting.RECIPE_BOOK_DATA)).setEnabled(false);
             return true;
         }), new ButtonState<>("knowledge_book.toggle.disabled", Material.RED_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-            ((RecipeBookData) items.getItem().getCustomData(CustomCrafting.RECIPE_BOOK)).setEnabled(true);
+            ((RecipeBookData) items.getItem().getCustomData(CustomCrafting.RECIPE_BOOK_DATA)).setEnabled(true);
             return true;
         })));
     }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/ClusterRecipeCreator.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/ClusterRecipeCreator.java
@@ -26,6 +26,7 @@ import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.CCCluster;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
+import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.utilities.api.inventory.gui.InventoryAPI;
 import me.wolfyscript.utilities.api.inventory.gui.button.ButtonState;
 import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ActionButton;
@@ -159,19 +160,20 @@ public class ClusterRecipeCreator extends CCCluster {
                 guiHandler.setChatTabComplete((guiHandler1, player1, args) -> {
                     List<String> results = new ArrayList<>();
                     if (args.length > 0) {
+                        var registryRecipes = customCrafting.getRegistries().getRecipes();
                         if (args.length == 1) {
-                            results.add("<namespace>");
-                            StringUtil.copyPartialMatches(args[0], customCrafting.getRegistries().getRecipes().namespaces(), results);
+                            results.add("<folder>");
+                            StringUtil.copyPartialMatches(args[0], registryRecipes.folders(NamespacedKeyUtils.NAMESPACE), results);
                         } else if (args.length == 2) {
-                            results.add("<key>");
-                            StringUtil.copyPartialMatches(args[1], customCrafting.getRegistries().getRecipes().get(args[0]).stream().filter(recipe -> cache.getRecipeCreatorCache().getRecipeType().isInstance(recipe)).map(recipe -> recipe.getNamespacedKey().getKey()).toList(), results);
+                            results.add("<recipe_name>");
+                            StringUtil.copyPartialMatches(args[1], registryRecipes.get(NamespacedKeyUtils.NAMESPACE, args[0]).stream().filter(recipe -> cache.getRecipeCreatorCache().getRecipeType().isInstance(recipe)).map(recipe -> recipe.getNamespacedKey().getKey()).toList(), results);
                         }
                     }
                     Collections.sort(results);
                     return results;
                 });
                 recipeCreator.openChat(guiHandler.getInvAPI().getGuiCluster(KEY), "save.input", guiHandler, (guiHandler1, player1, s, args) -> {
-                    var namespacedKey = ChatUtils.getInternalNamespacedKey(player1, s, args);
+                    var namespacedKey = ChatUtils.getNamespacedKey(player1, s, args);
                     if (namespacedKey != null && !namespacedKey.getNamespace().equalsIgnoreCase("minecraft")) {
                         cache.getRecipeCreatorCache().getRecipeCache().setKey(namespacedKey);
                         if (!cache.getRecipeCreatorCache().getRecipeCache().save(customCrafting, player, guiHandler)) {

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/ConfigHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/ConfigHandler.java
@@ -109,13 +109,13 @@ public class ConfigHandler {
             knowledgeBook.addLoreLine(me.wolfyscript.utilities.util.chat.ChatColor.convert("&7Contains some interesting recipes..."));
             knowledgeBook.addUnsafeEnchantment(Enchantment.DURABILITY, 5);
             knowledgeBook.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-            ((RecipeBookData) knowledgeBook.getCustomData(CustomCrafting.RECIPE_BOOK)).setEnabled(true);
+            ((RecipeBookData) knowledgeBook.getCustomData(CustomCrafting.RECIPE_BOOK_DATA)).setEnabled(true);
             ItemLoader.saveItem(CustomCrafting.RECIPE_BOOK, knowledgeBook);
 
             var knowledgeBookCraft = new CraftingRecipeShapeless(CustomCrafting.RECIPE_BOOK);
             knowledgeBookCraft.addIngredient(new Ingredient(Material.BOOK));
             knowledgeBookCraft.addIngredient(new Ingredient(Material.CRAFTING_TABLE));
-            knowledgeBookCraft.getResult().put(0, CustomItem.with(new WolfyUtilitiesRef(NamespacedKeyUtils.fromInternal(CustomCrafting.RECIPE_BOOK))));
+            knowledgeBookCraft.getResult().put(0, CustomItem.with(new WolfyUtilitiesRef(CustomCrafting.RECIPE_BOOK)));
             knowledgeBookCraft.save();
         }
 
@@ -138,7 +138,7 @@ public class ConfigHandler {
             workbenchCraft.setIngredient('C', new Ingredient(Material.CRAFTING_TABLE));
             workbenchCraft.setIngredient('D', new Ingredient(Material.GLOWSTONE_DUST));
             Result result = workbenchCraft.getResult();
-            result.put(0, CustomItem.with(new WolfyUtilitiesRef(CustomCrafting.INTERNAL_ADVANCED_CRAFTING_TABLE)));
+            result.put(0, CustomItem.with(new WolfyUtilitiesRef(CustomCrafting.ADVANCED_CRAFTING_TABLE)));
             if (WolfyUtilities.isDevEnv()) {
                 var commandExecution = new CommandResultExtension(Arrays.asList("say hi %player%", "effect give %player% minecraft:strength 100 100"), new ArrayList<>(), true, true);
                 commandExecution.setExecutionType(ExecutionType.BULK);

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/ConfigHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/ConfigHandler.java
@@ -66,7 +66,7 @@ public class ConfigHandler {
     private RecipeBookConfig recipeBookConfig;
 
     public ConfigHandler(CustomCrafting customCrafting) {
-        this.api = WolfyUtilities.get(customCrafting);
+        this.api = customCrafting.getApi();
         this.customCrafting = customCrafting;
         var configAPI = api.getConfigAPI();
         this.languageAPI = api.getLanguageAPI();

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 public class DataHandler implements Listener {
 
     public static final File DATA_FOLDER = new File(CustomCrafting.inst().getDataFolder() + File.separator + "data");
+    public static final String JSON_OBJ_PATH = DATA_FOLDER.getPath() + "/%s/%s/%s/%s.json";
     private final CustomCrafting customCrafting;
     private Categories categories;
     private List<Recipe> minecraftRecipes = new ArrayList<>();

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
@@ -70,9 +70,17 @@ public class DataHandler implements Listener {
             //Currently, there is only support for SQL. MongoDB is planned!
             this.databaseLoader = new SQLDatabaseLoader(customCrafting);
             this.databaseLoader.setPriority(2);
+
             if (config.isLocalStorageEnabled()) {
                 this.localStorageLoader = new LocalStorageLoader(customCrafting);
                 this.localStorageLoader.setPriority(config.isLocalStorageBeforeDatabase() ? 3 : 1);
+                if (config.isDataOverride()) {
+                    if (localStorageLoader.getPriority() > databaseLoader.getPriority()) {
+                        databaseLoader.setReplaceData(true);
+                    } else {
+                        localStorageLoader.setReplaceData(true);
+                    }
+                }
             } else {
                 this.localStorageLoader = null;
             }

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 public class DataHandler implements Listener {
 
     public static final File DATA_FOLDER = new File(CustomCrafting.inst().getDataFolder() + File.separator + "data");
-    public static final String JSON_OBJ_PATH = DATA_FOLDER.getPath() + "/%s/%s/%s/%s.json";
+    public static final String JSON_OBJ_PATH = DATA_FOLDER.getPath() + "/%s/%s/%s%s.json";
     private final CustomCrafting customCrafting;
     private Categories categories;
     private List<Recipe> minecraftRecipes = new ArrayList<>();

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
 public class DataHandler implements Listener {
 
     public static final File DATA_FOLDER = new File(CustomCrafting.inst().getDataFolder() + File.separator + "data");
-    public static final String JSON_OBJ_PATH = DATA_FOLDER.getPath() + "/%s/%s/%s%s.json";
+    public static final String JSON_OBJ_PATH = DATA_FOLDER.getPath() + "/%s/%s/%s.json";
     private final CustomCrafting customCrafting;
     private Categories categories;
     private List<Recipe> minecraftRecipes = new ArrayList<>();
@@ -123,6 +123,7 @@ public class DataHandler implements Listener {
     }
 
     public void setSaveDestination(SaveDestination saveDestination) {
+        customCrafting.getLogger().info("Data destination: " + saveDestination.toString());
         this.saveDestination = saveDestination;
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
@@ -178,7 +178,7 @@ public class LocalStorageLoader extends ResourceLoader {
 
     private void loadItemsInNamespace(String namespace) {
         readFiles(namespace, ITEMS_FOLDER, (relative, file, attrs) -> {
-            var namespacedKey = keyFromFile(relative);
+            var namespacedKey = keyFromFile(namespace, relative);
             try {
                 customCrafting.getApi().getRegistries().getCustomItems().register(namespacedKey, objectMapper.readValue(file.toFile(), CustomItem.class));
             } catch (IOException e) {
@@ -193,7 +193,7 @@ public class LocalStorageLoader extends ResourceLoader {
     private void loadRecipesInNamespace(String namespace) {
         var injectableValues = new InjectableValues.Std();
         readFiles(namespace, RECIPES_FOLDER, (relative, file, attrs) -> {
-            var namespacedKey = keyFromFile(relative);
+            var namespacedKey = keyFromFile(namespace, relative);
             try {
                 injectableValues.addValue("key", namespacedKey);
                 customCrafting.getRegistries().getRecipes().register(objectMapper.reader(injectableValues).readValue(file.toFile(), CustomRecipe.class));
@@ -217,9 +217,9 @@ public class LocalStorageLoader extends ResourceLoader {
         }
     }
 
-    private NamespacedKey keyFromFile(Path path) {
+    private NamespacedKey keyFromFile(String namespace, Path path) {
         String pathString = path.toString();
-        return new NamespacedKey(customCrafting, pathString + "/" + pathString.substring(0, pathString.lastIndexOf(".")));
+        return new NamespacedKey(customCrafting, namespace + "/" + pathString.substring(0, pathString.lastIndexOf(".")));
     }
 
     private void loadAndRegisterRecipe(RecipeLoader<?> loader, String namespace) {

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
@@ -102,7 +102,7 @@ public class LocalStorageLoader extends ResourceLoader {
     }
 
     private File getFileAt(NamespacedKey namespacedKey, String typeFolder) {
-        return new File(DataHandler.JSON_OBJ_PATH.formatted(NamespacedKeyUtils.getKeyRoot(namespacedKey), typeFolder, NamespacedKeyUtils.getKeyObjPath(namespacedKey, false), NamespacedKeyUtils.getKeyObj(namespacedKey)));
+        return new File(DataHandler.JSON_OBJ_PATH.formatted(NamespacedKeyUtils.getKeyRoot(namespacedKey), typeFolder, NamespacedKeyUtils.getRelativeKeyObjPath(namespacedKey), NamespacedKeyUtils.getKeyObj(namespacedKey)));
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
@@ -53,6 +53,18 @@ public class LocalStorageLoader extends ResourceLoader {
 
     @Override
     public void load() {
+        /*
+        New Folder structure:
+
+        CustomCrafting/data
+        |- <namespace>
+           |- recipes
+              |- <folder>
+                 |- <recipe_name>
+           |- items
+              |- <folder>
+                 |- <item_name>
+         */
         api.getConsole().info("- - - - [Local Storage] - - - -");
         api.getConsole().info("Searching for namespaces...");
         String[] dirs = DATA_FOLDER.list();
@@ -155,7 +167,7 @@ public class LocalStorageLoader extends ResourceLoader {
 
     private void loadItems(String subFolder) {
         for (File file : getFiles(subFolder, ITEMS_FOLDER)) {
-            String name = file.getName();
+            var name = file.getName();
             var namespacedKey = new NamespacedKey(customCrafting, subFolder + "/" + name.substring(0, name.lastIndexOf(".")));
             try {
                 customCrafting.getApi().getRegistries().getCustomItems().register(namespacedKey, objectMapper.readValue(file, CustomItem.class));
@@ -203,7 +215,8 @@ public class LocalStorageLoader extends ResourceLoader {
 
     private void loadRecipesFiles(RecipeLoader<?> loader, List<File> files, String namespace) {
         for (File file : files) {
-            var namespacedKey = new NamespacedKey(namespace, file.getName().replace(".json", ""));
+            var name = file.getName();
+            var namespacedKey = new NamespacedKey(customCrafting, namespace + "/" + name.substring(0, name.lastIndexOf(".")));
             try {
                 customCrafting.getRegistries().getRecipes().register(loader.getInstance(namespacedKey, objectMapper.readTree(file)));
             } catch (IOException | InstantiationException | InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
@@ -113,7 +113,7 @@ public class LocalStorageLoader extends ResourceLoader {
         var customItems = customCrafting.getApi().getRegistries().getCustomItems();
         readFiles(namespace, ITEMS_FOLDER, (relative, file, attrs) -> {
             var namespacedKey = keyFromFile(namespace, relative);
-            if (isReplaceData() || customItems.has(namespacedKey)) {
+            if (isReplaceData() || !customItems.has(namespacedKey)) {
                 try {
                     customItems.register(namespacedKey, objectMapper.readValue(file.toFile(), CustomItem.class));
                 } catch (IOException e) {

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
@@ -94,7 +94,7 @@ public class LocalStorageLoader extends ResourceLoader {
      * @return The File at the specific path.
      */
     private File getFileAt(NamespacedKey namespacedKey, String typeFolder) {
-        return new File(DataHandler.JSON_OBJ_PATH.formatted(NamespacedKeyUtils.getKeyRoot(namespacedKey), typeFolder, NamespacedKeyUtils.getRelativeKeyObjPath(namespacedKey), NamespacedKeyUtils.getKeyObj(namespacedKey)));
+        return new File(DataHandler.JSON_OBJ_PATH.formatted(NamespacedKeyUtils.getKeyRoot(namespacedKey), typeFolder, NamespacedKeyUtils.getRelativeKeyObjPath(namespacedKey)));
     }
 
     /**

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/ResourceLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/ResourceLoader.java
@@ -44,6 +44,7 @@ public abstract class ResourceLoader implements Comparable<ResourceLoader>, Keye
     protected final WolfyUtilities api;
     protected final ObjectMapper objectMapper;
     private int priority = 0;
+    private boolean replaceData = false;
 
     protected ResourceLoader(CustomCrafting customCrafting, NamespacedKey key) {
         this.key = key;
@@ -63,6 +64,14 @@ public abstract class ResourceLoader implements Comparable<ResourceLoader>, Keye
             api.getConsole().info("Loading updated Items & Recipes...");
             load();
         }
+    }
+
+    public void setReplaceData(boolean replaceData) {
+        this.replaceData = replaceData;
+    }
+
+    public boolean isReplaceData() {
+        return replaceData;
     }
 
     public void save() {

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/SQLDatabaseLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/SQLDatabaseLoader.java
@@ -264,7 +264,7 @@ public class SQLDatabaseLoader extends DatabaseLoader {
     public ResultSet getItem(NamespacedKey namespacedKey) {
         try {
             PreparedStatement pState = dataBase.open().prepareStatement("SELECT rData FROM customcrafting_items WHERE rNamespace=? AND rKey=?");
-            setNamespacedKey(pState, namespacedKey, 1, 1);
+            setNamespacedKey(pState, namespacedKey, 1, 2);
             return pState.executeQuery();
         } catch (SQLException e) {
             e.printStackTrace();

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/AnvilListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/AnvilListener.java
@@ -23,7 +23,6 @@
 package me.wolfyscript.customcrafting.listeners;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
-import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.customcrafting.recipes.CustomRecipeAnvil;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
 import me.wolfyscript.customcrafting.recipes.data.AnvilData;
@@ -34,7 +33,6 @@ import me.wolfyscript.utilities.util.inventory.InventoryUtils;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
-import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -60,7 +58,6 @@ public class AnvilListener implements Listener {
     public void onCheck(PrepareAnvilEvent event) {
         var player = (Player) event.getView().getPlayer();
         AnvilInventory inventory = event.getInventory();
-        Block block = inventory.getLocation() != null ? inventory.getLocation().getBlock() : null;
         preCraftedRecipes.remove(player.getUniqueId());
         ItemStack inputLeft = inventory.getItem(0);
         ItemStack inputRight = inventory.getItem(1);
@@ -68,9 +65,7 @@ public class AnvilListener implements Listener {
             event.setResult(null);
             return;
         }
-        List<CustomRecipeAnvil> recipes = customCrafting.getRegistries().getRecipes().getAvailable(RecipeType.ANVIL, player);
-        recipes.sort(Comparator.comparing(CustomRecipe::getPriority));
-        for (CustomRecipeAnvil recipe : recipes) {
+        for (CustomRecipeAnvil recipe : customCrafting.getRegistries().getRecipes().getAvailable(RecipeType.ANVIL, player)) {
             Optional<CustomItem> finalInputLeft = Optional.empty();
             Optional<CustomItem> finalInputRight = Optional.empty();
             if ((recipe.hasInputLeft() && (inputLeft == null || (finalInputLeft = recipe.getInputLeft().check(inputLeft, recipe.isCheckNBT())).isEmpty())) || (recipe.hasInputRight() && (inputRight == null || (finalInputRight = recipe.getInputRight().check(inputRight, recipe.isCheckNBT())).isEmpty()))) {
@@ -132,11 +127,8 @@ public class AnvilListener implements Listener {
                     ItemStack result = event.getCurrentItem();
                     ItemStack cursor = event.getCursor();
                     if (event.isShiftClick()) {
-                        if (InventoryUtils.hasInventorySpace(player, result)) {
-                            player.getInventory().addItem(result);
-                        } else {
-                            return;
-                        }
+                        if (!InventoryUtils.hasInventorySpace(player, result)) return;
+                        player.getInventory().addItem(result);
                     } else if (ItemUtils.isAirOrNull(cursor) || (result.isSimilar(cursor) && cursor.getAmount() + result.getAmount() <= cursor.getMaxStackSize())) {
                         if (ItemUtils.isAirOrNull(cursor)) {
                             event.setCursor(result);
@@ -162,25 +154,22 @@ public class AnvilListener implements Listener {
                     event.setCurrentItem(null);
                     player.updateInventory();
 
-                    CustomItem inputLeft = anvilData.getLeftIngredient().customItem();
-                    CustomItem inputRight = anvilData.getRightIngredient().customItem();
-
-                    if (inputLeft != null && inventory.getItem(0) != null) {
-                        ItemStack itemLeft = anvilData.getLeftIngredient().itemStack().clone();
-                        inputLeft.remove(itemLeft, 1, inventory);
-                        inventory.setItem(0, itemLeft);
-                    } else {
-                        inventory.setItem(0, null);
-                    }
-                    if (inputRight != null && inventory.getItem(1) != null) {
-                        ItemStack itemRight = anvilData.getRightIngredient().itemStack().clone();
-                        inputRight.remove(itemRight, 1, inventory);
-                        inventory.setItem(1, itemRight);
-                    } else {
-                        inventory.setItem(1, null);
-                    }
+                    IngredientData inputLeft = anvilData.getLeftIngredient();
+                    IngredientData inputRight = anvilData.getRightIngredient();
+                    consumeInputItem(inventory, inputLeft.customItem(), inputLeft, 0);
+                    consumeInputItem(inventory, inputRight.customItem(), inputRight, 1);
                 }
             }
+        }
+    }
+
+    private void consumeInputItem(AnvilInventory inventory, CustomItem input, IngredientData ingredient, int slot) {
+        if (input != null && inventory.getItem(slot) != null) {
+            ItemStack item = ingredient.itemStack().clone();
+            input.remove(item, 1, inventory);
+            inventory.setItem(slot, item);
+        } else {
+            inventory.setItem(slot, null);
         }
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/AnvilListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/AnvilListener.java
@@ -76,7 +76,7 @@ public class AnvilListener implements Listener {
         for (CustomRecipeAnvil recipe : recipes) {
             Optional<CustomItem> finalInputLeft = Optional.empty();
             Optional<CustomItem> finalInputRight = Optional.empty();
-            if ((recipe.hasInputLeft() && (inputLeft == null || (finalInputLeft = recipe.getInputLeft().check(inputLeft, recipe.isExactMeta())).isEmpty())) || (recipe.hasInputRight() && (inputRight == null || (finalInputRight = recipe.getInputRight().check(inputRight, recipe.isExactMeta())).isEmpty()))) {
+            if ((recipe.hasInputLeft() && (inputLeft == null || (finalInputLeft = recipe.getInputLeft().check(inputLeft, recipe.isCheckNBT())).isEmpty())) || (recipe.hasInputRight() && (inputRight == null || (finalInputRight = recipe.getInputRight().check(inputRight, recipe.isCheckNBT())).isEmpty()))) {
                 continue;
             }
             //Recipe is valid at this point!

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/BrewingStandListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/BrewingStandListener.java
@@ -121,7 +121,7 @@ public class BrewingStandListener implements Listener {
                         if (!ItemUtils.isAirOrNull(inventory.getItem(0)) || !ItemUtils.isAirOrNull(inventory.getItem(1)) || !ItemUtils.isAirOrNull(inventory.getItem(2))) {
                             //Check for possible recipes and add them to the map
                             customCrafting.getRegistries().getRecipes().getAvailable(RecipeType.BREWING_STAND, player).stream().filter(recipe -> fuelLevel >= recipe.getFuelCost()).forEach(recipe -> {
-                                Optional<CustomItem> optional = recipe.getIngredient().check(ingredient, recipe.isExactMeta());
+                                Optional<CustomItem> optional = recipe.getIngredient().check(ingredient, recipe.isCheckNBT());
                                 if (optional.isPresent()) {
                                     //Ingredient is valid
                                     //Checking for valid item in the bottom 3 slots of the brewing inventory
@@ -129,7 +129,7 @@ public class BrewingStandListener implements Listener {
                                     if (!recipe.getAllowedItems().isEmpty()) {
                                         for (int i = 0; i < 3; i++) {
                                             ItemStack itemStack = inventory.getItem(i);
-                                            if (!ItemUtils.isAirOrNull(itemStack) && !recipe.getAllowedItems().test(itemStack, recipe.isExactMeta())) {
+                                            if (!ItemUtils.isAirOrNull(itemStack) && !recipe.getAllowedItems().test(itemStack, recipe.isCheckNBT())) {
                                                 valid = false;
                                                 break;
                                             }
@@ -191,7 +191,7 @@ public class BrewingStandListener implements Listener {
                                                         ItemStack inputItem = brewerInventory.getItem(i);
                                                         if (!ItemUtils.isAirOrNull(inputItem)) {//is slot not empty?
                                                             //Check if item is contained in recipe before trying to process it
-                                                            if (recipe.getAllowedItems().isEmpty() || recipe.getAllowedItems().test(inputItem, recipe.isExactMeta())) {
+                                                            if (recipe.getAllowedItems().isEmpty() || recipe.getAllowedItems().test(inputItem, recipe.isCheckNBT())) {
                                                                 //Input in that slot is valid, so marking slot as processed
                                                                 processedSlots.add(i);
                                                                 //Process the item in the slot

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/CauldronListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/CauldronListener.java
@@ -106,7 +106,7 @@ public class CauldronListener implements Listener {
                         event.setUseItemInHand(Event.Result.DENY);
                         event.setUseInteractedBlock(Event.Result.DENY);
                         if (!ItemUtils.isAirOrNull(handItem)) {
-                            if (!ItemUtils.isAirOrNull(required) && required.isSimilar(handItem, recipe.isExactMeta())) {
+                            if (!ItemUtils.isAirOrNull(required) && required.isSimilar(handItem, recipe.isCheckNBT())) {
                                 handItem.setAmount(handItem.getAmount() - 1);
                             } else if (!ItemUtils.isAirOrNull(required)) {
                                 return;

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/CauldronListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/CauldronListener.java
@@ -29,6 +29,7 @@ import me.wolfyscript.customcrafting.listeners.customevents.CauldronPreCookEvent
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.customcrafting.recipes.CustomRecipeCauldron;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
+import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.inventory.InventoryUtils;
@@ -58,7 +59,7 @@ public class CauldronListener implements Listener {
 
     public CauldronListener(CustomCrafting customCrafting) {
         this.customCrafting = customCrafting;
-        this.api = WolfyUtilities.get(customCrafting);
+        this.api = customCrafting.getApi();
     }
 
     @EventHandler

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/EliteWorkbenchListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/EliteWorkbenchListener.java
@@ -50,7 +50,7 @@ public class EliteWorkbenchListener implements Listener {
             if (block != null && WorldUtils.getWorldCustomItemStore().isStored(block.getLocation())) {
                 var customItem = NamespacedKeyUtils.getCustomItem(block);
                 if (customItem != null) {
-                    EliteWorkbenchData eliteWorkbench = (EliteWorkbenchData) customItem.getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE);
+                    EliteWorkbenchData eliteWorkbench = (EliteWorkbenchData) customItem.getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA);
                     if (eliteWorkbench != null && eliteWorkbench.isEnabled()) {
                         event.setCancelled(true);
                         ((CCCache) api.getInventoryAPI().getGuiHandler(event.getPlayer()).getCustomCache()).getEliteWorkbench().setEliteWorkbenchData(eliteWorkbench.clone());

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
@@ -242,14 +242,14 @@ public class GrindStoneListener implements Listener {
         ) {
             Ingredient input = slot == 0 ? customRecipeGrindstone.getInputTop() : customRecipeGrindstone.getInputBottom();
             Ingredient otherInput = slot == 0 ? customRecipeGrindstone.getInputBottom() : customRecipeGrindstone.getInputTop();
-            Optional<CustomItem> optional = input.check(item, customRecipeGrindstone.isExactMeta());
+            Optional<CustomItem> optional = input.check(item, customRecipeGrindstone.isCheckNBT());
             if (!optional.isPresent()) {
                 //Item is invalid! Go to next recipe!
                 continue;
             }
             if (!ItemUtils.isAirOrNull(itemOther)) {
                 //Another item exists in the other slot! Check if current and other item are a valid recipe
-                Optional<CustomItem> optionalOther = otherInput.check(itemOther, customRecipeGrindstone.isExactMeta());
+                Optional<CustomItem> optionalOther = otherInput.check(itemOther, customRecipeGrindstone.isCheckNBT());
                 if (!optionalOther.isPresent()) {
                     //Other existing Item is invalid!
                     continue;

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/PlayerListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/PlayerListener.java
@@ -64,7 +64,7 @@ public class PlayerListener implements Listener {
         if (event.hasItem() && (event.getAction().equals(Action.RIGHT_CLICK_BLOCK) || event.getAction().equals(Action.RIGHT_CLICK_AIR))) {
             var customItem = CustomItem.getByItemStack(event.getItem());
             if (customItem != null) {
-                RecipeBookData knowledgeBook = (RecipeBookData) customItem.getCustomData(CustomCrafting.RECIPE_BOOK);
+                RecipeBookData knowledgeBook = (RecipeBookData) customItem.getCustomData(CustomCrafting.RECIPE_BOOK_DATA);
                 if (knowledgeBook != null && knowledgeBook.isEnabled()) {
                     event.setUseItemInHand(Event.Result.DENY);
                     event.setUseInteractedBlock(Event.Result.DENY);

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/SmithingListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/SmithingListener.java
@@ -72,9 +72,9 @@ public class SmithingListener implements Listener {
         preCraftedRecipes.put(player.getUniqueId(), null);
         for (CustomRecipeSmithing recipe : customCrafting.getRegistries().getRecipes().getAvailable(RecipeType.SMITHING, player)) {
             if (recipe.checkConditions(new Conditions.Data(player, event.getInventory().getLocation() != null ? event.getInventory().getLocation().getBlock() : null, event.getView()))) {
-                Optional<CustomItem> optionalBase = recipe.getBase().check(base, recipe.isExactMeta());
+                Optional<CustomItem> optionalBase = recipe.getBase().check(base, recipe.isCheckNBT());
                 if (optionalBase.isPresent()) {
-                    Optional<CustomItem> optionalAddition = recipe.getAddition().check(addition, recipe.isExactMeta());
+                    Optional<CustomItem> optionalAddition = recipe.getAddition().check(addition, recipe.isCheckNBT());
                     if (optionalAddition.isPresent()) {
                         //Recipe is valid
                         assert base != null;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
@@ -22,6 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
@@ -51,6 +54,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+@JsonPropertyOrder(value = { "@type", "group", "hidden", "vanillaBook", "priority", "checkNBT", "conditions", "symmetry", "shape", "ingredients" })
 public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>, S extends CraftingRecipeSettings<S>> extends CraftingRecipe<C, S> {
 
     private static final String SHAPE_KEY = "shape";
@@ -59,19 +63,15 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
     private static final String VERTICAL_KEY = "vertical";
     private static final String ROTATION_KEY = "rotation";
 
+    @JsonProperty("ingredients")
     protected Map<Character, Ingredient> mappedIngredients;
+    @JsonIgnore private Shape internalShape;
     private String[] shape;
-    private Shape internalShape;
-    private boolean mirrorHorizontal;
-    private boolean mirrorVertical;
-    private boolean mirrorRotation;
+    private final Symmetry symmetry;
 
     protected AbstractRecipeShaped(NamespacedKey namespacedKey, JsonNode node, int gridSize, Class<S> settingsType) {
         super(namespacedKey, node, gridSize, settingsType);
-        JsonNode mirrorNode = node.path(MIRROR_KEY);
-        this.mirrorHorizontal = mirrorNode.path(HORIZONTAL_KEY).asBoolean(true);
-        this.mirrorVertical = mirrorNode.path(VERTICAL_KEY).asBoolean(false);
-        this.mirrorRotation = mirrorNode.path(ROTATION_KEY).asBoolean(false);
+        this.symmetry = Symmetry.ofLegacy(node.path(MIRROR_KEY));
         this.mappedIngredients = Map.of();
 
         Map<Character, Ingredient> loadedIngredients = Streams.stream(node.path(INGREDIENTS_KEY).fields()).collect(Collectors.toMap(entry -> entry.getKey().charAt(0), entry -> ItemLoader.loadIngredient(entry.getValue())));
@@ -85,44 +85,50 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
 
     protected AbstractRecipeShaped(NamespacedKey key, int gridSize, S settings) {
         super(key, gridSize, settings);
-        this.mirrorHorizontal = true;
-        this.mirrorVertical = false;
-        this.mirrorRotation = false;
+        this.symmetry = new Symmetry();
         this.mappedIngredients = new HashMap<>();
     }
 
     protected AbstractRecipeShaped(AbstractRecipeShaped<C, S> recipe) {
         super(recipe);
-        this.mirrorHorizontal = recipe.mirrorHorizontal;
-        this.mirrorVertical = recipe.mirrorVertical;
-        this.mirrorRotation = recipe.mirrorRotation;
+        this.symmetry = recipe.symmetry.copy();
         this.mappedIngredients = new HashMap<>();
         setShape(recipe.shape.clone());
         setIngredients(recipe.mappedIngredients.entrySet().stream().map(entry -> Map.entry(entry.getKey(), entry.getValue().clone())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
+    @Deprecated
     public void setMirrorHorizontal(boolean mirrorHorizontal) {
-        this.mirrorHorizontal = mirrorHorizontal;
+        symmetry.setHorizontal(mirrorHorizontal);
     }
 
+    @Deprecated
     public void setMirrorVertical(boolean mirrorVertical) {
-        this.mirrorVertical = mirrorVertical;
+        symmetry.setVertical(mirrorVertical);
     }
 
+    @Deprecated
     public void setMirrorRotation(boolean mirrorRotation) {
-        this.mirrorRotation = mirrorRotation;
+        symmetry.setRotate(mirrorRotation);
     }
 
+    @Deprecated
     public boolean mirrorHorizontal() {
-        return mirrorHorizontal;
+        return symmetry.isHorizontal();
     }
 
+    @Deprecated
     public boolean mirrorVertical() {
-        return mirrorVertical;
+        return symmetry.isVertical();
     }
 
+    @Deprecated
     public boolean mirrorRotation() {
-        return mirrorRotation;
+        return symmetry.isRotate();
+    }
+
+    public Symmetry getSymmetry() {
+        return symmetry;
     }
 
     public String[] getShape() {
@@ -212,6 +218,12 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
         createFlatIngredients();
     }
 
+    @JsonIgnore
+    @Override
+    public List<Ingredient> getIngredients() {
+        return super.getIngredients();
+    }
+
     /**
      * @return An unmodifiable Map copy of the Ingredients mapped to the character in the shape.
      */
@@ -242,7 +254,7 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
                 if (recipeSlot >= 0) {
                     var ingredient = ingredients.get(recipeSlot);
                     if (ingredient != null) {
-                        Optional<CustomItem> item = ingredient.check(invItem, this.exactMeta);
+                        Optional<CustomItem> item = ingredient.check(invItem, this.checkNBT);
                         if (item.isPresent()) {
                             dataMap.put(recipeSlot, new IngredientData(recipeSlot, ingredient, item.get(), invItem));
                             i++;
@@ -280,14 +292,15 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
         }
     }
 
+    @Deprecated
     @Override
     public void writeToJson(JsonGenerator gen, SerializerProvider serializerProvider) throws IOException {
         super.writeToJson(gen, serializerProvider);
         gen.writeObjectField(SHAPE_KEY, shape);
         gen.writeObjectFieldStart(MIRROR_KEY);
-        gen.writeBooleanField(HORIZONTAL_KEY, this.mirrorHorizontal);
-        gen.writeBooleanField(VERTICAL_KEY, this.mirrorVertical);
-        gen.writeBooleanField(ROTATION_KEY, this.mirrorRotation);
+        gen.writeBooleanField(HORIZONTAL_KEY, symmetry.horizontal);
+        gen.writeBooleanField(VERTICAL_KEY, symmetry.vertical);
+        gen.writeBooleanField(ROTATION_KEY, symmetry.rotate);
         gen.writeEndObject();
         gen.writeObjectField(INGREDIENTS_KEY, this.mappedIngredients);
     }
@@ -332,20 +345,18 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
             this.height = original2d.length;
             this.width = original2d[0].length;
             apply(shapeEntryList, original2d);
-
-            if (mirrorHorizontal) {
+            if (symmetry.horizontal) {
                 final int[][] flippedHorizontally2d = original2d.clone();
                 for (int[] ints : flippedHorizontally2d) {
                     ArrayUtils.reverse(ints);
                 }
                 apply(shapeEntryList, flippedHorizontally2d);
             }
-
-            if (mirrorVertical) {
+            if (symmetry.vertical) {
                 final int[][] flippedVertically2d = original2d.clone();
                 ArrayUtils.reverse(flippedVertically2d);
                 apply(shapeEntryList, flippedVertically2d);
-                if (mirrorRotation) {
+                if (symmetry.rotate) {
                     int[][] rotated = flippedVertically2d.clone();
                     for (int[] ints : rotated) {
                         ArrayUtils.reverse(ints);
@@ -397,6 +408,62 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
             byteBuf.writeInt(height);
             byteBuf.writeVarInt(entries.size());
             entries.forEach(byteBuf::writeVarIntArray);
+        }
+
+    }
+
+    public static class Symmetry {
+
+        private boolean horizontal;
+        private boolean vertical;
+        private boolean rotate;
+
+        private Symmetry() {
+            this.horizontal = false;
+            this.vertical = false;
+            this.rotate = false;
+        }
+
+        private Symmetry(Symmetry other) {
+            this.horizontal = other.horizontal;
+            this.vertical = other.vertical;
+            this.rotate = other.rotate;
+        }
+
+        private static Symmetry ofLegacy(JsonNode node) {
+            var symmetry = new Symmetry();
+            symmetry.horizontal = node.path(HORIZONTAL_KEY).asBoolean(false);
+            symmetry.vertical = node.path(VERTICAL_KEY).asBoolean(false);
+            symmetry.rotate = node.path(ROTATION_KEY).asBoolean(false);
+            return symmetry;
+        }
+
+        public void setHorizontal(boolean horizontal) {
+            this.horizontal = horizontal;
+        }
+
+        public boolean isHorizontal() {
+            return horizontal;
+        }
+
+        public void setVertical(boolean vertical) {
+            this.vertical = vertical;
+        }
+
+        public boolean isVertical() {
+            return vertical;
+        }
+
+        public void setRotate(boolean rotate) {
+            this.rotate = rotate;
+        }
+
+        public boolean isRotate() {
+            return rotate;
+        }
+
+        public Symmetry copy() {
+            return new Symmetry(this);
         }
 
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
@@ -97,6 +97,7 @@ public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<
         setIngredients(ingredients.stream());
     }
 
+    @JsonIgnore
     public void setIngredients(Stream<Ingredient> ingredients) {
         List<Ingredient> ingredientsNew = ingredients.filter(ingredient -> ingredient != null && !ingredient.isEmpty()).toList();
         Preconditions.checkArgument(!ingredientsNew.isEmpty(), "Invalid ingredients! Recipe requires non-air ingredients!");
@@ -171,7 +172,7 @@ public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<
         for (int key : indexes) {
             if (!selectedSlots.contains(key) && !checkedSlots.contains(key)) {
                 var ingredient = ingredients.get(key);
-                Optional<CustomItem> validItem = ingredient.check(item, isExactMeta());
+                Optional<CustomItem> validItem = ingredient.check(item, isCheckNBT());
                 if (validItem.isPresent()) {
                     dataMap.put(pos, new IngredientData(key, ingredient, validItem.get(), item));
                     return key;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
@@ -22,6 +22,8 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonInclude;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
@@ -46,10 +48,10 @@ import java.util.stream.Stream;
 
 public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<C, S>, S extends CraftingRecipeSettings<S>> extends CraftingRecipe<C, S> {
 
-    private List<Integer> indexes;
-    private int combinations = 1;
-    private int nonEmptyIngredientSize;
-    private boolean hasAllowedEmptyIngredient;
+    @JsonIgnore private List<Integer> indexes;
+    @JsonIgnore private int combinations = 1;
+    @JsonIgnore private int nonEmptyIngredientSize;
+    @JsonIgnore private boolean hasAllowedEmptyIngredient;
 
     protected AbstractRecipeShapeless(NamespacedKey namespacedKey, JsonNode node, int gridSize, Class<S> settingsType) {
         super(namespacedKey, node, gridSize, settingsType);
@@ -185,6 +187,7 @@ public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<
         return true;
     }
 
+    @Deprecated
     @Override
     public void writeToJson(JsonGenerator gen, SerializerProvider serializerProvider) throws IOException {
         super.writeToJson(gen, serializerProvider);

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
@@ -24,6 +24,8 @@ package me.wolfyscript.customcrafting.recipes;
 
 import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
 import me.wolfyscript.customcrafting.CustomCrafting;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.type.TypeReference;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
@@ -72,8 +74,7 @@ public abstract class CraftingRecipe<C extends CraftingRecipe<C, S>, S extends C
         this.ingredients = List.of();
         this.maxGridDimension = gridSize;
         this.maxIngredients = maxGridDimension * maxGridDimension;
-        this.settings = Objects.requireNonNullElseGet(mapper.convertValue(node.path("settings"), new TypeReference<>() {
-        }), () -> {
+        this.settings = Objects.requireNonNullElseGet(mapper.convertValue(node.path("settings"), settingsType), () -> {
             try {
                 return settingsType.getDeclaredConstructor().newInstance();
             } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
@@ -103,6 +104,7 @@ public abstract class CraftingRecipe<C extends CraftingRecipe<C, S>, S extends C
         return ingredients.get(slot);
     }
 
+    @JsonIgnore
     public abstract boolean isShapeless();
 
     public abstract boolean fitsDimensions(CraftManager.MatrixData matrixData);
@@ -119,6 +121,7 @@ public abstract class CraftingRecipe<C extends CraftingRecipe<C, S>, S extends C
     /**
      * @return The max grid dimensions of the crafting recipe type.
      */
+    @JsonIgnore
     public int getMaxGridDimension() {
         return maxGridDimension;
     }
@@ -126,6 +129,7 @@ public abstract class CraftingRecipe<C extends CraftingRecipe<C, S>, S extends C
     /**
      * @return The maximum ingredients of the crafting recipe type. Usually the maxGridDimension squared (9, 16, 25, 36).
      */
+    @JsonIgnore
     public int getMaxIngredients() {
         return maxIngredients;
     }
@@ -216,6 +220,7 @@ public abstract class CraftingRecipe<C extends CraftingRecipe<C, S>, S extends C
         }
     }
 
+    @Deprecated
     @Override
     public void writeToJson(JsonGenerator gen, SerializerProvider serializerProvider) throws IOException {
         super.writeToJson(gen, serializerProvider);

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShaped.java
@@ -30,19 +30,17 @@ public class CraftingRecipeEliteShaped extends AbstractRecipeShaped<CraftingReci
 
     public CraftingRecipeEliteShaped(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node, 6, EliteRecipeSettings.class);
+        this.type = RecipeType.ELITE_CRAFTING_SHAPED;
     }
 
     public CraftingRecipeEliteShaped(NamespacedKey key) {
         super(key, 6, new EliteRecipeSettings());
+        this.type = RecipeType.ELITE_CRAFTING_SHAPED;
     }
 
     public CraftingRecipeEliteShaped(CraftingRecipeEliteShaped eliteCraftingRecipe) {
         super(eliteCraftingRecipe);
-    }
-
-    @Override
-    public RecipeType<CraftingRecipeEliteShaped> getRecipeType() {
-        return RecipeType.ELITE_CRAFTING_SHAPED;
+        this.type = RecipeType.ELITE_CRAFTING_SHAPED;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShaped.java
@@ -33,23 +33,19 @@ public class CraftingRecipeEliteShaped extends AbstractRecipeShaped<CraftingReci
 
     public CraftingRecipeEliteShaped(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node, 6, EliteRecipeSettings.class);
-        this.type = RecipeType.ELITE_CRAFTING_SHAPED;
     }
 
     @JsonCreator
     public CraftingRecipeEliteShaped(@JsonProperty("key") @JacksonInject("key") NamespacedKey key, @JsonProperty("shape") String[] shape) {
         super(key, shape, 6, new EliteRecipeSettings());
-        this.type = RecipeType.ELITE_CRAFTING_SHAPED;
     }
 
     public CraftingRecipeEliteShaped(NamespacedKey key) {
         super(key, 6, new EliteRecipeSettings());
-        this.type = RecipeType.ELITE_CRAFTING_SHAPED;
     }
 
     public CraftingRecipeEliteShaped(CraftingRecipeEliteShaped eliteCraftingRecipe) {
         super(eliteCraftingRecipe);
-        this.type = RecipeType.ELITE_CRAFTING_SHAPED;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShaped.java
@@ -22,6 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.customcrafting.recipes.settings.EliteRecipeSettings;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -33,7 +36,8 @@ public class CraftingRecipeEliteShaped extends AbstractRecipeShaped<CraftingReci
         this.type = RecipeType.ELITE_CRAFTING_SHAPED;
     }
 
-    public CraftingRecipeEliteShaped(NamespacedKey key) {
+    @JsonCreator
+    public CraftingRecipeEliteShaped(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key, 6, new EliteRecipeSettings());
         this.type = RecipeType.ELITE_CRAFTING_SHAPED;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShaped.java
@@ -37,7 +37,12 @@ public class CraftingRecipeEliteShaped extends AbstractRecipeShaped<CraftingReci
     }
 
     @JsonCreator
-    public CraftingRecipeEliteShaped(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
+    public CraftingRecipeEliteShaped(@JsonProperty("key") @JacksonInject("key") NamespacedKey key, @JsonProperty("shape") String[] shape) {
+        super(key, shape, 6, new EliteRecipeSettings());
+        this.type = RecipeType.ELITE_CRAFTING_SHAPED;
+    }
+
+    public CraftingRecipeEliteShaped(NamespacedKey key) {
         super(key, 6, new EliteRecipeSettings());
         this.type = RecipeType.ELITE_CRAFTING_SHAPED;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShapeless.java
@@ -22,6 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.customcrafting.recipes.settings.EliteRecipeSettings;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -33,7 +36,8 @@ public class CraftingRecipeEliteShapeless extends AbstractRecipeShapeless<Crafti
         this.type = RecipeType.ELITE_CRAFTING_SHAPELESS;
     }
 
-    public CraftingRecipeEliteShapeless(NamespacedKey key) {
+    @JsonCreator
+    public CraftingRecipeEliteShapeless(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key, 6, new EliteRecipeSettings());
         this.type = RecipeType.ELITE_CRAFTING_SHAPELESS;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShapeless.java
@@ -30,19 +30,17 @@ public class CraftingRecipeEliteShapeless extends AbstractRecipeShapeless<Crafti
 
     public CraftingRecipeEliteShapeless(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node, 6, EliteRecipeSettings.class);
+        this.type = RecipeType.ELITE_CRAFTING_SHAPELESS;
     }
 
     public CraftingRecipeEliteShapeless(NamespacedKey key) {
         super(key, 6, new EliteRecipeSettings());
+        this.type = RecipeType.ELITE_CRAFTING_SHAPELESS;
     }
 
     public CraftingRecipeEliteShapeless(CraftingRecipeEliteShapeless eliteCraftingRecipe) {
         super(eliteCraftingRecipe);
-    }
-
-    @Override
-    public RecipeType<CraftingRecipeEliteShapeless> getRecipeType() {
-        return RecipeType.ELITE_CRAFTING_SHAPELESS;
+        this.type = RecipeType.ELITE_CRAFTING_SHAPELESS;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShapeless.java
@@ -33,18 +33,15 @@ public class CraftingRecipeEliteShapeless extends AbstractRecipeShapeless<Crafti
 
     public CraftingRecipeEliteShapeless(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node, 6, EliteRecipeSettings.class);
-        this.type = RecipeType.ELITE_CRAFTING_SHAPELESS;
     }
 
     @JsonCreator
     public CraftingRecipeEliteShapeless(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key, 6, new EliteRecipeSettings());
-        this.type = RecipeType.ELITE_CRAFTING_SHAPELESS;
     }
 
     public CraftingRecipeEliteShapeless(CraftingRecipeEliteShapeless eliteCraftingRecipe) {
         super(eliteCraftingRecipe);
-        this.type = RecipeType.ELITE_CRAFTING_SHAPELESS;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
@@ -22,6 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.settings.AdvancedRecipeSettings;
@@ -36,7 +39,8 @@ public class CraftingRecipeShaped extends AbstractRecipeShaped<CraftingRecipeSha
         this.type = RecipeType.CRAFTING_SHAPED;
     }
 
-    public CraftingRecipeShaped(NamespacedKey key) {
+    @JsonCreator
+    public CraftingRecipeShaped(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key, 3, new AdvancedRecipeSettings());
         this.type = RecipeType.CRAFTING_SHAPED;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
@@ -36,23 +36,19 @@ public class CraftingRecipeShaped extends AbstractRecipeShaped<CraftingRecipeSha
 
     public CraftingRecipeShaped(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node, 3, AdvancedRecipeSettings.class);
-        this.type = RecipeType.CRAFTING_SHAPED;
     }
 
     @JsonCreator
     public CraftingRecipeShaped(@JsonProperty("key") @JacksonInject("key") NamespacedKey key, @JsonProperty("shape") String[] shape) {
         super(key, shape, 3, new AdvancedRecipeSettings());
-        this.type = RecipeType.CRAFTING_SHAPED;
     }
 
     public CraftingRecipeShaped(NamespacedKey key) {
         super(key, 3, new AdvancedRecipeSettings());
-        this.type = RecipeType.CRAFTING_SHAPED;
     }
 
     public CraftingRecipeShaped(CraftingRecipeShaped craftingRecipe) {
         super(craftingRecipe);
-        this.type = RecipeType.CRAFTING_SHAPED;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
@@ -33,19 +33,17 @@ public class CraftingRecipeShaped extends AbstractRecipeShaped<CraftingRecipeSha
 
     public CraftingRecipeShaped(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node, 3, AdvancedRecipeSettings.class);
+        this.type = RecipeType.CRAFTING_SHAPED;
     }
 
     public CraftingRecipeShaped(NamespacedKey key) {
         super(key, 3, new AdvancedRecipeSettings());
+        this.type = RecipeType.CRAFTING_SHAPED;
     }
 
     public CraftingRecipeShaped(CraftingRecipeShaped craftingRecipe) {
         super(craftingRecipe);
-    }
-
-    @Override
-    public RecipeType<CraftingRecipeShaped> getRecipeType() {
-        return RecipeType.CRAFTING_SHAPED;
+        this.type = RecipeType.CRAFTING_SHAPED;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
@@ -40,7 +40,12 @@ public class CraftingRecipeShaped extends AbstractRecipeShaped<CraftingRecipeSha
     }
 
     @JsonCreator
-    public CraftingRecipeShaped(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
+    public CraftingRecipeShaped(@JsonProperty("key") @JacksonInject("key") NamespacedKey key, @JsonProperty("shape") String[] shape) {
+        super(key, shape, 3, new AdvancedRecipeSettings());
+        this.type = RecipeType.CRAFTING_SHAPED;
+    }
+
+    public CraftingRecipeShaped(NamespacedKey key) {
         super(key, 3, new AdvancedRecipeSettings());
         this.type = RecipeType.CRAFTING_SHAPED;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
@@ -37,18 +37,15 @@ public class CraftingRecipeShapeless extends AbstractRecipeShapeless<CraftingRec
 
     public CraftingRecipeShapeless(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node, 3, AdvancedRecipeSettings.class);
-        this.type = RecipeType.CRAFTING_SHAPELESS;
     }
 
     @JsonCreator
     public CraftingRecipeShapeless(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key, 3, new AdvancedRecipeSettings());
-        this.type = RecipeType.CRAFTING_SHAPELESS;
     }
 
     public CraftingRecipeShapeless(CraftingRecipeShapeless craftingRecipe) {
         super(craftingRecipe);
-        this.type = RecipeType.CRAFTING_SHAPELESS;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
@@ -54,7 +54,7 @@ public class CraftingRecipeShapeless extends AbstractRecipeShapeless<CraftingRec
 
     @Override
     public org.bukkit.inventory.ShapelessRecipe getVanillaRecipe() {
-        if (!getSettings().isAllowVanillaRecipe() && !getResult().isEmpty()) {
+        if (!getResult().isEmpty()) {
             var shapelessRecipe = new org.bukkit.inventory.ShapelessRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getItemStack());
             for (Ingredient value : ingredients) {
                 shapelessRecipe.addIngredient(new RecipeChoice.ExactChoice(value.getChoices().stream().map(CustomItem::getItemStack).distinct().toList()));

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
@@ -22,6 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
@@ -37,7 +40,8 @@ public class CraftingRecipeShapeless extends AbstractRecipeShapeless<CraftingRec
         this.type = RecipeType.CRAFTING_SHAPELESS;
     }
 
-    public CraftingRecipeShapeless(NamespacedKey key) {
+    @JsonCreator
+    public CraftingRecipeShapeless(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key, 3, new AdvancedRecipeSettings());
         this.type = RecipeType.CRAFTING_SHAPELESS;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
@@ -34,19 +34,17 @@ public class CraftingRecipeShapeless extends AbstractRecipeShapeless<CraftingRec
 
     public CraftingRecipeShapeless(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node, 3, AdvancedRecipeSettings.class);
+        this.type = RecipeType.CRAFTING_SHAPELESS;
     }
 
     public CraftingRecipeShapeless(NamespacedKey key) {
         super(key, 3, new AdvancedRecipeSettings());
+        this.type = RecipeType.CRAFTING_SHAPELESS;
     }
 
     public CraftingRecipeShapeless(CraftingRecipeShapeless craftingRecipe) {
         super(craftingRecipe);
-    }
-
-    @Override
-    public RecipeType<CraftingRecipeShapeless> getRecipeType() {
-        return RecipeType.CRAFTING_SHAPELESS;
+        this.type = RecipeType.CRAFTING_SHAPELESS;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonAutoDetect;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
@@ -313,7 +314,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     public boolean save(ResourceLoader loader, @Nullable Player player) {
         if (loader.save(this)) {
             getAPI().getChat().sendKey(player, "recipe_creator", "save.success");
-            getAPI().getChat().sendMessage(player, String.format("§6data/%s/%s/%s/", getNamespacedKey().getNamespace(), getRecipeType().getId(), getNamespacedKey().getKey()));
+            getAPI().getChat().sendMessage(player, String.format("§6data/%s/recipes/%s", NamespacedKeyUtils.getKeyRoot(getNamespacedKey()), NamespacedKeyUtils.getKeyObjPath(getNamespacedKey(), false)));
             return true;
         }
         return false;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -22,7 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonAutoDetect;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonGetter;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
@@ -99,7 +101,6 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
      * @param namespacedKey The namespaced key of the recipe.
      * @param node The json node read from the recipe file.
      */
-    @Deprecated
     protected CustomRecipe(NamespacedKey namespacedKey, JsonNode node) {
         this.namespacedKey = Objects.requireNonNull(namespacedKey, ERROR_MSG_KEY);
         this.mapper = JacksonUtil.getObjectMapper();
@@ -120,19 +121,9 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
         }
     }
 
-    protected CustomRecipe(NamespacedKey key) {
-        this.type = RecipeType.valueOfRecipe(this);
-        this.namespacedKey = Objects.requireNonNull(key, ERROR_MSG_KEY);
-        this.mapper = JacksonUtil.getObjectMapper();
-        this.api = CustomCrafting.inst().getApi();
-        this.result = new Result();
-
-        this.group = "";
-        this.priority = RecipePriority.NORMAL;
-        this.checkNBT = true;
-        this.vanillaBook = false;
-        this.conditions = new Conditions();
-        this.hidden = false;
+    @JsonCreator
+    protected CustomRecipe(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
+        this(key, (RecipeType<C>) null);
     }
 
     protected CustomRecipe(NamespacedKey key, RecipeType<C> type) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -314,7 +314,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     public boolean save(ResourceLoader loader, @Nullable Player player) {
         if (loader.save(this)) {
             getAPI().getChat().sendKey(player, "recipe_creator", "save.success");
-            getAPI().getChat().sendMessage(player, String.format("§6data/%s/recipes/%s", NamespacedKeyUtils.getKeyRoot(getNamespacedKey()), NamespacedKeyUtils.getKeyObjPath(getNamespacedKey(), false)));
+            getAPI().getChat().sendMessage(player, String.format("§6data/%s/recipes/%s", NamespacedKeyUtils.getKeyRoot(getNamespacedKey()), NamespacedKeyUtils.getRelativeKeyObjPath(getNamespacedKey())));
             return true;
         }
         return false;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -166,6 +166,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     @Override
     public abstract C clone();
 
+    @JsonIgnore
     public WolfyUtilities getAPI() {
         return api;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -93,6 +93,13 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     protected String group;
     protected Result result;
 
+    /**
+     *
+     * @deprecated Used only for deserializing recipes from old json files.
+     * @param namespacedKey The namespaced key of the recipe.
+     * @param node The json node read from the recipe file.
+     */
+    @Deprecated
     protected CustomRecipe(NamespacedKey namespacedKey, JsonNode node) {
         this.namespacedKey = Objects.requireNonNull(namespacedKey, ERROR_MSG_KEY);
         this.mapper = JacksonUtil.getObjectMapper();
@@ -114,6 +121,23 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     }
 
     protected CustomRecipe(NamespacedKey key) {
+        this.type = RecipeType.valueOfRecipe(this);
+        this.namespacedKey = Objects.requireNonNull(key, ERROR_MSG_KEY);
+        this.mapper = JacksonUtil.getObjectMapper();
+        this.api = CustomCrafting.inst().getApi();
+        this.result = new Result();
+
+        this.group = "";
+        this.priority = RecipePriority.NORMAL;
+        this.checkNBT = true;
+        this.vanillaBook = false;
+        this.conditions = new Conditions();
+        this.hidden = false;
+    }
+
+    protected CustomRecipe(NamespacedKey key, RecipeType<C> type) {
+        this.type = type == null ? RecipeType.valueOfRecipe(this) : type;
+        Preconditions.checkArgument(this.type != null, "Error constructing Recipe Object \"" + getClass().getName() + "\": Missing RecipeType!");
         this.namespacedKey = Objects.requireNonNull(key, ERROR_MSG_KEY);
         this.mapper = JacksonUtil.getObjectMapper();
         this.api = CustomCrafting.inst().getApi();
@@ -133,7 +157,8 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
      *
      * @param customRecipe The other CustomRecipe. Can be from another type, but must have the same ResultTarget.
      */
-    protected CustomRecipe(CustomRecipe<?> customRecipe) {
+    protected CustomRecipe(CustomRecipe<C> customRecipe) {
+        this.type = customRecipe.type;
         this.mapper = JacksonUtil.getObjectMapper();
         this.api = CustomCrafting.inst().getApi();
         this.namespacedKey = Objects.requireNonNull(customRecipe.namespacedKey, ERROR_MSG_KEY);
@@ -330,6 +355,14 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
 
     public abstract void prepareMenu(GuiHandler<CCCache> guiHandler, GuiCluster<CCCache> cluster);
 
+    /**
+     * Writes the recipe to json using the specified generator and provider.
+     *
+     * @param gen The JsonGenerator
+     * @param provider The SerializerProvider
+     * @throws IOException Any exception caused when writing it to json.
+     * @deprecated This is no longer used. Instead, the recipe object can be written to json directly.
+     */
     @Deprecated
     public void writeToJson(JsonGenerator gen, SerializerProvider provider) throws IOException {
         gen.writeStringField(KEY_GROUP, group);

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -103,6 +103,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
      * @param node The json node read from the recipe file.
      */
     protected CustomRecipe(NamespacedKey namespacedKey, JsonNode node) {
+        this.type = RecipeType.valueOfRecipe(this);
         this.namespacedKey = Objects.requireNonNull(namespacedKey, ERROR_MSG_KEY);
         this.mapper = JacksonUtil.getObjectMapper();
         this.api = CustomCrafting.inst().getApi();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
@@ -23,6 +23,9 @@
 package me.wolfyscript.customcrafting.recipes;
 
 import me.wolfyscript.customcrafting.gui.recipebook.ClusterRecipeBook;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
@@ -80,6 +83,19 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
         this.repairCostMode = RepairCostMode.valueOf(repairNode.path("mode").asText("NONE"));
     }
 
+    @JsonCreator
+    public CustomRecipeAnvil(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
+        super(key);
+        this.mode = Mode.RESULT;
+        this.durability = 0;
+        this.repairCost = 1;
+        this.applyRepairCost = false;
+        this.repairCostMode = RepairCostMode.NONE;
+        this.blockEnchant = false;
+        this.blockRename = false;
+        this.blockRepair = false;
+    }
+
     public CustomRecipeAnvil(CustomRecipeAnvil recipe) {
         super(recipe);
         this.mode = recipe.getMode();
@@ -92,18 +108,6 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
         this.blockEnchant = recipe.blockEnchant;
         this.blockRename = recipe.blockRename;
         this.blockRepair = recipe.blockRepair;
-    }
-
-    public CustomRecipeAnvil(NamespacedKey key) {
-        super(key);
-        this.mode = Mode.RESULT;
-        this.durability = 0;
-        this.repairCost = 1;
-        this.applyRepairCost = false;
-        this.repairCostMode = RepairCostMode.NONE;
-        this.blockEnchant = false;
-        this.blockRename = false;
-        this.blockRepair = false;
     }
 
     private void readInput(JsonNode node) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
@@ -85,7 +85,7 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
 
     @JsonCreator
     public CustomRecipeAnvil(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
-        super(key);
+        super(key, RecipeType.ANVIL);
         this.mode = Mode.RESULT;
         this.durability = 0;
         this.repairCost = 1;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
@@ -25,6 +25,7 @@ package me.wolfyscript.customcrafting.recipes;
 import me.wolfyscript.customcrafting.gui.recipebook.ClusterRecipeBook;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
@@ -152,18 +153,22 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
         this.durability = durability;
     }
 
+    @JsonIgnore
     public Ingredient getInputLeft() {
         return getIngredient(0);
     }
 
+    @JsonIgnore
     public Ingredient getInputRight() {
         return getIngredient(1);
     }
 
+    @JsonIgnore
     public boolean hasInputLeft() {
         return !getInputLeft().isEmpty();
     }
 
+    @JsonIgnore
     public boolean hasInputRight() {
         return !getInputRight().isEmpty();
     }
@@ -252,6 +257,7 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
         gen.writeObjectField("addition", this.addition);
     }
 
+    @JsonIgnore
     @Override
     public List<CustomItem> getRecipeBookItems() {
         return getMode().equals(CustomRecipeAnvil.Mode.RESULT) ? getResult().getChoices() : hasInputLeft() ? getInputLeft().getChoices() : getInputRight().getChoices();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
@@ -82,7 +82,6 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
 
     public CustomRecipeAnvil(CustomRecipeAnvil recipe) {
         super(recipe);
-        this.type = RecipeType.ANVIL;
         this.mode = recipe.getMode();
         this.base = recipe.base.clone();
         this.addition = recipe.addition.clone();
@@ -97,7 +96,6 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
 
     public CustomRecipeAnvil(NamespacedKey key) {
         super(key);
-        this.type = RecipeType.ANVIL;
         this.mode = Mode.RESULT;
         this.durability = 0;
         this.repairCost = 1;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
@@ -65,6 +65,7 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
 
     public CustomRecipeAnvil(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
+        this.type = RecipeType.ANVIL;
         JsonNode modeNode = node.path("mode");
         this.durability = modeNode.path("durability").asInt(0);
         this.mode = Mode.valueOf(modeNode.get("usedMode").asText("DURABILITY"));
@@ -81,6 +82,7 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
 
     public CustomRecipeAnvil(CustomRecipeAnvil recipe) {
         super(recipe);
+        this.type = RecipeType.ANVIL;
         this.mode = recipe.getMode();
         this.base = recipe.base.clone();
         this.addition = recipe.addition.clone();
@@ -95,6 +97,7 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
 
     public CustomRecipeAnvil(NamespacedKey key) {
         super(key);
+        this.type = RecipeType.ANVIL;
         this.mode = Mode.RESULT;
         this.durability = 0;
         this.repairCost = 1;
@@ -201,11 +204,6 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
 
     public void setRepairCostMode(RepairCostMode repairCostMode) {
         this.repairCostMode = repairCostMode;
-    }
-
-    @Override
-    public RecipeType<CustomRecipeAnvil> getRecipeType() {
-        return RecipeType.ANVIL;
     }
 
     public void setBase(@NotNull Ingredient base) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
@@ -32,14 +32,17 @@ public class CustomRecipeBlasting extends CustomRecipeCooking<CustomRecipeBlasti
 
     public CustomRecipeBlasting(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
+        this.type = RecipeType.BLAST_FURNACE;
     }
 
     public CustomRecipeBlasting(NamespacedKey key) {
         super(key);
+        this.type = RecipeType.BLAST_FURNACE;
     }
 
     public CustomRecipeBlasting(CustomRecipeBlasting customRecipeBlasting) {
         super(customRecipeBlasting);
+        this.type = RecipeType.BLAST_FURNACE;
     }
 
     @Override
@@ -50,11 +53,6 @@ public class CustomRecipeBlasting extends CustomRecipeCooking<CustomRecipeBlasti
             return recipe;
         }
         return null;
-    }
-
-    @Override
-    public RecipeType<CustomRecipeBlasting> getRecipeType() {
-        return RecipeType.BLAST_FURNACE;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
@@ -22,6 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -35,7 +38,8 @@ public class CustomRecipeBlasting extends CustomRecipeCooking<CustomRecipeBlasti
         this.type = RecipeType.BLAST_FURNACE;
     }
 
-    public CustomRecipeBlasting(NamespacedKey key) {
+    @JsonCreator
+    public CustomRecipeBlasting(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
         this.type = RecipeType.BLAST_FURNACE;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
@@ -35,18 +35,15 @@ public class CustomRecipeBlasting extends CustomRecipeCooking<CustomRecipeBlasti
 
     public CustomRecipeBlasting(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
-        this.type = RecipeType.BLAST_FURNACE;
     }
 
     @JsonCreator
     public CustomRecipeBlasting(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
-        this.type = RecipeType.BLAST_FURNACE;
     }
 
     public CustomRecipeBlasting(CustomRecipeBlasting customRecipeBlasting) {
         super(customRecipeBlasting);
-        this.type = RecipeType.BLAST_FURNACE;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBrewing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBrewing.java
@@ -81,7 +81,6 @@ public class CustomRecipeBrewing extends CustomRecipe<CustomRecipeBrewing> {
 
     public CustomRecipeBrewing(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
-        this.type = RecipeType.BREWING_STAND;
         this.ingredients = ItemLoader.loadIngredient(node.path("ingredients"));
         this.result = ItemLoader.loadResult(node.path("results"));
         this.fuelCost = node.path("fuel_cost").asInt(1);
@@ -124,7 +123,7 @@ public class CustomRecipeBrewing extends CustomRecipe<CustomRecipeBrewing> {
 
     @JsonCreator
     public CustomRecipeBrewing(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
-        super(key);
+        super(key, RecipeType.BREWING_STAND);
         this.ingredients = new Ingredient();
         this.fuelCost = 1;
         this.brewTime = 400;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBrewing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBrewing.java
@@ -121,7 +121,6 @@ public class CustomRecipeBrewing extends CustomRecipe<CustomRecipeBrewing> {
 
     public CustomRecipeBrewing(NamespacedKey key) {
         super(key);
-        this.type = RecipeType.BREWING_STAND;
         this.ingredients = new Ingredient();
         this.fuelCost = 1;
         this.brewTime = 400;
@@ -140,7 +139,6 @@ public class CustomRecipeBrewing extends CustomRecipe<CustomRecipeBrewing> {
 
     public CustomRecipeBrewing(CustomRecipeBrewing customRecipeBrewing) {
         super(customRecipeBrewing);
-        this.type = RecipeType.BREWING_STAND;
         this.ingredients = customRecipeBrewing.getIngredient();
         this.fuelCost = customRecipeBrewing.getFuelCost();
         this.brewTime = customRecipeBrewing.getBrewTime();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBrewing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBrewing.java
@@ -78,6 +78,7 @@ public class CustomRecipeBrewing extends CustomRecipe<CustomRecipeBrewing> {
 
     public CustomRecipeBrewing(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
+        this.type = RecipeType.BREWING_STAND;
         this.ingredients = ItemLoader.loadIngredient(node.path("ingredients"));
         this.result = ItemLoader.loadResult(node.path("results"));
         this.fuelCost = node.path("fuel_cost").asInt(1);
@@ -120,6 +121,7 @@ public class CustomRecipeBrewing extends CustomRecipe<CustomRecipeBrewing> {
 
     public CustomRecipeBrewing(NamespacedKey key) {
         super(key);
+        this.type = RecipeType.BREWING_STAND;
         this.ingredients = new Ingredient();
         this.fuelCost = 1;
         this.brewTime = 400;
@@ -138,6 +140,7 @@ public class CustomRecipeBrewing extends CustomRecipe<CustomRecipeBrewing> {
 
     public CustomRecipeBrewing(CustomRecipeBrewing customRecipeBrewing) {
         super(customRecipeBrewing);
+        this.type = RecipeType.BREWING_STAND;
         this.ingredients = customRecipeBrewing.getIngredient();
         this.fuelCost = customRecipeBrewing.getFuelCost();
         this.brewTime = customRecipeBrewing.getBrewTime();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBrewing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBrewing.java
@@ -23,6 +23,9 @@
 package me.wolfyscript.customcrafting.recipes;
 
 import me.wolfyscript.customcrafting.gui.recipebook.ClusterRecipeBook;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
@@ -119,7 +122,8 @@ public class CustomRecipeBrewing extends CustomRecipe<CustomRecipeBrewing> {
         setRequiredEffects(requiredEffects);
     }
 
-    public CustomRecipeBrewing(NamespacedKey key) {
+    @JsonCreator
+    public CustomRecipeBrewing(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
         this.ingredients = new Ingredient();
         this.fuelCost = 1;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCampfire.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCampfire.java
@@ -35,18 +35,15 @@ public class CustomRecipeCampfire extends CustomRecipeCooking<CustomRecipeCampfi
 
     public CustomRecipeCampfire(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
-        this.type = RecipeType.CAMPFIRE;
     }
 
     @JsonCreator
     public CustomRecipeCampfire(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
-        this.type = RecipeType.CAMPFIRE;
     }
 
     public CustomRecipeCampfire(CustomRecipeCampfire customRecipeCampfire) {
         super(customRecipeCampfire);
-        this.type = RecipeType.CAMPFIRE;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCampfire.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCampfire.java
@@ -32,14 +32,17 @@ public class CustomRecipeCampfire extends CustomRecipeCooking<CustomRecipeCampfi
 
     public CustomRecipeCampfire(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
+        this.type = RecipeType.CAMPFIRE;
     }
 
     public CustomRecipeCampfire(NamespacedKey key) {
         super(key);
+        this.type = RecipeType.CAMPFIRE;
     }
 
     public CustomRecipeCampfire(CustomRecipeCampfire customRecipeCampfire) {
         super(customRecipeCampfire);
+        this.type = RecipeType.CAMPFIRE;
     }
 
     @Override
@@ -50,11 +53,6 @@ public class CustomRecipeCampfire extends CustomRecipeCooking<CustomRecipeCampfi
             return recipe;
         }
         return null;
-    }
-
-    @Override
-    public RecipeType<CustomRecipeCampfire> getRecipeType() {
-        return RecipeType.CAMPFIRE;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCampfire.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCampfire.java
@@ -22,6 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -35,7 +38,8 @@ public class CustomRecipeCampfire extends CustomRecipeCooking<CustomRecipeCampfi
         this.type = RecipeType.CAMPFIRE;
     }
 
-    public CustomRecipeCampfire(NamespacedKey key) {
+    @JsonCreator
+    public CustomRecipeCampfire(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
         this.type = RecipeType.CAMPFIRE;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
@@ -63,7 +63,6 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
 
     public CustomRecipeCauldron(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
-        this.type = RecipeType.CAULDRON;
         this.xp = node.path("exp").asInt(0);
         this.cookingTime = node.path("cookingTime").asInt(60);
         this.waterLevel = node.path("waterLevel").asInt(1);
@@ -79,7 +78,7 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
 
     @JsonCreator
     public CustomRecipeCauldron(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
-        super(key);
+        super(key, RecipeType.CAULDRON);
         this.result = new Result();
         this.ingredients = new Ingredient();
         this.dropItems = true;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
@@ -76,7 +76,6 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
 
     public CustomRecipeCauldron(NamespacedKey key) {
         super(key);
-        this.type = RecipeType.CAULDRON;
         this.result = new Result();
         this.ingredients = new Ingredient();
         this.dropItems = true;
@@ -90,7 +89,6 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
 
     public CustomRecipeCauldron(CustomRecipeCauldron customRecipeCauldron) {
         super(customRecipeCauldron);
-        this.type = RecipeType.CAULDRON;
         this.result = customRecipeCauldron.getResult();
         this.ingredients = customRecipeCauldron.getIngredient();
         this.dropItems = customRecipeCauldron.dropItems();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
@@ -60,6 +60,7 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
 
     public CustomRecipeCauldron(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
+        this.type = RecipeType.CAULDRON;
         this.xp = node.path("exp").asInt(0);
         this.cookingTime = node.path("cookingTime").asInt(60);
         this.waterLevel = node.path("waterLevel").asInt(1);
@@ -75,6 +76,7 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
 
     public CustomRecipeCauldron(NamespacedKey key) {
         super(key);
+        this.type = RecipeType.CAULDRON;
         this.result = new Result();
         this.ingredients = new Ingredient();
         this.dropItems = true;
@@ -88,6 +90,7 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
 
     public CustomRecipeCauldron(CustomRecipeCauldron customRecipeCauldron) {
         super(customRecipeCauldron);
+        this.type = RecipeType.CAULDRON;
         this.result = customRecipeCauldron.getResult();
         this.ingredients = customRecipeCauldron.getIngredient();
         this.dropItems = customRecipeCauldron.dropItems();
@@ -169,11 +172,6 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
 
     public void setHandItem(CustomItem handItem) {
         this.handItem = handItem;
-    }
-
-    @Override
-    public RecipeType<CustomRecipeCauldron> getRecipeType() {
-        return RecipeType.CAULDRON;
     }
 
     public Ingredient getIngredient() {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
@@ -23,6 +23,9 @@
 package me.wolfyscript.customcrafting.recipes;
 
 import me.wolfyscript.customcrafting.gui.recipebook.ClusterRecipeBook;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
@@ -74,7 +77,8 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
         this.ingredients = ItemLoader.loadIngredient(node.path("ingredients"));
     }
 
-    public CustomRecipeCauldron(NamespacedKey key) {
+    @JsonCreator
+    public CustomRecipeCauldron(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
         this.result = new Result();
         this.ingredients = new Ingredient();
@@ -152,7 +156,7 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
         List<Item> validItems = new ArrayList<>();
         for (CustomItem customItem : getIngredient().getChoices()) {
             for (Item item : items) {
-                if (customItem.isSimilar(item.getItemStack(), isExactMeta()) && customItem.getAmount() == item.getItemStack().getAmount()) {
+                if (customItem.isSimilar(item.getItemStack(), isCheckNBT()) && customItem.getAmount() == item.getItemStack().getAmount()) {
                     validItems.add(item);
                     break;
                 }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
@@ -129,7 +129,7 @@ public abstract class CustomRecipeCooking<C extends CustomRecipeCooking<C, T>, T
     }
 
     protected RecipeChoice getRecipeChoice() {
-        return isExactMeta() ? new RecipeChoice.ExactChoice(getSource().getChoices().parallelStream().map(CustomItem::create).toList()) : new RecipeChoice.MaterialChoice(getSource().getChoices().parallelStream().map(i -> i.create().getType()).toList());
+        return isCheckNBT() ? new RecipeChoice.ExactChoice(getSource().getChoices().parallelStream().map(CustomItem::create).toList()) : new RecipeChoice.MaterialChoice(getSource().getChoices().parallelStream().map(i -> i.create().getType()).toList());
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
@@ -156,6 +156,7 @@ public abstract class CustomRecipeCooking<C extends CustomRecipeCooking<C, T>, T
         event.setButton(24, ButtonContainerIngredient.key(cluster, 24));
     }
 
+    @Deprecated
     @Override
     public void writeToJson(JsonGenerator gen, SerializerProvider serializerProvider) throws IOException {
         super.writeToJson(gen, serializerProvider);

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
@@ -35,18 +35,15 @@ public class CustomRecipeFurnace extends CustomRecipeCooking<CustomRecipeFurnace
 
     public CustomRecipeFurnace(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
-        this.type = RecipeType.FURNACE;
     }
 
     @JsonCreator
     public CustomRecipeFurnace(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
-        this.type = RecipeType.FURNACE;
     }
 
     public CustomRecipeFurnace(CustomRecipeFurnace customRecipeFurnace) {
         super(customRecipeFurnace);
-        this.type = RecipeType.FURNACE;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
@@ -22,6 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -35,7 +38,8 @@ public class CustomRecipeFurnace extends CustomRecipeCooking<CustomRecipeFurnace
         this.type = RecipeType.FURNACE;
     }
 
-    public CustomRecipeFurnace(NamespacedKey key) {
+    @JsonCreator
+    public CustomRecipeFurnace(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
         this.type = RecipeType.FURNACE;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
@@ -32,14 +32,17 @@ public class CustomRecipeFurnace extends CustomRecipeCooking<CustomRecipeFurnace
 
     public CustomRecipeFurnace(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
+        this.type = RecipeType.FURNACE;
     }
 
     public CustomRecipeFurnace(NamespacedKey key) {
         super(key);
+        this.type = RecipeType.FURNACE;
     }
 
     public CustomRecipeFurnace(CustomRecipeFurnace customRecipeFurnace) {
         super(customRecipeFurnace);
+        this.type = RecipeType.FURNACE;
     }
 
     @Override
@@ -50,11 +53,6 @@ public class CustomRecipeFurnace extends CustomRecipeCooking<CustomRecipeFurnace
             return recipe;
         }
         return null;
-    }
-
-    @Override
-    public RecipeType<CustomRecipeFurnace> getRecipeType() {
-        return RecipeType.FURNACE;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeGrindstone.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeGrindstone.java
@@ -61,8 +61,7 @@ public class CustomRecipeGrindstone extends CustomRecipe<CustomRecipeGrindstone>
 
     @JsonCreator
     public CustomRecipeGrindstone(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
-        super(key);
-        this.type = RecipeType.GRINDSTONE;
+        super(key, RecipeType.GRINDSTONE);
         this.result = new Result();
         this.inputTop = new Ingredient();
         this.inputBottom = new Ingredient();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeGrindstone.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeGrindstone.java
@@ -50,6 +50,7 @@ public class CustomRecipeGrindstone extends CustomRecipe<CustomRecipeGrindstone>
 
     public CustomRecipeGrindstone(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
+        this.type = RecipeType.GRINDSTONE;
         this.xp = node.path("exp").intValue();
         this.inputTop = ItemLoader.loadIngredient(node.path("input_top"));
         this.inputBottom = ItemLoader.loadIngredient(node.path("input_bottom"));
@@ -57,6 +58,7 @@ public class CustomRecipeGrindstone extends CustomRecipe<CustomRecipeGrindstone>
 
     public CustomRecipeGrindstone(NamespacedKey key) {
         super(key);
+        this.type = RecipeType.GRINDSTONE;
         this.result = new Result();
         this.inputTop = new Ingredient();
         this.inputBottom = new Ingredient();
@@ -65,6 +67,7 @@ public class CustomRecipeGrindstone extends CustomRecipe<CustomRecipeGrindstone>
 
     public CustomRecipeGrindstone(CustomRecipeGrindstone customRecipeGrindstone) {
         super(customRecipeGrindstone);
+        this.type = RecipeType.GRINDSTONE;
         this.inputBottom = customRecipeGrindstone.getInputBottom();
         this.inputTop = customRecipeGrindstone.getInputTop();
         this.xp = customRecipeGrindstone.getXp();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeGrindstone.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeGrindstone.java
@@ -67,7 +67,6 @@ public class CustomRecipeGrindstone extends CustomRecipe<CustomRecipeGrindstone>
 
     public CustomRecipeGrindstone(CustomRecipeGrindstone customRecipeGrindstone) {
         super(customRecipeGrindstone);
-        this.type = RecipeType.GRINDSTONE;
         this.inputBottom = customRecipeGrindstone.getInputBottom();
         this.inputTop = customRecipeGrindstone.getInputTop();
         this.xp = customRecipeGrindstone.getXp();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeGrindstone.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeGrindstone.java
@@ -23,6 +23,9 @@
 package me.wolfyscript.customcrafting.recipes;
 
 import me.wolfyscript.customcrafting.gui.recipebook.ClusterRecipeBook;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
@@ -56,7 +59,8 @@ public class CustomRecipeGrindstone extends CustomRecipe<CustomRecipeGrindstone>
         this.inputBottom = ItemLoader.loadIngredient(node.path("input_bottom"));
     }
 
-    public CustomRecipeGrindstone(NamespacedKey key) {
+    @JsonCreator
+    public CustomRecipeGrindstone(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
         this.type = RecipeType.GRINDSTONE;
         this.result = new Result();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
@@ -63,7 +63,6 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
 
     public CustomRecipeSmithing(NamespacedKey key) {
         super(key);
-        this.type = RecipeType.SMITHING;
         this.base = new Ingredient();
         this.addition = new Ingredient();
         this.result = new Result();
@@ -73,7 +72,6 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
 
     public CustomRecipeSmithing(CustomRecipeSmithing customRecipeSmithing) {
         super(customRecipeSmithing);
-        this.type = RecipeType.SMITHING;
         this.result = customRecipeSmithing.getResult();
         this.base = customRecipeSmithing.getBase();
         this.addition = customRecipeSmithing.getAddition();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
@@ -23,6 +23,9 @@
 package me.wolfyscript.customcrafting.recipes;
 
 import me.wolfyscript.customcrafting.gui.recipebook.ClusterRecipeBook;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
@@ -61,7 +64,8 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
         onlyChangeMaterial = node.path("onlyChangeMaterial").asBoolean(false);
     }
 
-    public CustomRecipeSmithing(NamespacedKey key) {
+    @JsonCreator
+    public CustomRecipeSmithing(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
         this.base = new Ingredient();
         this.addition = new Ingredient();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
@@ -54,6 +54,7 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
 
     public CustomRecipeSmithing(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
+        this.type = RecipeType.SMITHING;
         base = ItemLoader.loadIngredient(node.path(KEY_BASE));
         addition = ItemLoader.loadIngredient(node.path(KEY_ADDITION));
         preserveEnchants = node.path("preserve_enchants").asBoolean(true);
@@ -62,6 +63,7 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
 
     public CustomRecipeSmithing(NamespacedKey key) {
         super(key);
+        this.type = RecipeType.SMITHING;
         this.base = new Ingredient();
         this.addition = new Ingredient();
         this.result = new Result();
@@ -71,16 +73,12 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
 
     public CustomRecipeSmithing(CustomRecipeSmithing customRecipeSmithing) {
         super(customRecipeSmithing);
+        this.type = RecipeType.SMITHING;
         this.result = customRecipeSmithing.getResult();
         this.base = customRecipeSmithing.getBase();
         this.addition = customRecipeSmithing.getAddition();
         this.preserveEnchants = customRecipeSmithing.isPreserveEnchants();
         this.onlyChangeMaterial = customRecipeSmithing.isOnlyChangeMaterial();
-    }
-
-    @Override
-    public RecipeType<CustomRecipeSmithing> getRecipeType() {
-        return RecipeType.SMITHING;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
@@ -66,7 +66,7 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
 
     @JsonCreator
     public CustomRecipeSmithing(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
-        super(key);
+        super(key, RecipeType.SMITHING);
         this.base = new Ingredient();
         this.addition = new Ingredient();
         this.result = new Result();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
@@ -35,18 +35,15 @@ public class CustomRecipeSmoking extends CustomRecipeCooking<CustomRecipeSmoking
 
     public CustomRecipeSmoking(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
-        this.type = RecipeType.SMOKER;
     }
 
     @JsonCreator
     public CustomRecipeSmoking(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
-        this.type = RecipeType.SMOKER;
     }
 
     public CustomRecipeSmoking(CustomRecipeSmoking customRecipeSmoking) {
         super(customRecipeSmoking);
-        this.type = RecipeType.SMOKER;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
@@ -32,19 +32,17 @@ public class CustomRecipeSmoking extends CustomRecipeCooking<CustomRecipeSmoking
 
     public CustomRecipeSmoking(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
+        this.type = RecipeType.SMOKER;
     }
 
     public CustomRecipeSmoking(NamespacedKey key) {
         super(key);
+        this.type = RecipeType.SMOKER;
     }
 
     public CustomRecipeSmoking(CustomRecipeSmoking customRecipeSmoking) {
         super(customRecipeSmoking);
-    }
-
-    @Override
-    public RecipeType<CustomRecipeSmoking> getRecipeType() {
-        return RecipeType.SMOKER;
+        this.type = RecipeType.SMOKER;
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
@@ -22,6 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -35,7 +38,8 @@ public class CustomRecipeSmoking extends CustomRecipeCooking<CustomRecipeSmoking
         this.type = RecipeType.SMOKER;
     }
 
-    public CustomRecipeSmoking(NamespacedKey key) {
+    @JsonCreator
+    public CustomRecipeSmoking(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
         this.type = RecipeType.SMOKER;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
@@ -69,7 +69,7 @@ public class CustomRecipeStonecutter extends CustomRecipe<CustomRecipeStonecutte
 
     @JsonCreator
     public CustomRecipeStonecutter(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
-        super(key);
+        super(key, RecipeType.STONECUTTER);
         this.result = new Result();
         this.source = new Ingredient();
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
@@ -22,6 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonSetter;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
@@ -64,7 +67,8 @@ public class CustomRecipeStonecutter extends CustomRecipe<CustomRecipeStonecutte
         setSource(ItemLoader.loadIngredient(node.path(KEY_SOURCE)));
     }
 
-    public CustomRecipeStonecutter(NamespacedKey key) {
+    @JsonCreator
+    public CustomRecipeStonecutter(@JsonProperty("key") @JacksonInject("key") NamespacedKey key) {
         super(key);
         this.result = new Result();
         this.source = new Ingredient();
@@ -142,7 +146,7 @@ public class CustomRecipeStonecutter extends CustomRecipe<CustomRecipeStonecutte
     @Override
     public StonecuttingRecipe getVanillaRecipe() {
         if (!getResult().isEmpty() && !getSource().isEmpty()) {
-            RecipeChoice choice = isExactMeta() ? new RecipeChoice.ExactChoice(getSource().getBukkitChoices()) : new RecipeChoice.MaterialChoice(getSource().getBukkitChoices().stream().map(ItemStack::getType).toList());
+            RecipeChoice choice = isCheckNBT() ? new RecipeChoice.ExactChoice(getSource().getBukkitChoices()) : new RecipeChoice.MaterialChoice(getSource().getBukkitChoices().stream().map(ItemStack::getType).toList());
             var recipe = new StonecuttingRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getChoices().get(0).create(), choice);
             recipe.setGroup(group);
             return recipe;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonSetter;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
@@ -82,6 +83,12 @@ public class CustomRecipeStonecutter extends CustomRecipe<CustomRecipeStonecutte
     public void setSource(@NotNull Ingredient source) {
         Preconditions.checkArgument(!source.isEmpty(), "Invalid source! Recipe must have non-air source!");
         this.source = source;
+    }
+
+    @JsonSetter("result")
+    @Override
+    protected void setResult(JsonNode node) {
+        setResult(node.has("custom_amount") ? new Result(JacksonUtil.getObjectMapper().convertValue(node, APIReference.class)) : ItemLoader.loadResult(node));
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/ICustomVanillaRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/ICustomVanillaRecipe.java
@@ -22,14 +22,15 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.bukkit.inventory.Recipe;
 
 public interface ICustomVanillaRecipe<T extends Recipe> {
 
-    T getVanillaRecipe();
+    @JsonIgnore T getVanillaRecipe();
 
-    boolean isVisibleVanillaBook();
+    @JsonIgnore boolean isVisibleVanillaBook();
 
-    void setVisibleVanillaBook(boolean vanillaBook);
+    @JsonIgnore void setVisibleVanillaBook(boolean vanillaBook);
 
 }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/RecipeType.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/RecipeType.java
@@ -71,6 +71,10 @@ public interface RecipeType<C extends CustomRecipe<?>> extends RecipeLoader<C>, 
         return RecipeTypeImpl.values.get(type.toString().toLowerCase(Locale.ROOT));
     }
 
+    static <C extends CustomRecipe<C>> RecipeType<C> valueOfRecipe(CustomRecipe<C> type) {
+        return (RecipeType<C>) values().stream().filter(recipeType -> recipeType.isInstance(type)).findFirst().orElse(null);
+    }
+
     Type getType();
 
     String getCreatorID();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/RecipeType.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/RecipeType.java
@@ -72,6 +72,7 @@ public interface RecipeType<C extends CustomRecipe<?>> extends RecipeLoader<C>, 
     }
 
     static <C extends CustomRecipe<C>> RecipeType<C> valueOfRecipe(CustomRecipe<C> type) {
+        if (type == null) return null;
         return (RecipeType<C>) values().stream().filter(recipeType -> recipeType.isInstance(type)).findFirst().orElse(null);
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/RecipeType.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/RecipeType.java
@@ -264,7 +264,8 @@ public interface RecipeType<C extends CustomRecipe<?>> extends RecipeLoader<C>, 
         CAULDRON,
         GRINDSTONE,
         BREWING_STAND,
-        SMITHING
+        SMITHING,
+        CUSTOM
     }
 
     class RecipeTypeImpl<C extends CustomRecipe<?>> implements RecipeType<C> {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/RecipeType.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/RecipeType.java
@@ -22,16 +22,20 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.customcrafting.recipes.settings.AdvancedRecipeSettings;
 import me.wolfyscript.customcrafting.recipes.settings.CraftingRecipeSettings;
 import me.wolfyscript.customcrafting.recipes.settings.EliteRecipeSettings;
+import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.json.jackson.annotations.OptionalKeyReference;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
-public interface RecipeType<C extends CustomRecipe<?>> extends RecipeLoader<C> {
+@OptionalKeyReference(field = "key")
+public interface RecipeType<C extends CustomRecipe<?>> extends RecipeLoader<C>, Keyed {
 
     //Crafting recipes
     RecipeType<CraftingRecipeShaped> CRAFTING_SHAPED = new RecipeTypeImpl<>(Type.CRAFTING_SHAPED, CraftingRecipeShaped.class);
@@ -157,6 +161,7 @@ public interface RecipeType<C extends CustomRecipe<?>> extends RecipeLoader<C> {
             public CraftingRecipe<?, S> getInstance(NamespacedKey namespacedKey, JsonNode node) throws IllegalAccessException, InvocationTargetException, InstantiationException, NoSuchMethodException {
                 return !node.path("shapeless").asBoolean() ? types.get(0).getInstance(namespacedKey, node) : types.get(1).getInstance(namespacedKey, node);
             }
+
         }
 
         class ContainerImpl<C extends CustomRecipe<?>> implements Container<C> {
@@ -262,6 +267,7 @@ public interface RecipeType<C extends CustomRecipe<?>> extends RecipeLoader<C> {
 
         static final Map<String, RecipeType<? extends CustomRecipe<?>>> values = new HashMap<>();
 
+        private final NamespacedKey key;
         private final String id;
         private final Type type;
         private final String creatorID;
@@ -273,6 +279,7 @@ public interface RecipeType<C extends CustomRecipe<?>> extends RecipeLoader<C> {
         }
 
         private RecipeTypeImpl(Type type, Class<C> clazz, String creatorID) {
+            this.key = new NamespacedKey(CustomCrafting.inst(), creatorID);
             this.type = type;
             this.clazz = clazz;
             this.id = type.toString().toLowerCase(Locale.ROOT);
@@ -340,5 +347,9 @@ public interface RecipeType<C extends CustomRecipe<?>> extends RecipeLoader<C> {
                     '}';
         }
 
+        @Override
+        public NamespacedKey getNamespacedKey() {
+            return key;
+        }
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/RecipeTypeIdResolver.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/RecipeTypeIdResolver.java
@@ -1,0 +1,75 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes;
+
+import me.wolfyscript.customcrafting.CustomCrafting;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonTypeInfo;
+import me.wolfyscript.lib.com.fasterxml.jackson.databind.DatabindContext;
+import me.wolfyscript.lib.com.fasterxml.jackson.databind.JavaType;
+import me.wolfyscript.lib.com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import me.wolfyscript.lib.com.fasterxml.jackson.databind.type.TypeFactory;
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+public class RecipeTypeIdResolver extends TypeIdResolverBase {
+
+    private JavaType superType;
+
+    @Override
+    public void init(JavaType baseType) {
+        super.init(baseType);
+        this.superType = baseType;
+    }
+
+    @Override
+    public String idFromValue(Object value) {
+        return getKey(value);
+    }
+
+    @Override
+    public String idFromValueAndType(Object value, Class<?> aClass) {
+        return getKey(value);
+    }
+
+    private String getKey(Object value) {
+        if (value instanceof CustomRecipe<?> customRecipe) {
+            return customRecipe.type.toString();
+        } else {
+            throw new IllegalArgumentException(String.format("Object %s is not of type CustomRecipe!", value.getClass().getName()));
+        }
+    }
+
+    @Override
+    public JavaType typeFromId(DatabindContext context, String id) {
+        RecipeType<?> recipeType = CustomCrafting.inst().getRegistries().getRecipeTypes().get(NamespacedKey.of(id));
+        if (recipeType != null) {
+            Class<?> clazz = recipeType.getRecipeClass();
+            return clazz != null ? context.constructSpecializedType(this.superType, clazz) : TypeFactory.unknownType();
+        }
+        return TypeFactory.unknownType();
+    }
+
+    @Override
+    public JsonTypeInfo.Id getMechanism() {
+        return JsonTypeInfo.Id.CUSTOM;
+    }
+}

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/RecipeTypeResolver.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/RecipeTypeResolver.java
@@ -1,0 +1,33 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes;
+
+import me.wolfyscript.lib.com.fasterxml.jackson.databind.JavaType;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeResolver;
+
+public class RecipeTypeResolver extends KeyedTypeResolver {
+
+    public boolean useForType(JavaType t) {
+        return t.isTypeOrSubTypeOf(CustomRecipe.class);
+    }
+}

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/anvil/RepairTask.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/anvil/RepairTask.java
@@ -1,0 +1,68 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes.anvil;
+
+import me.wolfyscript.customcrafting.recipes.CustomRecipeAnvil;
+import me.wolfyscript.customcrafting.recipes.data.AnvilData;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonAutoDetect;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonTypeInfo;
+import me.wolfyscript.lib.com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import me.wolfyscript.lib.com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
+import me.wolfyscript.utilities.util.Keyed;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeIdResolver;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeResolver;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
+import org.bukkit.inventory.ItemStack;
+
+@JsonTypeResolver(KeyedTypeResolver.class)
+@JsonTypeIdResolver(KeyedTypeIdResolver.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "key")
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonPropertyOrder(value = {"key", "mode"})
+public abstract class RepairTask implements Keyed {
+
+    private final NamespacedKey key;
+    private final CustomRecipeAnvil.Mode mode;
+
+    protected RepairTask(NamespacedKey key, CustomRecipeAnvil.Mode mode) {
+        this.mode = mode;
+        this.key = key;
+    }
+
+    public CustomRecipeAnvil.Mode getMode() {
+        return mode;
+    }
+
+    public abstract CustomItem computeResult(CustomRecipeAnvil recipe, PrepareAnvilEvent event, AnvilData anvilData, Player player, ItemStack inputLeft, ItemStack inputRight);
+
+    @JsonIgnore
+    @Override
+    public NamespacedKey getNamespacedKey() {
+        return key;
+    }
+}

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/anvil/RepairTaskDefault.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/anvil/RepairTaskDefault.java
@@ -1,0 +1,85 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes.anvil;
+
+import me.wolfyscript.customcrafting.recipes.CustomRecipeAnvil;
+import me.wolfyscript.customcrafting.recipes.data.AnvilData;
+import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+
+import java.util.Map;
+
+public class RepairTaskDefault extends RepairTask {
+
+    public static final NamespacedKey KEY = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "default");
+
+    public RepairTaskDefault() {
+        super(KEY, CustomRecipeAnvil.Mode.NONE);
+    }
+
+    protected RepairTaskDefault(NamespacedKey key, CustomRecipeAnvil.Mode mode) {
+        super(key, mode);
+    }
+
+    @Override
+    public CustomItem computeResult(CustomRecipeAnvil recipe, PrepareAnvilEvent event, AnvilData anvilData, Player player, ItemStack inputLeft, ItemStack inputRight) {
+        CustomItem resultItem = new CustomItem(event.getResult());
+        ItemStack resultStack = resultItem.getItemStack();
+        if (resultItem.hasItemMeta()) {
+            //Further recipe options to block features.
+            if (recipe.isBlockEnchant() && resultStack.hasItemMeta() && resultItem.getItemMeta().hasEnchants()) {
+                //Block Enchants
+                for (Enchantment enchantment : resultStack.getEnchantments().keySet()) {
+                    resultItem.removeEnchantment(enchantment);
+                }
+                if (inputLeft != null) {
+                    for (Map.Entry<Enchantment, Integer> entry : inputLeft.getEnchantments().entrySet()) {
+                        resultItem.addUnsafeEnchantment(entry.getKey(), entry.getValue());
+                    }
+                }
+            }
+            if (recipe.isBlockRename()) {
+                //Block Renaming
+                if (inputLeft != null && inputLeft.hasItemMeta() && inputLeft.getItemMeta().hasDisplayName()) {
+                    resultItem.setDisplayName(inputLeft.getItemMeta().getDisplayName());
+                } else {
+                    resultItem.setDisplayName(null);
+                }
+            }
+            if (recipe.isBlockRepair() && resultItem.getItemMeta() instanceof Damageable resultDamageable) {
+                //Block Repairing
+                if (inputLeft != null && inputLeft.hasItemMeta() && inputLeft.getItemMeta() instanceof Damageable damageable) {
+                    resultDamageable.setDamage(damageable.getDamage());
+                }
+                resultItem.setItemMeta(resultDamageable);
+            }
+        }
+        return resultItem;
+    }
+}

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/anvil/RepairTaskDurability.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/anvil/RepairTaskDurability.java
@@ -1,0 +1,65 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes.anvil;
+
+import me.wolfyscript.customcrafting.recipes.CustomRecipeAnvil;
+import me.wolfyscript.customcrafting.recipes.data.AnvilData;
+import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+
+public class RepairTaskDurability extends RepairTaskDefault {
+
+    public static final NamespacedKey KEY = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "durability");
+
+    private int durability;
+
+    public RepairTaskDurability() {
+        super(KEY, CustomRecipeAnvil.Mode.DURABILITY);
+    }
+
+    public void setDurability(int durability) {
+        this.durability = durability;
+    }
+
+    public int getDurability() {
+        return durability;
+    }
+
+    @Override
+    public CustomItem computeResult(CustomRecipeAnvil recipe, PrepareAnvilEvent event, AnvilData anvilData, Player player, ItemStack inputLeft, ItemStack inputRight) {
+        CustomItem resultItem = super.computeResult(recipe, event, anvilData, player, inputLeft, inputRight);
+        //Durability mode is set.
+        if (resultItem.hasCustomDurability()) {
+            resultItem.setCustomDamage(Math.max(0, resultItem.getCustomDamage() - durability));
+        } else if (resultItem.getItemMeta() instanceof Damageable damageable) {
+            damageable.setDamage(damageable.getDamage() - durability);
+            resultItem.setItemMeta(damageable);
+        }
+        return resultItem;
+    }
+}

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/anvil/RepairTaskResult.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/anvil/RepairTaskResult.java
@@ -1,0 +1,65 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes.anvil;
+
+import com.google.common.base.Preconditions;
+import me.wolfyscript.customcrafting.recipes.CustomRecipeAnvil;
+import me.wolfyscript.customcrafting.recipes.data.AnvilData;
+import me.wolfyscript.customcrafting.recipes.items.Result;
+import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Objects;
+
+public class RepairTaskResult extends RepairTask {
+
+    public static final NamespacedKey KEY = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "result");
+
+    private Result result;
+
+    public RepairTaskResult() {
+        super(KEY, CustomRecipeAnvil.Mode.RESULT);
+    }
+
+    public void setResult(Result result) {
+        Objects.requireNonNull(result, "Invalid result! Result must not be null!");
+        Preconditions.checkArgument(!result.isEmpty(), "Invalid result! Recipe must have a non-air result!");
+        this.result = result;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    @Override
+    public CustomItem computeResult(CustomRecipeAnvil recipe, PrepareAnvilEvent event, AnvilData anvilData, Player player, ItemStack inputLeft, ItemStack inputRight) {
+        //Recipe has a plain result set that we can use.
+        anvilData.setUsedResult(true);
+        return recipe.getResult().getItem(player, event.getInventory().getLocation() != null ? event.getInventory().getLocation().getBlock() : null).orElse(new CustomItem(Material.AIR));
+    }
+}

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/brewing/EffectAddition.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/brewing/EffectAddition.java
@@ -1,0 +1,52 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes.brewing;
+
+import org.bukkit.potion.PotionEffect;
+
+public class EffectAddition {
+
+    private PotionEffect effect;
+    private boolean replace;
+
+    public EffectAddition(PotionEffect effect, boolean replace) {
+        this.effect = effect;
+        this.replace = replace;
+    }
+
+    public PotionEffect getEffect() {
+        return effect;
+    }
+
+    public void setEffect(PotionEffect effect) {
+        this.effect = effect;
+    }
+
+    public boolean isReplace() {
+        return replace;
+    }
+
+    public void setReplace(boolean replace) {
+        this.replace = replace;
+    }
+}

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/brewing/EffectSettings.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/brewing/EffectSettings.java
@@ -1,0 +1,63 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes.brewing;
+
+import org.bukkit.potion.PotionEffectType;
+
+public abstract class EffectSettings {
+
+    private PotionEffectType effectType;
+    private int amplifier;
+    private int duration;
+
+    protected EffectSettings(PotionEffectType effectType, int amplifier, int duration) {
+        this.effectType = effectType;
+        this.amplifier = amplifier;
+        this.duration = duration;
+    }
+
+    public PotionEffectType getEffectType() {
+        return effectType;
+    }
+
+    public void setEffectType(PotionEffectType effectType) {
+        this.effectType = effectType;
+    }
+
+    public int getAmplifier() {
+        return amplifier;
+    }
+
+    public void setAmplifier(int amplifier) {
+        this.amplifier = amplifier;
+    }
+
+    public int getDuration() {
+        return duration;
+    }
+
+    public void setDuration(int duration) {
+        this.duration = duration;
+    }
+
+}

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/brewing/EffectSettingsRequired.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/brewing/EffectSettingsRequired.java
@@ -1,0 +1,32 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes.brewing;
+
+import org.bukkit.potion.PotionEffectType;
+
+public class EffectSettingsRequired extends EffectSettings {
+
+    public EffectSettingsRequired(PotionEffectType effectType, int amplifier, int duration) {
+        super(effectType, amplifier, duration);
+    }
+}

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/brewing/EffectSettingsUpgrade.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/brewing/EffectSettingsUpgrade.java
@@ -1,0 +1,32 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes.brewing;
+
+import org.bukkit.potion.PotionEffectType;
+
+public class EffectSettingsUpgrade extends EffectSettings {
+
+    public EffectSettingsUpgrade(PotionEffectType effectType, int amplifier, int duration) {
+        super(effectType, amplifier, duration);
+    }
+}

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/conditions/AdvancedWorkbenchCondition.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/conditions/AdvancedWorkbenchCondition.java
@@ -46,7 +46,7 @@ public class AdvancedWorkbenchCondition extends Condition<AdvancedWorkbenchCondi
         if (recipe instanceof CraftingRecipe) {
             if (data.getBlock() != null) {
                 var customItem = NamespacedKeyUtils.getCustomItem(data.getBlock());
-                return customItem != null && (customItem.getNamespacedKey().equals(CustomCrafting.INTERNAL_ADVANCED_CRAFTING_TABLE) || customItem.getNamespacedKey().equals(CustomCrafting.ADVANCED_WORKBENCH));
+                return customItem != null && (customItem.getNamespacedKey().equals(CustomCrafting.ADVANCED_CRAFTING_TABLE) || customItem.getNamespacedKey().equals(CustomCrafting.ADVANCED_WORKBENCH));
             }
             return false;
         }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/conditions/EliteWorkbenchCondition.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/conditions/EliteWorkbenchCondition.java
@@ -75,7 +75,7 @@ public class EliteWorkbenchCondition extends Condition<EliteWorkbenchCondition> 
             if (data.getBlock() != null) {
                 CustomItem customItem = NamespacedKeyUtils.getCustomItem(data.getBlock());
                 if (customItem != null && customItem.getApiReference() instanceof WolfyUtilitiesRef wolfyUtilsRef) {
-                    return eliteWorkbenches.contains(wolfyUtilsRef.getNamespacedKey()) && ((EliteWorkbenchData) customItem.getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE)).isEnabled();
+                    return eliteWorkbenches.contains(wolfyUtilsRef.getNamespacedKey()) && ((EliteWorkbenchData) customItem.getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA)).isEnabled();
                 }
             }
             return false;
@@ -123,7 +123,7 @@ public class EliteWorkbenchCondition extends Condition<EliteWorkbenchCondition> 
                                         menu.sendMessage(player, "error");
                                         return true;
                                     }
-                                    EliteWorkbenchData data = (EliteWorkbenchData) customItem.getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE);
+                                    EliteWorkbenchData data = (EliteWorkbenchData) customItem.getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA);
                                     if (data != null && !data.isEnabled()) {
                                         menu.sendMessage(player, "not_elite_workbench");
                                         return true;
@@ -136,7 +136,7 @@ public class EliteWorkbenchCondition extends Condition<EliteWorkbenchCondition> 
                             return true;
                         }, (guiHandler, player, args) -> {
                             Set<NamespacedKey> entries = api.getRegistries().getCustomItems().entrySet().stream().filter(entry -> {
-                                EliteWorkbenchData data = (EliteWorkbenchData) entry.getValue().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE);
+                                EliteWorkbenchData data = (EliteWorkbenchData) entry.getValue().getCustomData(CustomCrafting.ELITE_CRAFTING_TABLE_DATA);
                                 return data != null && data.isEnabled();
                             }).map(entry -> NamespacedKeyUtils.toInternal(entry.getKey())).collect(Collectors.toSet());
                             List<String> results = new ArrayList<>();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/Ingredient.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/Ingredient.java
@@ -22,6 +22,8 @@
 
 package me.wolfyscript.customcrafting.recipes.items;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -46,6 +48,11 @@ public class Ingredient extends RecipeItemStack {
         this.replaceWithRemains = ingredient.replaceWithRemains;
     }
 
+    @JsonCreator
+    public Ingredient(@JsonProperty("items") List<APIReference> items, @JsonProperty("tags") Set<NamespacedKey> tags) {
+        super(items, tags);
+    }
+
     public Ingredient(Material... materials) {
         super(materials);
     }
@@ -60,10 +67,6 @@ public class Ingredient extends RecipeItemStack {
 
     public Ingredient(APIReference... references) {
         super(references);
-    }
-
-    public Ingredient(List<APIReference> references, Set<NamespacedKey> tags) {
-        super(references, tags);
     }
 
     public boolean isReplaceWithRemains() {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/Result.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/Result.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.recipes.items;
 
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonInclude;
@@ -92,8 +93,9 @@ public class Result extends RecipeItemStack {
         this.extensions = new ArrayList<>();
     }
 
-    public Result(List<APIReference> references, Set<NamespacedKey> tags) {
-        super(references, tags);
+    @JsonCreator
+    public Result(@JsonProperty("items") List<APIReference> items, @JsonProperty("tags") Set<NamespacedKey> tags) {
+        super(items, tags);
         this.extensions = new ArrayList<>();
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/registry/CCRegistries.java
+++ b/src/main/java/me/wolfyscript/customcrafting/registry/CCRegistries.java
@@ -24,10 +24,12 @@ package me.wolfyscript.customcrafting.registry;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.gui.item_creator.tabs.ItemCreatorTab;
+import me.wolfyscript.customcrafting.recipes.RecipeType;
 import me.wolfyscript.customcrafting.recipes.items.extension.ResultExtension;
 import me.wolfyscript.customcrafting.recipes.items.target.MergeAdapter;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.registry.Registry;
+import me.wolfyscript.utilities.registry.RegistrySimple;
 import me.wolfyscript.utilities.registry.TypeRegistry;
 import me.wolfyscript.utilities.registry.TypeRegistrySimple;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -39,6 +41,7 @@ public class CCRegistries {
     private final TypeRegistryRecipeConditions recipeConditions;
     private final TypeRegistry<MergeAdapter> recipeMergeAdapters;
     private final TypeRegistry<ResultExtension> recipeResultExtensions;
+    private final Registry<RecipeType<?>> recipeTypes;
 
     public CCRegistries(CustomCrafting customCrafting, WolfyUtilCore core) {
         var registries = core.getRegistries();
@@ -47,6 +50,7 @@ public class CCRegistries {
         this.recipeConditions = new TypeRegistryRecipeConditions(customCrafting, registries);
         this.recipeMergeAdapters = new TypeRegistrySimple<>(new NamespacedKey(customCrafting, "recipe/merge_adapters"), registries);
         this.recipeResultExtensions = new TypeRegistrySimple<>(new NamespacedKey(customCrafting, "recipe/result_extensions"), registries);
+        this.recipeTypes = new RegistrySimple<>(new NamespacedKey(customCrafting, "recipe/types"), registries, (Class<RecipeType<?>>)(Object) RecipeType.class);
     }
 
     public TypeRegistryRecipeConditions getRecipeConditions() {
@@ -63,6 +67,10 @@ public class CCRegistries {
 
     public TypeRegistry<ResultExtension> getRecipeResultExtensions() {
         return recipeResultExtensions;
+    }
+
+    public Registry<RecipeType<?>> getRecipeTypes() {
+        return recipeTypes;
     }
 
     public RegistryRecipes getRecipes() {

--- a/src/main/java/me/wolfyscript/customcrafting/registry/CCRegistries.java
+++ b/src/main/java/me/wolfyscript/customcrafting/registry/CCRegistries.java
@@ -25,6 +25,7 @@ package me.wolfyscript.customcrafting.registry;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.gui.item_creator.tabs.ItemCreatorTab;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
+import me.wolfyscript.customcrafting.recipes.anvil.RepairTask;
 import me.wolfyscript.customcrafting.recipes.items.extension.ResultExtension;
 import me.wolfyscript.customcrafting.recipes.items.target.MergeAdapter;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
@@ -41,6 +42,7 @@ public class CCRegistries {
     private final TypeRegistryRecipeConditions recipeConditions;
     private final TypeRegistry<MergeAdapter> recipeMergeAdapters;
     private final TypeRegistry<ResultExtension> recipeResultExtensions;
+    private final TypeRegistry<RepairTask> anvilRecipeRepairTasks;
     private final Registry<RecipeType<?>> recipeTypes;
 
     public CCRegistries(CustomCrafting customCrafting, WolfyUtilCore core) {
@@ -51,6 +53,7 @@ public class CCRegistries {
         this.recipeMergeAdapters = new TypeRegistrySimple<>(new NamespacedKey(customCrafting, "recipe/merge_adapters"), registries);
         this.recipeResultExtensions = new TypeRegistrySimple<>(new NamespacedKey(customCrafting, "recipe/result_extensions"), registries);
         this.recipeTypes = new RegistrySimple<>(new NamespacedKey(customCrafting, "recipe/types"), registries, (Class<RecipeType<?>>)(Object) RecipeType.class);
+        this.anvilRecipeRepairTasks = new TypeRegistrySimple<>(new NamespacedKey(customCrafting, "recipe/anvil/repair_tasks"), registries);
     }
 
     public TypeRegistryRecipeConditions getRecipeConditions() {
@@ -67,6 +70,10 @@ public class CCRegistries {
 
     public TypeRegistry<ResultExtension> getRecipeResultExtensions() {
         return recipeResultExtensions;
+    }
+
+    public TypeRegistry<RepairTask> getAnvilRecipeRepairTasks() {
+        return anvilRecipeRepairTasks;
     }
 
     public Registry<RecipeType<?>> getRecipeTypes() {

--- a/src/main/java/me/wolfyscript/customcrafting/utils/ChatUtils.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/ChatUtils.java
@@ -95,13 +95,26 @@ public class ChatUtils {
      */
     public static NamespacedKey getNamespacedKey(Player player, String s, String[] args) {
         try {
+            String folder;
+            String fileName;
             if (args.length > 1) {
-                return new NamespacedKey(CustomCrafting.inst(), args[0] + "/" + args[1]);
+                folder = args[0];
+                fileName = args[1];
             } else if (s.contains(":")) {
                 NamespacedKey key = NamespacedKey.of(s);
-                return key != null ? new NamespacedKey(CustomCrafting.inst(), key.toString("/")) : null;
+                if (key == null) return null;
+                folder = key.getNamespace();
+                fileName = key.getKey();
+            } else {
+                return null;
             }
-            return null;
+            if (!folder.endsWith("/")) {
+                folder += "/";
+            }
+            if (fileName.startsWith("/")) {
+                fileName = fileName.substring(1);
+            }
+            return new NamespacedKey(CustomCrafting.inst(), folder + fileName);
         } catch (IllegalArgumentException e) {
             api.getLanguageAPI().replaceKey("msg.player.invalid_namespacedkey").forEach(s1 -> api.getChat().sendMessage(player, s1));
         }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/ChatUtils.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/ChatUtils.java
@@ -74,6 +74,7 @@ public class ChatUtils {
      * @param args   The input as separate arguments (split by spaces)
      * @return The {@link NamespacedKey} used internally in CustomCrafting in the format <b><i>namespace</i>:<i>key</i></b>
      */
+    @Deprecated
     public static NamespacedKey getInternalNamespacedKey(Player player, String s, String[] args) {
         try {
             if (args.length > 1) {
@@ -93,7 +94,18 @@ public class ChatUtils {
      * @return The {@link NamespacedKey} used in WolfyUtilities, to identify which plugin it's from, in the format <b>customcrafting:<i>namespace</i>/<i>key</i></b>
      */
     public static NamespacedKey getNamespacedKey(Player player, String s, String[] args) {
-        return NamespacedKeyUtils.fromInternal(getInternalNamespacedKey(player, s, args));
+        try {
+            if (args.length > 1) {
+                return new NamespacedKey(CustomCrafting.inst(), args[0] + "/" + args[1]);
+            } else if (s.contains(":")) {
+                NamespacedKey key = NamespacedKey.of(s);
+                return key != null ? new NamespacedKey(CustomCrafting.inst(), key.toString("/")) : null;
+            }
+            return null;
+        } catch (IllegalArgumentException e) {
+            api.getLanguageAPI().replaceKey("msg.player.invalid_namespacedkey").forEach(s1 -> api.getChat().sendMessage(player, s1));
+        }
+        return null;
     }
 
     public static void sendCategoryDescription(Player player) {

--- a/src/main/java/me/wolfyscript/customcrafting/utils/ItemLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/ItemLoader.java
@@ -136,10 +136,9 @@ public class ItemLoader {
 
     public static void saveItem(ResourceLoader loader, NamespacedKey namespacedKey, CustomItem customItem) {
         if (namespacedKey.getNamespace().equals(NamespacedKeyUtils.NAMESPACE)) {
-            var internalKey = NamespacedKeyUtils.toInternal(namespacedKey);
-            customItem.setNamespacedKey(internalKey);
+            customItem.setNamespacedKey(namespacedKey);
             loader.save(customItem);
-            WolfyUtilCore.getInstance().getRegistries().getCustomItems().register(NamespacedKeyUtils.fromInternal(internalKey), customItem);
+            WolfyUtilCore.getInstance().getRegistries().getCustomItems().register(customItem);
         }
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/utils/NamespacedKeyUtils.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/NamespacedKeyUtils.java
@@ -94,6 +94,7 @@ public class NamespacedKeyUtils {
      * In case the key has no folders then an empty String is returned.
      * <pre>
      *     "namespace:root_folder/sub_folder/object" -> "root_folder"
+     *     "namespace:root_folder/object" -> "root_folder"
      *     "namespace:object" -> ""
      * </pre>
      *
@@ -126,46 +127,23 @@ public class NamespacedKeyUtils {
     }
 
     /**
-     * Gets the path to the object of the NamespacedKeys' key.
-     * That means the part between the root folder and object separated by "/", if one is available, is returned.
+     * Gets the path to the object of the NamespacedKeys' key relative to the root (see {@link #getKeyRoot(NamespacedKey)}).<br>
+     * That means the part between the root folder and object.<br>
      * In case the key has no folders then it returns an empty String.
-     * <pre>
-     * "namespace:root_folder/sub_folder/object" -> "sub_folder/object"
-     * "namespace:root_folder/first/another/object" -> "first/another/object"
-     * "namespace:object" -> ""
-     * </pre>
+     * <p>
+     * <code>
+     *     "namespace:root_folder/sub_folder/object" -> "sub_folder/"<br>
+     *     "namespace:root_folder/first/another/object" -> "first/another/"<br>
+     *     "namespace:root_folder/object" -> ""<br>
+     *     "namespace:object" -> ""<br>
+     * </code>
+     * </p>
      *
      * @param namespacedKey The NamespacedKey
      * @return The path to the object, that is separated by "/"; Otherwise if no folder exists, an empty String.
-     * @see #getKeyObjPath(NamespacedKey, boolean)
      */
-    public static String getKeyObjPath(NamespacedKey namespacedKey) {
-        return getKeyObjPath(namespacedKey, true);
-    }
-
-    /**
-     * Gets the path to the object of the NamespacedKeys' key.
-     * That means the part between the root folder and object separated by "/", if one is available, is returned.
-     * In case the key has no folders then it returns an empty String.
-     * <pre>includeObj = true:
-     *  "namespace:root_folder/sub_folder/object" -> "sub_folder/object"
-     *  "namespace:root_folder/first/another/object" -> "first/another/object"
-     *  "namespace:object" -> ""
-     * </pre><pre>includeObj = false:
-     *  "namespace:root_folder/sub_folder/object" -> "sub_folder/"
-     *  "namespace:root_folder/first/another/object" -> "first/another/"
-     *  "namespace:object" -> ""
-     * </pre>
-     *
-     * @param namespacedKey The NamespacedKey
-     * @param includeObj If it should include the object itself in the path.
-     * @return The path to the object, that is separated by "/"; Otherwise if no folder exists, an empty String.
-     */
-    public static String getKeyObjPath(NamespacedKey namespacedKey, boolean includeObj) {
+    public static String getRelativeKeyObjPath(NamespacedKey namespacedKey) {
         String key = namespacedKey.getKey();
-        if (includeObj) {
-            return key.substring(key.indexOf("/") + 1);
-        }
         int firstIndex = key.indexOf("/") + 1;
         if (firstIndex > 0) {
             int lastIndex = key.lastIndexOf("/") + 1;

--- a/src/main/java/me/wolfyscript/customcrafting/utils/NamespacedKeyUtils.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/NamespacedKeyUtils.java
@@ -128,13 +128,13 @@ public class NamespacedKeyUtils {
 
     /**
      * Gets the path to the object of the NamespacedKeys' key relative to the root (see {@link #getKeyRoot(NamespacedKey)}).<br>
-     * That means the part between the root folder and object.<br>
+     * That means the part after the root folder.<br>
      * In case the key has no folders then it returns an empty String.
      * <p>
      * <code>
-     *     "namespace:root_folder/sub_folder/object" -> "sub_folder/"<br>
-     *     "namespace:root_folder/first/another/object" -> "first/another/"<br>
-     *     "namespace:root_folder/object" -> ""<br>
+     *     "namespace:root_folder/sub_folder/object" -> "sub_folder/object"<br>
+     *     "namespace:root_folder/first/another/object" -> "first/another/object"<br>
+     *     "namespace:root_folder/object" -> "object"<br>
      *     "namespace:object" -> ""<br>
      * </code>
      * </p>
@@ -146,11 +146,7 @@ public class NamespacedKeyUtils {
         String key = namespacedKey.getKey();
         int firstIndex = key.indexOf("/") + 1;
         if (firstIndex > 0) {
-            int lastIndex = key.lastIndexOf("/") + 1;
-            if (lastIndex == 0) {
-                lastIndex = key.length();
-            }
-            return key.substring(firstIndex, lastIndex);
+            return key.substring(firstIndex);
         }
         return "";
     }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/NamespacedKeyUtils.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/NamespacedKeyUtils.java
@@ -74,6 +74,10 @@ public class NamespacedKeyUtils {
         return namespacedKey;
     }
 
+    /**
+     * @deprecated Use {@link #getKeyRoot(NamespacedKey)} instead!
+     */
+    @Deprecated
     public static String getInternalNamespace(NamespacedKey namespacedKey) {
         if (namespacedKey.getNamespace().equals(NAMESPACE)) {
             String[] values = namespacedKey.getKey().split("/", 2);
@@ -82,6 +86,95 @@ public class NamespacedKeyUtils {
             }
         }
         return null;
+    }
+
+    /**
+     * Gets the root of the NamespacedKeys' key.
+     * That means the first folder separated by a "/", if one is available, is returned.
+     * In case the key has no folders then an empty String is returned.
+     * <pre>
+     *     "namespace:root_folder/sub_folder/object" -> "root_folder"
+     *     "namespace:object" -> ""
+     * </pre>
+     *
+     * @param namespacedKey The NamespacedKey
+     * @return The root folder, that is separated by "/", of the key; Otherwise if no folder exists, an empty String.
+     */
+    public static String getKeyRoot(NamespacedKey namespacedKey) {
+        return namespacedKey.getKey().contains("/") ? namespacedKey.getKey().split("/", 2)[0] : "";
+    }
+
+    /**
+     * Gets the object of the NamespacedKeys' key.
+     * That means the last part separated by a "/", if one is available, is returned.
+     * In case the key has no folders then it returns the key as is.
+     * <pre>
+     *     "namespace:root_folder/sub_folder/object" -> "object"
+     *     "namespace:object" -> "object"
+     * </pre>
+     *
+     * @param namespacedKey The NamespacedKey
+     * @return The root folder, that is separated by "/", of the key; Otherwise if no folder exists, the key as is.
+     */
+    public static String getKeyObj(NamespacedKey namespacedKey) {
+        String key = namespacedKey.getKey();
+        if (key.contains("/")) {
+            String[] parts = key.split("/");
+            return parts[parts.length - 1];
+        }
+        return key;
+    }
+
+    /**
+     * Gets the path to the object of the NamespacedKeys' key.
+     * That means the part between the root folder and object separated by "/", if one is available, is returned.
+     * In case the key has no folders then it returns an empty String.
+     * <pre>
+     * "namespace:root_folder/sub_folder/object" -> "sub_folder/object"
+     * "namespace:root_folder/first/another/object" -> "first/another/object"
+     * "namespace:object" -> ""
+     * </pre>
+     *
+     * @param namespacedKey The NamespacedKey
+     * @return The path to the object, that is separated by "/"; Otherwise if no folder exists, an empty String.
+     * @see #getKeyObjPath(NamespacedKey, boolean)
+     */
+    public static String getKeyObjPath(NamespacedKey namespacedKey) {
+        return getKeyObjPath(namespacedKey, true);
+    }
+
+    /**
+     * Gets the path to the object of the NamespacedKeys' key.
+     * That means the part between the root folder and object separated by "/", if one is available, is returned.
+     * In case the key has no folders then it returns an empty String.
+     * <pre>includeObj = true:
+     *  "namespace:root_folder/sub_folder/object" -> "sub_folder/object"
+     *  "namespace:root_folder/first/another/object" -> "first/another/object"
+     *  "namespace:object" -> ""
+     * </pre><pre>includeObj = false:
+     *  "namespace:root_folder/sub_folder/object" -> "sub_folder/"
+     *  "namespace:root_folder/first/another/object" -> "first/another/"
+     *  "namespace:object" -> ""
+     * </pre>
+     *
+     * @param namespacedKey The NamespacedKey
+     * @param includeObj If it should include the object itself in the path.
+     * @return The path to the object, that is separated by "/"; Otherwise if no folder exists, an empty String.
+     */
+    public static String getKeyObjPath(NamespacedKey namespacedKey, boolean includeObj) {
+        String key = namespacedKey.getKey();
+        if (includeObj) {
+            return key.substring(key.indexOf("/") + 1);
+        }
+        int firstIndex = key.indexOf("/") + 1;
+        if (firstIndex > 0) {
+            int lastIndex = key.lastIndexOf("/") + 1;
+            if (lastIndex == 0) {
+                lastIndex = key.length();
+            }
+            return key.substring(firstIndex, lastIndex);
+        }
+        return "";
     }
 
     public static boolean partiallyMatches(String token, NamespacedKey namespacedKey) {

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/SmeltAPIAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/SmeltAPIAdapter.java
@@ -64,7 +64,7 @@ public abstract class SmeltAPIAdapter {
 
     protected Pair<CookingRecipeData<?>, Boolean> processRecipe(ItemStack source, NamespacedKey recipeKey, Block block) {
         if (customCrafting.getRegistries().getRecipes().get(recipeKey) instanceof CustomRecipeCooking<?, ?> cookingRecipe && cookingRecipe.validType(block.getType())) {
-            Optional<CustomItem> customSource = cookingRecipe.getSource().check(source, cookingRecipe.isExactMeta());
+            Optional<CustomItem> customSource = cookingRecipe.getSource().check(source, cookingRecipe.isCheckNBT());
             if (customSource.isPresent()) {
                 if (cookingRecipe.checkConditions(new Conditions.Data(null, block, null))) {
                     var data = new IngredientData(0, cookingRecipe.getSource(), customSource.get(), source);

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -775,9 +775,9 @@
             "name": "&6Save As...",
             "lore": [
               "&7Save the item with a new namespaced key.",
-              "&7Input: &e<namespace> <key>",
-              "&cThe names must be lowercase alphanumeric",
-              "&cand must only contain [a-z 0-9 _ -]"
+              "&7Input: &e&lfolder item_key",
+              "&cThe folder and key must be lowercase and",
+              "&conly contain letters, numbers, '_', '-', or '/'!"
             ]
           },
           "apply_item": {
@@ -1770,9 +1770,9 @@
           "name": "&6Save As...",
           "lore": [
             "&7Save the recipe with a new namespaced key!",
-            "&7Input: &e<namespace> <key>",
-            "&cThe names must be lowercase alphanumeric",
-            "&cand must only contain [a-z 0-9 _ -]"
+            "&7Input: &e&lfolder recipe_key",
+            "&cThe folder and key must be lowercase and",
+            "&conly contain letters, numbers, '_', '-', or '/'!"
           ]
         },
         "priority": {
@@ -2098,7 +2098,7 @@
                 "lore": [
                   "&8[&aClick&8] &7Add Elite Workbenches"
                 ],
-                "message": "&eType in the namespaced key of the elite crafting table item! Usage: &6<namespace> <key>"
+                "message": "&eType in the namespaced key of the elite crafting table item! Usage: &e&lfolder item_key"
               },
               "list": {
                 "name": "&6&lValues",


### PR DESCRIPTION
The way recipes are saved was majorly overhauled.
Instead of saving recipes in type specific folders, all types of recipes are put in the same folder.
Thanks to the new system you can also specify your own sub-folders.

Previous structure:
Items: `data/<namespace>/items/<key>.json`
Recipes: `data/<namespace>/<type>/<key>.json`

New structure:
Items: `data/<folder>/items/<subfolders>/<key>.json`
Recipes: `data/<folder>/recipes/<subfolders>/<key>.json`

All the type information of a recipe is included in the JSON file now. This allows for easier de-/serialization and improved modularity. 

In preparation for upcoming features in WolfyUtilities and CustomCrafting, the new system makes sure that recipes created inside CustomCrafting are all using the `customcrafting` namespace.
There are no changes for you when it comes to saving recipes, with the exceptions that we will no longer talk about namespaces and keys.

User input:
You are no longer able to define the namespace of the recipe, instead you type in:
`<folder> <key>` 
or 
`<folder>/<subfolders> <key>`

You can see you are able to structure your recipes using subfolders.


Internal registration:
To make sure there are no conflicts with other plugins, the recipes are all saved under `customcrafting` namespace.
The folder and key are combined and set to key of the new NamespacedKey:  
`<folder> <key>` → `customcrafting:<folder>/<key>`  
`<folder>/<subfolders> <key>` → `customcrafting:<folder>/<subfolders>/<key>`  
`<folder> <subfolders>/<key>` → `customcrafting:<folder>/<subfolders>/<key>`  
The order in which the subfolders are specified don't matter, as they are resulting in the same key.


Custom Recipe Types
The new modular recipe system, allows for custom Recipe types to be registered.  
todo: more info
