### PR TITLE
Furnace Recipe Experience & CustomItem blocking

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/listeners/FurnaceListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/FurnaceListener.java
@@ -154,14 +154,14 @@ public class FurnaceListener implements Listener {
         Bukkit.getScheduler().runTask(customCrafting, () -> {
             Furnace blockState = (Furnace) location.getBlock().getState();
             PersistentDataContainer rootContainer = blockState.getPersistentDataContainer();
-            me.wolfyscript.utilities.util.NamespacedKey activeRecipeKey = NamespacedKeyUtils.toInternal(me.wolfyscript.utilities.util.NamespacedKey.of(rootContainer.getOrDefault(FurnaceListener.ACTIVE_RECIPE_KEY, PersistentDataType.STRING, "")));
+            me.wolfyscript.utilities.util.NamespacedKey activeRecipeKey = me.wolfyscript.utilities.util.NamespacedKey.of(rootContainer.getOrDefault(FurnaceListener.ACTIVE_RECIPE_KEY, PersistentDataType.STRING, ""));
             if (activeRecipeKey != null) {
                 CustomRecipe<?> recipeFurnace = customCrafting.getRegistries().getRecipes().get(activeRecipeKey);
                 if (recipeFurnace instanceof CustomRecipeCooking<?, ?> furnaceRecipe) {
                     if (furnaceRecipe.getExp() > 0) {
                         PersistentDataContainer usedRecipes = rootContainer.get(FurnaceListener.RECIPES_USED_KEY, PersistentDataType.TAG_CONTAINER);
                         if (usedRecipes != null) {
-                            NamespacedKey bukkitRecipeKey = activeRecipeKey.toBukkit(customCrafting);
+                            NamespacedKey bukkitRecipeKey = org.bukkit.NamespacedKey.fromString(activeRecipeKey.toString());
                             float recipeXP = furnaceRecipe.getExp();
                             int amount = usedRecipes.getOrDefault(bukkitRecipeKey, PersistentDataType.INTEGER, 0);
 

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/FurnaceListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/FurnaceListener.java
@@ -115,8 +115,14 @@ public class FurnaceListener implements Listener {
             manager.getAdapter().applyResult(event);
             return;
         }
+        //Similar to the check in the FurnaceStartSmeltEvent.
+        //This is needed in 1.16 as the FurnaceStartSmeltEvent doesn't exist.
+        //Check if the CustomItem is allowed in Vanilla recipes
+        if (CustomItem.getByItemStack(event.getSource()) != null) {
+            event.setCancelled(true); //Cancel the process if it is.
+        }
         Bukkit.getScheduler().runTask(customCrafting, () -> {
-            //Reset the active recipe
+            //make sure to reset the active custom recipe when the new recipe is a vanilla recipe.
             var state = ((Furnace) event.getBlock().getState());
             PersistentDataContainer container = state.getPersistentDataContainer();
             container.remove(FurnaceListener.ACTIVE_RECIPE_KEY);

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
@@ -49,7 +49,7 @@ public class CustomRecipeBlasting extends CustomRecipeCooking<CustomRecipeBlasti
     @Override
     public BlastingRecipe getVanillaRecipe() {
         if (!getSource().isEmpty()) {
-            var recipe = new BlastingRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getChoices().get(0).create(), getRecipeChoice(), getExp(), getCookingTime());
+            var recipe = new BlastingRecipe(org.bukkit.NamespacedKey.fromString(getNamespacedKey().toString()), getResult().getChoices().get(0).create(), getRecipeChoice(), getExp(), getCookingTime());
             recipe.setGroup(group);
             return recipe;
         }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCampfire.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCampfire.java
@@ -49,7 +49,7 @@ public class CustomRecipeCampfire extends CustomRecipeCooking<CustomRecipeCampfi
     @Override
     public CampfireRecipe getVanillaRecipe() {
         if (!getSource().isEmpty()) {
-            var recipe = new CampfireRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            var recipe = new CampfireRecipe(org.bukkit.NamespacedKey.fromString(getNamespacedKey().toString()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
             recipe.setGroup(group);
             return recipe;
         }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
@@ -49,7 +49,7 @@ public class CustomRecipeFurnace extends CustomRecipeCooking<CustomRecipeFurnace
     @Override
     public FurnaceRecipe getVanillaRecipe() {
         if (!getSource().isEmpty()) {
-            var recipe = new FurnaceRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            var recipe = new FurnaceRecipe(org.bukkit.NamespacedKey.fromString(getNamespacedKey().toString()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
             recipe.setGroup(group);
             return recipe;
         }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
@@ -59,7 +59,7 @@ public class CustomRecipeSmoking extends CustomRecipeCooking<CustomRecipeSmoking
     @Override
     public SmokingRecipe getVanillaRecipe() {
         if (!getSource().isEmpty()) {
-            var recipe = new SmokingRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            var recipe = new SmokingRecipe(org.bukkit.NamespacedKey.fromString(getNamespacedKey().toString()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
             recipe.setGroup(group);
             return recipe;
         }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
@@ -147,7 +147,7 @@ public class CustomRecipeStonecutter extends CustomRecipe<CustomRecipeStonecutte
     public StonecuttingRecipe getVanillaRecipe() {
         if (!getResult().isEmpty() && !getSource().isEmpty()) {
             RecipeChoice choice = isCheckNBT() ? new RecipeChoice.ExactChoice(getSource().getBukkitChoices()) : new RecipeChoice.MaterialChoice(getSource().getBukkitChoices().stream().map(ItemStack::getType).toList());
-            var recipe = new StonecuttingRecipe(getNamespacedKey().toBukkit(CustomCrafting.inst()), getResult().getChoices().get(0).create(), choice);
+            var recipe = new StonecuttingRecipe(org.bukkit.NamespacedKey.fromString(getNamespacedKey().toString()), getResult().getChoices().get(0).create(), choice);
             recipe.setGroup(group);
             return recipe;
         }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/BukkitSmeltAPIAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/BukkitSmeltAPIAdapter.java
@@ -53,7 +53,7 @@ public class BukkitSmeltAPIAdapter extends SmeltAPIAdapter {
         while (recipeIterator.hasNext()) {
             if (recipeIterator.next() instanceof CookingRecipe<?> recipe && recipe.getKey().getNamespace().equals(NamespacedKeyUtils.NAMESPACE) && recipe.getResult().isSimilar(event.getResult())) {
                 customRecipe = true;
-                Pair<CookingRecipeData<?>, Boolean> data = processRecipe(event.getSource(), NamespacedKeyUtils.toInternal(NamespacedKey.fromBukkit(recipe.getKey())), block);
+                Pair<CookingRecipeData<?>, Boolean> data = processRecipe(event.getSource(), NamespacedKey.fromBukkit(recipe.getKey()), block);
                 if (data.getKey() != null) {
                     return data;
                 }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/FurnaceListener1_17Adapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/FurnaceListener1_17Adapter.java
@@ -48,7 +48,7 @@ public class FurnaceListener1_17Adapter implements Listener {
     public void onStartSmelt(FurnaceStartSmeltEvent event) {
         var recipe = event.getRecipe();
         if (recipe.getKey().getNamespace().equals(NamespacedKeyUtils.NAMESPACE)) {
-            var data = manager.getAdapter().processRecipe(event.getSource(), NamespacedKeyUtils.toInternal(NamespacedKey.fromBukkit(recipe.getKey())), event.getBlock());
+            var data = manager.getAdapter().processRecipe(event.getSource(), NamespacedKey.fromBukkit(recipe.getKey()), event.getBlock());
             if(data.getKey() == null) { //"Cancel" the process when no custom recipe is valid.
                 event.setTotalCookTime(0);
             }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/FurnaceListener1_17Adapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/FurnaceListener1_17Adapter.java
@@ -24,12 +24,16 @@ package me.wolfyscript.customcrafting.utils.cooking;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.Pair;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.FurnaceStartSmeltEvent;
 
+/**
+ * Uses the new {@link FurnaceStartSmeltEvent} to more efficiently handle custom cooking recipes.
+ */
 public class FurnaceListener1_17Adapter implements Listener {
 
     private final CustomCrafting customCrafting;
@@ -45,12 +49,18 @@ public class FurnaceListener1_17Adapter implements Listener {
         var recipe = event.getRecipe();
         if (recipe.getKey().getNamespace().equals(NamespacedKeyUtils.NAMESPACE)) {
             var data = manager.getAdapter().processRecipe(event.getSource(), NamespacedKeyUtils.toInternal(NamespacedKey.fromBukkit(recipe.getKey())), event.getBlock());
-            if(data.getKey() == null) {
+            if(data.getKey() == null) { //"Cancel" the process when no custom recipe is valid.
                 event.setTotalCookTime(0);
             }
+            //Update the cache to the new Custom Recipe.
             manager.cacheRecipeData(event.getBlock(), data);
         } else {
+            //Update the cache with the vanilla recipe
             manager.cacheRecipeData(event.getBlock(), new Pair<>(null, false));
+            //Check if the CustomItem is allowed in Vanilla recipes
+            if (CustomItem.getByItemStack(event.getSource()) != null) {
+                event.setTotalCookTime(0); //"Cancel" the process if it is.
+            }
         }
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/PaperSmeltAPIAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/PaperSmeltAPIAdapter.java
@@ -41,7 +41,7 @@ public class PaperSmeltAPIAdapter extends SmeltAPIAdapter {
     public Pair<CookingRecipeData<?>, Boolean> process(FurnaceSmeltEvent event, Block block, Furnace furnace) {
         var recipe = event.getRecipe();
         if (recipe != null && recipe.getKey().getNamespace().equals(NamespacedKeyUtils.NAMESPACE)) {
-            return processRecipe(event.getSource(), NamespacedKeyUtils.toInternal(NamespacedKey.fromBukkit(recipe.getKey())), block);
+            return processRecipe(event.getSource(), NamespacedKey.fromBukkit(recipe.getKey()), block);
         }
         return new Pair<>(null, false);
     }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/SmeltAPIAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/SmeltAPIAdapter.java
@@ -123,7 +123,7 @@ public abstract class SmeltAPIAdapter {
                 container.set(FurnaceListener.ACTIVE_RECIPE_KEY, PersistentDataType.STRING, recipe.getNamespacedKey().toString());
                 //Increase recipe used counter
                 var usedRecipesContainer = container.getOrDefault(FurnaceListener.RECIPES_USED_KEY, PersistentDataType.TAG_CONTAINER, container.getAdapterContext().newPersistentDataContainer());
-                var bukkitKey = NamespacedKeyUtils.toInternal(recipe.getNamespacedKey()).toBukkit(customCrafting);
+                var bukkitKey = org.bukkit.NamespacedKey.fromString(recipe.getNamespacedKey().toString());
                 int amount = usedRecipesContainer.getOrDefault(bukkitKey, PersistentDataType.INTEGER, 0);
                 usedRecipesContainer.set(bukkitKey, PersistentDataType.INTEGER, ++amount);
                 //Update data

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -238,49 +238,32 @@
           "name": "&4"
         },
         "back": {
-          "name": "&5Back",
-          "help": []
+          "name": "&5Back"
         },
         "back_bottom": {
-          "name": "&c&lBack",
-          "lore": []
+          "name": "&c&lBack"
         },
         "close": {
-          "name": "&4Close",
-          "help": []
+          "name": "&4Close"
         },
         "gui_help_on": {
-          "name": "&3&lHelp",
+          "name": "&f&l&n[?] Information",
           "lore": [
-            "%wolfyutilities.help%",
-            "",
-            "&7[&aEnabled&7] &eClick to disable Button descriptions."
-          ],
-          "help": []
+            "%wolfyutilities.help%"
+          ]
         },
         "gui_help_off": {
-          "name": "&3&lHelp",
+          "name": "&f&l&n[?] Information",
           "lore": [
-            "%wolfyutilities.help%",
-            "",
-            "&7[&cDisabled&7] &eClick to view Button descriptions."
-          ],
-          "help": []
+            "%wolfyutilities.help%"
+          ]
         },
         "patreon": {
           "name": "&6&ktt   &r&6&lPatreon   &6&ktt",
           "lore": [
-            "&eBecome a Patron and get early acces to ",
-            "&ereleases and development builds.",
-            "&eTake part in Patreon only polls and",
-            "&ehelp shape and improve the plugin",
+            "&eBecome a Patron and get access to ",
+            "&elatest updates.",
             "&7[&aClick&7] View current Patrons Credits"
-          ]
-        },
-        "instagram": {
-          "name": "&5&lInstagram",
-          "lore": [
-            "&eCheck out my Instgram"
           ]
         },
         "youtube": {
@@ -1775,7 +1758,7 @@
           ]
         },
         "save_as": {
-          "name": "&6Save As...",
+          "name": "&7\u270E &6&lSave As...",
           "lore": [
             "&7Save the recipe with a new namespaced key!",
             "&7Input: &e&lfolder recipe_key",
@@ -1784,7 +1767,7 @@
           ]
         },
         "priority": {
-          "name": "&3Priority:&7 %PRI%",
+          "name": "&7&l\u274F &6&lPriority:&a %PRI%",
           "lore": [
             "&7Sets the priority of this recipe!",
             "&7Priorities: ",
@@ -1796,10 +1779,11 @@
           ]
         },
         "conditions": {
-          "name": "&3Conditions",
+          "name": "&7\u27A5 &6&lConditions",
           "lore": [
             "&eSet conditions to further customize your recipe.",
             "&eSuch as World Time, Weather, etc.",
+            "",
             "&7[&aClick&7] Configure conditons"
           ]
         },
@@ -1847,21 +1831,26 @@
         },
         "exact_meta": {
           "enabled": {
-            "name": "&aExact Meta",
+            "name": "&a\u2714 &6&lCheck NBT",
             "help": [],
             "lore": [
-              "&7Items need to be exactly the same!",
-              "&7That means if you put in a IronSword with no damage ",
-              "&7then IronSwords with damage won't be allowed!"
+              "&eItems need to be exactly the same!",
+              "&eI.e. the NBT of the ingredient &lmust",
+              "&ematch the NBT of item put into slot!",
+              "",
+              "&7[&aClick&7] &7Ignore NBT"
             ]
           },
           "disabled": {
-            "name": "&3Ignore Meta",
+            "name": "&a\u2714 &6&lIgnore NBT",
             "help": [],
             "lore": [
-              "&7Items without Meta will only",
-              "&7be checked for their type!",
-              "&7Items with Meta still need to be exact!"
+              "&eItems without NBT will only",
+              "&ebe checked for their type!",
+              "&cWarning: Ingredients that have NBT",
+              "&care still checked for their NBT!",
+              "",
+              "&7[&aClick&7] &7Check NBT"
             ]
           }
         },
@@ -1930,7 +1919,7 @@
           }
         },
         "tags": {
-          "name": "&6&lTags",
+          "name": "&7\u27A5 &6&lTags",
           "lore": [
             "&7Allows you to configure Tags.",
             "&7Tags are a collection of Items,",
@@ -1938,11 +1927,12 @@
           ]
         },
         "group": {
-          "name": "&6&lRecipe Group",
+          "name": "&7\u270E &6&lRecipe Group",
           "lore": [
             "&7Group: &e%group%",
-            "&7Recipes with the same group are",
-            "&7grouped together in the recipe book.",
+            "&eRecipes with the same group are",
+            "&egrouped together in the recipe book.",
+            "",
             "&7[&aLeft-Click&7] &eInput Group",
             "&7[&aRight-Click&7] &eReset Group"
           ],
@@ -2308,80 +2298,115 @@
       "anvil": {
         "gui_name": "&4&lRecipe Creator &7[&8Anvil&7]",
         "gui_help": [
-          "&7Tip:",
-          "&eShift &7+ &eRight click &7on Result or Ingredients will ",
-          "&7allow you to edit the item/s"
+          "&6&lResult/Ingredient slot&7:",
+          "  &aShift&7+&aRight-Click &7\u27A0",
+          "    &eopens the Result/Ingredient editor!",
+          ""
         ],
         "items": {
           "mode": {
-            "name": "&7Mode:&6 %MODE%",
-            "help": [
-              ""
+            "name": "&7\u274F &6&lMode:&a %MODE%",
+            "lore": [
+              "&eThe mode of the result.",
+              "&7&l–––––––––––––––––",
+              "&aResult &7- Applies the specified result item.",
+              "&aNone &7- Acts the same as vanilla recipes.",
+              "          &7(Block features see bottom left)",
+              "&aDurability &7- Same as None, plus you can modify",
+              "                &7the amount of damage to repair."
             ]
           },
           "repair_cost": {
-            "name": "&7Repair Cost:&6 %VAR%",
+            "name": "&7\u270E &6&lRepair Cost:&e %VAR%",
             "lore": [
               "&eThe Repair Cost for this recipe.",
-              "&eMust be greater than 0, else the recipe won't work!",
-              "&7[&aClick&7] Input Repair Cost"
+              "&cMust be greater than 0!",
+              "",
+              "&7[&aClick&7] Change Repair Cost"
             ],
-            "message": "&3Type in the amount of repair_cost. &cMust be greater than 0!"
+            "message": "&eType in the amount of the repair cost (in levels). &cMust be greater than 0!"
           },
           "block_repair": {
             "true": {
-              "name": "&aRepairing blocked"
+              "name": "&c\u274C &6&lRepairing blocked",
+              "lore": [
+                "&eThe left ingredient cannot be repaired."
+              ]
             },
             "false": {
-              "name": "&cRepairing allowed"
+              "name": "&a\u2714 &6&lRepairing allowed",
+              "lore": [
+                "&eThe left ingredient can be repaired.",
+                "&e(If possible in vanilla!)"
+              ]
             }
           },
           "block_rename": {
             "true": {
-              "name": "&aRenaming blocked"
+              "name": "&c\u274C &6&lRenaming blocked",
+              "lore": [
+                "&eThe left ingredient cannot be renamed."
+              ]
             },
             "false": {
-              "name": "&cRenaming allowed"
+              "name": "&a\u2714 &6&lRenaming allowed",
+              "lore": [
+                "&eThe left ingredient can be renamed.",
+                "&e(If possible in vanilla!)"
+              ]
             }
           },
           "block_enchant": {
             "true": {
-              "name": "&aEnchanting blocked"
+              "name": "&c\u274C &6&lEnchanting blocked",
+              "lore": [
+                "&eThe left ingredient cannot be enchanted."
+              ]
             },
             "false": {
-              "name": "&cEnchanting allowed"
+              "name": "&a\u2714 &6&lEnchanting allowed",
+              "lore": [
+                "&eThe left ingredient can be enchanted.",
+                "&e(If possible in vanilla!)"
+              ]
             }
           },
           "durability": {
-            "name": "&7Durability:&6 %VAR%",
+            "name": "&7\u270E &6&lDamage Repair:&a %VAR%",
             "lore": [
-              ""
+              "&eThe amount of damage to repair."
             ],
             "message": "&3Type in the amount of durability. &6>0 increase&7, <0 decrease"
           },
           "repair_apply": {
             "true": {
-              "name": "&aApply to Result",
+              "name": "&a\u2714 &6&lApply Repair Cost",
               "lore": [
-                "&7Applies the repair cost",
-                "&7to the result's MetaData!"
+                "&eApplies the repair cost",
+                "&eto the result item!",
+                "",
+                "&7[&aClick&7] Do not apply repair cost"
               ]
             },
             "false": {
-              "name": "&cNot Applied!",
+              "name": "&c\u274C &6&lDon't Apply Repair Cost",
               "lore": [
-                "&7The result's MetaData stays the same!"
+                "&eDoesn't apply the repair cost.",
+                "",
+                "&7[&aClick&7] Apply repair cost"
               ]
             }
           },
           "repair_mode": {
-            "name": "&7RepairCost mode: &3%VAR%",
+            "name": "&7\u274F &6&lRepair Cost Mode: &a%VAR%",
             "lore": [
-              "&eThe mode how the repaircost should be ",
-              "&eaffected by the left input!",
-              "&3NONE &7- Not affected at all",
-              "&3ADD &7- Gets added to recipe repaircost!",
-              "&3MULTIPLY &7- Gets multiplied with recipe repaircost",
+              "&eThis mode specifies how the repair cost",
+              "&eshould be affected by the left ingredient!",
+              "&7&l–––––––––––––––––",
+              "&aNONE &7- Not affected at all",
+              "&aADD &7- Gets added to recipe repaircost!",
+              "&aMULTIPLY &7- Gets multiplied with recipe repaircost",
+              "",
               "&7[&aClick&7] Toggle Mode"
             ]
           }

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -1,9 +1,9 @@
 {
   "author": "WolfyScript",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "info": [
-    "YouTube:",
-    "   https://www.youtube.com/channel/UCTlqRLm4PxZuAI4nVN4X74g"
+    "YouTube: https://www.youtube.com/channel/UCTlqRLm4PxZuAI4nVN4X74g",
+    "GitHub:  https://github.com/WolfyScript"
   ],
   "crafting": {
     "workbench": {
@@ -238,13 +238,13 @@
           "name": "&4"
         },
         "back": {
-          "name": "&5Back"
+          "name": "&7\u27A6 &6&lBack"
         },
         "back_bottom": {
-          "name": "&c&lBack"
+          "name": "&7\u27A6 &c&lBack"
         },
         "close": {
-          "name": "&4Close"
+          "name": "&4&lClose"
         },
         "gui_help_on": {
           "name": "&f&l&n[?] Information",
@@ -275,29 +275,29 @@
         "github": {
           "name": "&7&lGitHub",
           "lore": [
-            "&eNeed a Wiki, tutorials, or would like to contribute?",
-            "&eHave a look at my GitHub repositories."
+            "&eNeed a Wiki, tutorials, or wanna contribute?",
+            "&eHave a look at the GitHub repository."
           ]
         },
         "discord": {
           "name": "&9&lDiscord",
           "lore": [
-            "&eNeed support? Found a bug? Have an suggestion or idea?",
-            "&eJoin the discord and join the awesome community!"
+            "&eNeed support? Found a bug?",
+            "&eFeel free to join the Discord server!"
           ]
         },
         "recipe_list": {
-          "name": "&6Recipe List",
+          "name": "&7\u27A5 &6&lRecipe List",
           "lore": [
-            "&7List of all recipes ",
-            "&8(&7including minecraft recipes&8)",
-            "&7Toggle any Recipe on/off"
+            "&eList of custom & vanilla recipes ",
+            "&eDisable&7/&eEnable any recipe."
           ]
         },
         "item_list": {
-          "name": "&6Item List",
+          "name": "&7\u27A5 &6&lItem List",
           "lore": [
-            "&eGet or edit custom items just by one click.",
+            "&eLists all your Custom Items.",
+            "&eEasily Get, Edit, or Delete them.",
             "",
             "&7[&aClick&7]&e Open Item List"
           ]
@@ -306,21 +306,25 @@
       "main_menu": {
         "gui_name": "&3&lCustomCrafting &7[&8%plugin.version%&7]",
         "gui_help": [
-          "&7Options:",
-          "&7- Click on the type of the Recipe you want to create.",
-          "&7- ItemCreator bottom left or RecipeList bottom right.",
-          "&7- Go to the Settings in the top left."
+          "&6&lOptions:",
+          "&7- &eClick the Recipe type for that you ",
+          "   &ewould like to create a new recipe.",
+          "&7- &eCreate Custom Items via the ItemCreator",
+          "   &e(Bottom left)",
+          "&7- &eView your recipes in the RecipeList",
+          "   &e(Bottom right)",
+          "&7- &eSettings in the top left."
         ],
         "items": {
           "settings": {
-            "name": "&7&lSettings",
+            "name": "&7\u27A5 &6&lSettings",
             "lore": [
               "&eConfigure the main settings ",
               "&ewithout stopping the server!"
             ]
           },
           "recipe_book_editor": {
-            "name": "&6Recipe Book &8[&7Beta&8]",
+            "name": "&7\u27A5 &6&lRecipe Book &8[&7Beta&8]",
             "lore": [
               "&eConfigure the Recipe Book.",
               "&eCreate Categories and set up which",
@@ -403,12 +407,12 @@
             ]
           },
           "item_editor": {
-            "name": "&6Item Creator",
+            "name": "&7\u27A5 &6&lItem Creator",
             "lore": [
-              "&7Create&8/&7Edit custom Items",
-              "&7with special features e.g.",
-              "&7Custom Durability&8, Furnace Fuel&8, ",
-              "&7Custom Equipment and more."
+              "&eCreate&7/&eEdit Custom Items.",
+              "&ewith special features e.g.",
+              "&eCustom Durability&7,&e Furnace Fuel&7, ",
+              "&eCustom Equipment and more."
             ]
           }
         }
@@ -433,9 +437,8 @@
       "recipe_list": {
         "gui_name": "&8&lRecipe List",
         "gui_help": [
-          "&7Toggle recipes.",
-          "&7if a recipe is disabled it won't be craftable to anyone!",
-          "&7Not even for players with permissions"
+          "&eToggle custom & vanilla recipes.",
+          "&eIf a recipe is disabled it can't be crafted by anyone!"
         ],
         "items": {
           "lores": {
@@ -1752,9 +1755,10 @@
     "recipe_creator": {
       "global_items": {
         "save": {
-          "name": "&3Save",
+          "name": "&7\u25B7 &6&lSave",
           "lore": [
-            "&7Saves the recipe with the existing namespaced key!"
+            "&eSaves the recipe under the",
+            "&eexisting namespaced key."
           ]
         },
         "save_as": {
@@ -1781,10 +1785,11 @@
         "conditions": {
           "name": "&7\u27A5 &6&lConditions",
           "lore": [
-            "&eSet conditions to further customize your recipe.",
-            "&eSuch as World Time, Weather, etc.",
+            "&eAdd conditions to your recipe.",
+            "&eto further customize it. e.g.: ",
+            "&eWorld, Time, Weather, Biomes, etc.",
             "",
-            "&7[&aClick&7] Configure conditons"
+            "&7[&aClick&7] Configure conditions"
           ]
         },
         "hidden": {
@@ -1800,8 +1805,7 @@
           "disabled": {
             "name": "&a✔ &6&lShow Recipe",
             "lore": [
-              "&eRecipe is shown in the plugin recipe book,",
-              "&eand, if enabled, inside the vanilla recipe book.",
+              "&eRecipe is shown in the recipe book.",
               "",
               "&7[&aClick&7] Hide in plugin recipe book"
             ]
@@ -1857,15 +1861,19 @@
         "crafting": {
           "shapeless": {
             "enabled": {
-              "name": "&3Shapeless Recipe",
-              "help": [
-                "&7Recipe is shapeless!"
+              "name": "&7\u25A1 &l&6Shapeless Recipe",
+              "lore": [
+                "&eThe ingredients have no shape.",
+                "&ei.e. They can be placed into",
+                "&ethe grid without any specific order."
               ]
             },
             "disabled": {
-              "name": "&3Shaped Recipe",
-              "help": [
-                "&7Recipe has a shape!"
+              "name": "&7\u25A0 &l&6Shaped Recipe",
+              "lore": [
+                "&eThe ingredients have a shape.",
+                "&ei.e. They must to be placed, into",
+                "&ethe grid, in this exact shape."
               ]
             }
           },
@@ -2209,28 +2217,11 @@
       "crafting": {
         "gui_name": "&4&lCreator &7[&8Workbench&7]",
         "gui_help": [
-          "&7Tip:",
-          "&eShift &7+ &eRight click &7on Result or Ingredients will ",
-          "&7allow you to edit the item/s"
-        ],
-        "items": {
-          "adv_workbench": {
-            "enabled": {
-              "name": "&3Advanced Workbench",
-              "help": [
-                "&7Can only be crafted in",
-                "&7Advanced Workbenches",
-                ""
-              ]
-            },
-            "disabled": {
-              "name": "&4Every Workbench",
-              "help": [
-                "&7Can be crafted in every Workbench"
-              ]
-            }
-          }
-        }
+          "&6&lResult/Ingredient slot&7:",
+          " &aShift&7+&aRight-Click",
+          " &7\u27A0&e Open the Result/Ingredient Editor",
+          ""
+        ]
       },
       "elite_crafting": {
         "gui_name": "&4&lCreator &7[&8Elite Workbench&7]",


### PR DESCRIPTION
At the moment Furnace Recipes are not awarding the experience of all stored custom recipes (and none when a vanilla recipe is collected), which is not the intended behaviour. Now when an item is collected (vanilla or custom recipe) it will drop the experience of all stored custom recipes.  

Fixed #68 - Custom Items Vanilla Recipe Blocker feature is not working for smelting vanilla recipes




