### PR TITLE
Smithing Recipes - Copy Item Damage 

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCacheSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCacheSmithing.java
@@ -31,10 +31,14 @@ public class RecipeCacheSmithing extends RecipeCache<CustomRecipeSmithing> {
     private Ingredient addition;
 
     private boolean preserveEnchants;
+    private boolean preserveDamage;
     private boolean onlyChangeMaterial;
 
     RecipeCacheSmithing() {
         super();
+        this.preserveEnchants = true;
+        this.preserveDamage = true;
+        this.onlyChangeMaterial = false;
     }
 
     RecipeCacheSmithing(CustomRecipeSmithing recipe) {
@@ -42,6 +46,7 @@ public class RecipeCacheSmithing extends RecipeCache<CustomRecipeSmithing> {
         this.base = recipe.getBase().clone();
         this.addition = recipe.getAddition().clone();
         this.preserveEnchants = recipe.isPreserveEnchants();
+        this.preserveDamage = recipe.isPreserveDamage();
     }
 
     @Override
@@ -70,6 +75,7 @@ public class RecipeCacheSmithing extends RecipeCache<CustomRecipeSmithing> {
         recipeSmithing.setAddition(addition);
 
         recipeSmithing.setPreserveEnchants(preserveEnchants);
+        recipeSmithing.setPreserveDamage(preserveDamage);
         recipeSmithing.setOnlyChangeMaterial(onlyChangeMaterial);
         return recipeSmithing;
     }
@@ -96,6 +102,14 @@ public class RecipeCacheSmithing extends RecipeCache<CustomRecipeSmithing> {
 
     public void setPreserveEnchants(boolean preserveEnchants) {
         this.preserveEnchants = preserveEnchants;
+    }
+
+    public boolean isPreserveDamage() {
+        return preserveDamage;
+    }
+
+    public void setPreserveDamage(boolean preserveDamage) {
+        this.preserveDamage = preserveDamage;
     }
 
     public void setOnlyChangeMaterial(boolean onlyChangeMaterial) {

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorSmithing.java
@@ -33,6 +33,8 @@ import org.bukkit.Material;
 public class RecipeCreatorSmithing extends RecipeCreator {
 
     private static final String CHANGE_MATERIAL = "change_material";
+    private static final String PRESERVE_ENCHANTS = "preserve_enchants";
+    private static final String PRESERVE_DAMAGE = "preserve_damage";
 
     public RecipeCreatorSmithing(GuiCluster<CCCache> cluster, CustomCrafting customCrafting) {
         super(cluster, "smithing", 45, customCrafting);
@@ -45,11 +47,25 @@ public class RecipeCreatorSmithing extends RecipeCreator {
         registerButton(new ButtonRecipeIngredient(0));
         registerButton(new ButtonRecipeIngredient(1));
         registerButton(new ButtonRecipeResult());
-        registerButton(new ToggleButton<>(CHANGE_MATERIAL, (cache, guiHandler, player, guiInventory, i) -> cache.getRecipeCreatorCache().getSmithingCache().isOnlyChangeMaterial(), new ButtonState<>(CHANGE_MATERIAL + ".enabled", Material.LIME_CONCRETE, (customCache, guiHandler, player, guiInventory, i, inventoryInteractEvent) -> {
+        registerButton(new ToggleButton<>(CHANGE_MATERIAL, (cache, guiHandler, player, guiInv, i) -> cache.getRecipeCreatorCache().getSmithingCache().isOnlyChangeMaterial(), new ButtonState<>(CHANGE_MATERIAL + ".enabled", Material.PAPER, (customCache, guiHandler, player, guiInv, i, event) -> {
             customCache.getRecipeCreatorCache().getSmithingCache().setOnlyChangeMaterial(false);
             return true;
-        }), new ButtonState<>(CHANGE_MATERIAL + ".disabled", Material.RED_CONCRETE, (customCache, guiHandler, player, guiInventory, i, inventoryInteractEvent) -> {
+        }), new ButtonState<>(CHANGE_MATERIAL + ".disabled", Material.WRITABLE_BOOK, (customCache, guiHandler, player, guiInventory, i, inventoryInteractEvent) -> {
             customCache.getRecipeCreatorCache().getSmithingCache().setOnlyChangeMaterial(true);
+            return true;
+        })));
+        registerButton(new ToggleButton<>(PRESERVE_ENCHANTS, (cache, guiHandler, player, guiInv, i) -> cache.getRecipeCreatorCache().getSmithingCache().isPreserveEnchants(), new ButtonState<>(PRESERVE_ENCHANTS + ".enabled", Material.ENCHANTED_BOOK, (customCache, guiHandler, player, guiInv, i, event) -> {
+            customCache.getRecipeCreatorCache().getSmithingCache().setPreserveEnchants(false);
+            return true;
+        }), new ButtonState<>(PRESERVE_ENCHANTS + ".disabled", Material.BOOK, (customCache, guiHandler, player, guiInventory, i, inventoryInteractEvent) -> {
+            customCache.getRecipeCreatorCache().getSmithingCache().setPreserveEnchants(true);
+            return true;
+        })));
+        registerButton(new ToggleButton<>(PRESERVE_DAMAGE, (cache, guiHandler, player, guiInv, i) -> cache.getRecipeCreatorCache().getSmithingCache().isPreserveDamage(), new ButtonState<>(PRESERVE_DAMAGE + ".enabled", Material.LIME_CONCRETE, (customCache, guiHandler, player, guiInv, i, event) -> {
+            customCache.getRecipeCreatorCache().getSmithingCache().setPreserveDamage(false);
+            return true;
+        }), new ButtonState<>(PRESERVE_DAMAGE + ".disabled", Material.RED_CONCRETE, (customCache, guiHandler, player, guiInventory, i, inventoryInteractEvent) -> {
+            customCache.getRecipeCreatorCache().getSmithingCache().setPreserveDamage(true);
             return true;
         })));
     }
@@ -68,7 +84,9 @@ public class RecipeCreatorSmithing extends RecipeCreator {
         event.setButton(22, "recipe.ingredient_1");
         event.setButton(25, "recipe.result");
 
-        event.setButton(39, CHANGE_MATERIAL);
+        event.setButton(37, PRESERVE_ENCHANTS);
+        event.setButton(38, PRESERVE_DAMAGE);
+        event.setButton(40, CHANGE_MATERIAL);
 
         event.setButton(42, ClusterRecipeCreator.GROUP);
         if (smithingRecipe.isSaved()) {

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/SmithingListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/SmithingListener.java
@@ -102,7 +102,7 @@ public class SmithingListener implements Listener {
                                 endResult.addUnsafeEnchantments(base.getEnchantments());
                             }
                             if (recipe.isPreserveDamage() && endResult.getItemMeta() instanceof Damageable resultDamageable) {
-                                //Block Repairing
+                                //Copy damage from base item to result
                                 if (base.hasItemMeta() && base.getItemMeta() instanceof Damageable damageable) {
                                     resultDamageable.setDamage(damageable.getDamage());
                                 }

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/SmithingListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/SmithingListener.java
@@ -45,6 +45,7 @@ import org.bukkit.event.inventory.PrepareSmithingEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.SmithingInventory;
 import org.bukkit.inventory.SmithingRecipe;
+import org.bukkit.inventory.meta.Damageable;
 
 import java.util.*;
 import java.util.stream.Stream;
@@ -97,6 +98,13 @@ public class SmithingListener implements Listener {
                             //Manual result processing & transferring data.
                             if(recipe.isPreserveEnchants()) {
                                 endResult.addUnsafeEnchantments(base.getEnchantments());
+                            }
+                            if (recipe.isPreserveDamage() && endResult.getItemMeta() instanceof Damageable resultDamageable) {
+                                //Block Repairing
+                                if (base.hasItemMeta() && base.getItemMeta() instanceof Damageable damageable) {
+                                    resultDamageable.setDamage(damageable.getDamage());
+                                }
+                                endResult.setItemMeta(resultDamageable);
                             }
                             event.setResult(endResult);
                         }

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/SmithingListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/SmithingListener.java
@@ -34,6 +34,8 @@ import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.InventoryUtils;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -145,6 +147,9 @@ public class SmithingListener implements Listener {
             smithingData.getResult().executeExtensions(inventory.getLocation() != null ? inventory.getLocation() : player.getLocation(), inventory.getLocation() != null, player);
             smithingData.getBase().remove(baseItem, 1, inventory);
             smithingData.getAddition().remove(additionItem, 1, inventory);
+            if (inventory.getLocation() != null) {
+                inventory.getLocation().getWorld().playSound(inventory.getLocation(), Sound.BLOCK_SMITHING_TABLE_USE, SoundCategory.BLOCKS, 1, 1);
+            }
             inventory.setItem(0, baseItem);
             inventory.setItem(1, additionItem);
             preCraftedRecipes.remove(player.getUniqueId());

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
@@ -53,6 +53,7 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
     private Ingredient addition;
 
     private boolean preserveEnchants;
+    private boolean preserveDamage;
     private boolean onlyChangeMaterial; //Only changes the material of the item. Useful to make vanilla style recipes.
 
     public CustomRecipeSmithing(NamespacedKey namespacedKey, JsonNode node) {
@@ -61,6 +62,7 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
         base = ItemLoader.loadIngredient(node.path(KEY_BASE));
         addition = ItemLoader.loadIngredient(node.path(KEY_ADDITION));
         preserveEnchants = node.path("preserve_enchants").asBoolean(true);
+        preserveDamage = node.path("preserveDamage").asBoolean(true);
         onlyChangeMaterial = node.path("onlyChangeMaterial").asBoolean(false);
     }
 
@@ -71,6 +73,7 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
         this.addition = new Ingredient();
         this.result = new Result();
         this.preserveEnchants = true;
+        this.preserveDamage = true;
         this.onlyChangeMaterial = false;
     }
 
@@ -80,6 +83,7 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
         this.base = customRecipeSmithing.getBase();
         this.addition = customRecipeSmithing.getAddition();
         this.preserveEnchants = customRecipeSmithing.isPreserveEnchants();
+        this.preserveDamage = customRecipeSmithing.isPreserveDamage();
         this.onlyChangeMaterial = customRecipeSmithing.isOnlyChangeMaterial();
     }
 
@@ -112,6 +116,14 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
 
     public void setPreserveEnchants(boolean preserveEnchants) {
         this.preserveEnchants = preserveEnchants;
+    }
+
+    public boolean isPreserveDamage() {
+        return preserveDamage;
+    }
+
+    public void setPreserveDamage(boolean preserveDamage) {
+        this.preserveDamage = preserveDamage;
     }
 
     public boolean isOnlyChangeMaterial() {
@@ -147,6 +159,7 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> {
     public void writeToJson(JsonGenerator gen, SerializerProvider serializerProvider) throws IOException {
         super.writeToJson(gen, serializerProvider);
         gen.writeBooleanField("preserve_enchants", preserveEnchants);
+        gen.writeBooleanField("preserveDamage", preserveDamage);
         gen.writeBooleanField("onlyChangeMaterial", onlyChangeMaterial);
         gen.writeObjectField(KEY_RESULT, result);
         gen.writeObjectField(KEY_BASE, base);

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -2766,6 +2766,48 @@
                 "&8[&aClick&8] &eMaterial Only"
               ]
             }
+          },
+          "preserve_enchants": {
+            "enabled": {
+              "name": "&6&lPreserve Enchants",
+              "lore": [
+                "&eCopies the enchantments from",
+                "&ethe base to the result item.",
+                "",
+                "&8[&aClick&8] &eDiscard Enchants"
+              ]
+            },
+            "disabled": {
+              "name": "&4&lDiscard Enchants",
+              "lore": [
+                "&eLeaves the enchants of the",
+                "&eresult as is and discards",
+                "&ethe base ingredient enchants.",
+                "",
+                "&8[&aClick&8] &ePreserve Enchants"
+              ]
+            }
+          },
+          "preserve_damage": {
+            "enabled": {
+              "name": "&6&lPreserve Damage",
+              "lore": [
+                "&eCopies the damage from",
+                "&ethe base to the result item.",
+                "",
+                "&8[&aClick&8] &eDiscard Damage"
+              ]
+            },
+            "disabled": {
+              "name": "&4&lDiscard Damage",
+              "lore": [
+                "&eLeaves the damage of the",
+                "&eresult as is and discards",
+                "&ethe base ingredient damage.",
+                "",
+                "&8[&aClick&8] &ePreserve Damage"
+              ]
+            }
           }
         }
       },


### PR DESCRIPTION
Added preserveDamage setting so the damage is copied to the result.
This fixes an inconsistency with vanilla behaviour, which always copies the damage.

Added sound to custom smithing recipes.