### PR TITLE
More EnchantMergeAdapter settings

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/EnchantMergeAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/EnchantMergeAdapter.java
@@ -93,7 +93,11 @@ public class EnchantMergeAdapter extends MergeAdapter {
         enchants.forEach((enchantment, level) -> {
             if ((!result.containsEnchantment(enchantment) || result.getEnchantmentLevel(enchantment) < level) && meta != null) {
                 if ((ignoreConflicts || !meta.hasConflictingEnchant(enchantment)) && (ignoreItemLimit || enchantment.canEnchantItem(result))) {
-                    meta.addEnchant(enchantment, level, ignoreEnchantLimit);
+                    if (ignoreEnchantLimit) {
+                        meta.addEnchant(enchantment, level, true);
+                    } else {
+                        meta.addEnchant(enchantment, Math.min(level, enchantment.getMaxLevel()), false);
+                    }
                 }
             }
         });

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/EnchantMergeAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/EnchantMergeAdapter.java
@@ -50,7 +50,7 @@ public class EnchantMergeAdapter extends MergeAdapter {
     public EnchantMergeAdapter() {
         super(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "enchant"));
         this.ignoreEnchantLimit = false;
-        this.ignoreConflicts = false;
+        this.ignoreConflicts = true;
         this.increaseLevels = false;
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/EnchantMergeAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/EnchantMergeAdapter.java
@@ -44,6 +44,7 @@ public class EnchantMergeAdapter extends MergeAdapter {
 
     private final boolean ignoreEnchantLimit;
     private final boolean ignoreConflicts;
+    private final boolean ignoreItemLimit;
     private final boolean increaseLevels;
     private List<Enchantment> blackListedEnchants = new ArrayList<>();
 
@@ -52,6 +53,7 @@ public class EnchantMergeAdapter extends MergeAdapter {
         this.ignoreEnchantLimit = false;
         this.ignoreConflicts = true;
         this.increaseLevels = false;
+        this.ignoreItemLimit = true;
     }
 
     public EnchantMergeAdapter(EnchantMergeAdapter adapter) {
@@ -59,6 +61,7 @@ public class EnchantMergeAdapter extends MergeAdapter {
         this.ignoreEnchantLimit = adapter.ignoreEnchantLimit;
         this.ignoreConflicts = adapter.ignoreConflicts;
         this.increaseLevels = adapter.increaseLevels;
+        this.ignoreItemLimit = adapter.ignoreItemLimit;
         this.blackListedEnchants = List.copyOf(blackListedEnchants);
     }
 
@@ -95,7 +98,7 @@ public class EnchantMergeAdapter extends MergeAdapter {
         var meta = result.getItemMeta();
         enchants.forEach((enchantment, level) -> {
             if ((!result.containsEnchantment(enchantment) || result.getEnchantmentLevel(enchantment) < level) && meta != null) {
-                if (ignoreConflicts || !meta.hasConflictingEnchant(enchantment)) {
+                if ((ignoreConflicts || !meta.hasConflictingEnchant(enchantment)) && (ignoreItemLimit || enchantment.canEnchantItem(result))) {
                     meta.addEnchant(enchantment, level, ignoreEnchantLimit);
                 }
             }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/EnchantMergeAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/EnchantMergeAdapter.java
@@ -22,11 +22,11 @@
 
 package me.wolfyscript.customcrafting.recipes.items.target.adapters;
 
-import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.customcrafting.recipes.data.IngredientData;
 import me.wolfyscript.customcrafting.recipes.data.RecipeData;
 import me.wolfyscript.customcrafting.recipes.items.target.MergeAdapter;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.block.Block;
@@ -36,19 +36,30 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class EnchantMergeAdapter extends MergeAdapter {
 
-    private final boolean ignoreEnchantLimit = false;
+    private final boolean ignoreEnchantLimit;
+    private final boolean ignoreConflicts;
+    private final boolean increaseLevels;
     private List<Enchantment> blackListedEnchants = new ArrayList<>();
 
     public EnchantMergeAdapter() {
         super(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "enchant"));
+        this.ignoreEnchantLimit = false;
+        this.ignoreConflicts = false;
+        this.increaseLevels = false;
     }
 
     public EnchantMergeAdapter(EnchantMergeAdapter adapter) {
         super(adapter);
+        this.ignoreEnchantLimit = adapter.ignoreEnchantLimit;
+        this.ignoreConflicts = adapter.ignoreConflicts;
+        this.increaseLevels = adapter.increaseLevels;
+        this.blackListedEnchants = List.copyOf(blackListedEnchants);
     }
 
     public boolean isIgnoreEnchantLimit() {
@@ -67,22 +78,29 @@ public class EnchantMergeAdapter extends MergeAdapter {
 
     @Override
     public ItemStack merge(RecipeData<?> recipeData, @Nullable Player player, @Nullable Block block, CustomItem customResult, ItemStack result) {
+        Map<Enchantment, Integer> enchants = new HashMap<>();
         for (IngredientData data : recipeData.getBySlots(slots)) {
             var item = data.itemStack();
             item.getEnchantments().forEach((enchantment, level) -> {
-                if (
-                    !blackListedEnchants.contains(enchantment) && (
-                        !result.containsEnchantment(enchantment) ||
-                        result.getEnchantmentLevel(enchantment) < level
-                    )
-                ) {
-                    var meta = result.getItemMeta();
-                    if (meta != null && meta.addEnchant(enchantment, level, ignoreEnchantLimit)) {
-                        result.setItemMeta(meta);
-                    }
+                if (!blackListedEnchants.contains(enchantment)) {
+                    enchants.merge(enchantment, level, (currentLevel, otherLevel) -> {
+                        if (!increaseLevels) {
+                            return Math.max(currentLevel, otherLevel);
+                        }
+                        return currentLevel.equals(otherLevel) ? ++currentLevel : Math.max(currentLevel, otherLevel);
+                    });
                 }
             });
         }
+        var meta = result.getItemMeta();
+        enchants.forEach((enchantment, level) -> {
+            if ((!result.containsEnchantment(enchantment) || result.getEnchantmentLevel(enchantment) < level) && meta != null) {
+                if (ignoreConflicts || !meta.hasConflictingEnchant(enchantment)) {
+                    meta.addEnchant(enchantment, level, ignoreEnchantLimit);
+                }
+            }
+        });
+        result.setItemMeta(meta);
         return result;
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/EnchantMergeAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/EnchantMergeAdapter.java
@@ -83,15 +83,9 @@ public class EnchantMergeAdapter extends MergeAdapter {
     public ItemStack merge(RecipeData<?> recipeData, @Nullable Player player, @Nullable Block block, CustomItem customResult, ItemStack result) {
         Map<Enchantment, Integer> enchants = new HashMap<>();
         for (IngredientData data : recipeData.getBySlots(slots)) {
-            var item = data.itemStack();
-            item.getEnchantments().forEach((enchantment, level) -> {
+            data.itemStack().getEnchantments().forEach((enchantment, level) -> {
                 if (!blackListedEnchants.contains(enchantment)) {
-                    enchants.merge(enchantment, level, (currentLevel, otherLevel) -> {
-                        if (!increaseLevels) {
-                            return Math.max(currentLevel, otherLevel);
-                        }
-                        return currentLevel.equals(otherLevel) ? ++currentLevel : Math.max(currentLevel, otherLevel);
-                    });
+                    enchants.merge(enchantment, level, (currentLevel, otherLevel) -> increaseLevels && currentLevel.equals(otherLevel) ? ++currentLevel : Math.max(currentLevel, otherLevel));
                 }
             });
         }


### PR DESCRIPTION
Adds optional `ignoreConflicts`, `ignoreItemLimit`, `increaseLevels` settings to the EnchantMergeAdpter.

### Defaults:
`ignoreConflicts = true`
`ignoreItemLimit = true`
`increaseLevels = false`

### Features:
#### Ignore Conflicts
Ignores conflicting enchants when applying enchantments to the result item.

#### Ignore Item Limit
Ignores the check if the enchantment can be applied to the item.
If disabled only enchantments that can be applied to the type of the result are added.

#### Increase Levels
Only useful if the target targets multiple ingredient slots.
Goes through each targeted slot and compares the previous enchantment levels (if available) with the current one. If the previous level and current one are the same, then the level is increased. Otherwise it will use the higher level.