### PR TITLE
Prevent overflow of Furnace Recipe Cook Time

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCacheCooking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCacheCooking.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.data.cache.recipe_creator;
 
+import com.google.common.base.Preconditions;
 import me.wolfyscript.customcrafting.recipes.CustomRecipeCooking;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
 
@@ -85,6 +86,7 @@ public abstract class RecipeCacheCooking<R extends CustomRecipeCooking<R, ?>> ex
     }
 
     public void setCookingTime(int cookingTime) {
+        Preconditions.checkArgument(cookingTime <= Short.MAX_VALUE, "The cooking time cannot be higher than 32767.");
         this.cookingTime = cookingTime;
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorCooking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorCooking.java
@@ -67,7 +67,7 @@ public class RecipeCreatorCooking extends RecipeCreator {
         }, (guiHandler, player, s, args) -> {
             int time;
             try {
-                time = Integer.parseInt(args[0]);
+                time = Short.parseShort(args[0]);
             } catch (NumberFormatException e) {
                 api.getChat().sendKey(player, getCluster(), "valid_number");
                 return true;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
@@ -113,6 +113,7 @@ public abstract class CustomRecipeCooking<C extends CustomRecipeCooking<C, T>, T
     }
 
     public void setCookingTime(int cookingTime) {
+        Preconditions.checkArgument(cookingTime <= Short.MAX_VALUE, "The cooking time cannot be higher than 32767.");
         this.cookingTime = cookingTime;
     }
 

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -2301,7 +2301,7 @@
             "lore": [
               "&6%TIME% ticks"
             ],
-            "message": "&3Type in the cooking time in ticks. e.g. 20"
+            "message": "&eType in the cooking time in ticks. e.g. 20. &cMax value: 32767"
           }
         }
       },


### PR DESCRIPTION
Added cook time limitation (32767 ticks) to the CookingRecipes.
Added cook time limitation to the GUI