### PR TITLE
Player Scoreboard Condition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.wolfyscript.wolfyutilities</groupId>
             <artifactId>wolfyutilities</artifactId>
-            <version>3.16.0.0</version>
+            <version>3.16-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!--

--- a/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
@@ -71,6 +71,7 @@ import me.wolfyscript.utilities.util.Reflection;
 import me.wolfyscript.utilities.util.entity.CustomPlayerData;
 import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 import me.wolfyscript.utilities.util.json.jackson.KeyedTypeIdResolver;
+import me.wolfyscript.utilities.util.version.ServerVersion;
 import me.wolfyscript.utilities.util.version.WUVersion;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
@@ -204,7 +205,10 @@ public class CustomCrafting extends JavaPlugin {
         recipeConditions.register(WorldTimeCondition.KEY, WorldTimeCondition.class, new WorldTimeCondition.GUIComponent());
         recipeConditions.register(ConditionAdvancement.KEY, ConditionAdvancement.class, new ConditionAdvancement.GUIComponent());
 
-        recipeConditions.register(ConditionScoreboard.KEY, ConditionScoreboard.class);
+        if (ServerVersion.getWUVersion().isAfterOrEq(WUVersion.of(3, 16, 3, 0))) {
+            //Only register it when the features are available
+            recipeConditions.register(ConditionScoreboard.KEY, ConditionScoreboard.class, new ConditionScoreboard.GUIComponent());
+        }
 
         var recipeTypes = getRegistries().getRecipeTypes();
         recipeTypes.register(RecipeType.CRAFTING_SHAPED);
@@ -239,17 +243,14 @@ public class CustomCrafting extends JavaPlugin {
         writeBanner();
         writePatreonCredits();
         writeSeparator();
+        this.configHandler = new ConfigHandler(this);
+        this.configHandler.load();
         this.otherPlugins.init();
-
-        configHandler = new ConfigHandler(this);
-        configHandler.load();
-        dataHandler = new DataHandler(this);
-        disableRecipesHandler = new DisableRecipesHandler(this);
-
+        this.dataHandler = new DataHandler(this);
+        this.disableRecipesHandler = new DisableRecipesHandler(this);
         registerListeners();
         registerCommands();
         registerInventories();
-
         //Used for testing purposes, might be available for production in the future
         if (WolfyUtilities.isDevEnv()) {
             this.networkHandler.registerPackets();

--- a/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
@@ -204,6 +204,8 @@ public class CustomCrafting extends JavaPlugin {
         recipeConditions.register(WorldTimeCondition.KEY, WorldTimeCondition.class, new WorldTimeCondition.GUIComponent());
         recipeConditions.register(ConditionAdvancement.KEY, ConditionAdvancement.class, new ConditionAdvancement.GUIComponent());
 
+        recipeConditions.register(ConditionScoreboard.KEY, ConditionScoreboard.class);
+
         var recipeTypes = getRegistries().getRecipeTypes();
         recipeTypes.register(RecipeType.CRAFTING_SHAPED);
         recipeTypes.register(RecipeType.CRAFTING_SHAPELESS);

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/conditions/ConditionScoreboard.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/conditions/ConditionScoreboard.java
@@ -1,0 +1,102 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes.conditions;
+
+import me.wolfyscript.customcrafting.recipes.CustomRecipe;
+import me.wolfyscript.customcrafting.recipes.RecipeType;
+import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.context.EvalContext;
+import me.wolfyscript.utilities.util.operators.BoolOperator;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.advancement.Advancement;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Score;
+import org.bukkit.scoreboard.Scoreboard;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ConditionScoreboard extends Condition<ConditionScoreboard> {
+
+    public static final NamespacedKey KEY = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "scoreboard");
+
+    private BoolOperator check;
+
+    public ConditionScoreboard() {
+        super(KEY);
+        this.check = null;
+        setAvailableOptions(Conditions.Option.EXACT);
+    }
+
+    @Override
+    public boolean isApplicable(CustomRecipe<?> recipe) {
+        return RecipeType.Container.CRAFTING.isInstance(recipe) || RecipeType.Container.ELITE_CRAFTING.isInstance(recipe) || switch (recipe.getRecipeType().getType()) {
+            case BREWING_STAND, GRINDSTONE -> true;
+            default -> false;
+        };
+    }
+
+    @Override
+    public boolean check(CustomRecipe<?> recipe, Conditions.Data data) {
+        EvalContext context = new EvalContext();
+        Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+        Player player = data.getPlayer();
+        if (player != null) {
+            for (Objective objective : scoreboard.getObjectives()) {
+                String varName = objective.getName();
+                context.setVariable(varName, objective.getScore(player));
+            }
+            if (check != null) {
+                return check.evaluate(context);
+            }
+        } else {
+            for (String entry : scoreboard.getEntries()) {
+                for (Score score : scoreboard.getScores(entry)) {
+                    context.setVariable(entry + "_" + score.getObjective().getName(), score.getScore());
+                }
+            }
+            if (check != null) {
+                return check.evaluate(context);
+            }
+        }
+        return true;
+    }
+
+    public static class GUIComponent extends FunctionalGUIComponent<ConditionScoreboard> {
+
+        public GUIComponent() {
+            super(Material.EXPERIENCE_BOTTLE, getLangKey(KEY.getKey(), "name"), List.of(getLangKey(KEY.getKey(), "description")),
+                    (menu, api) -> {},
+                    (update, cache, condition, recipe) -> {});
+        }
+
+        @Override
+        public boolean shouldRender(RecipeType<?> type) {
+            return RecipeType.Container.CRAFTING.has(type) || RecipeType.Container.ELITE_CRAFTING.has(type) || type == RecipeType.BREWING_STAND || type == RecipeType.GRINDSTONE;
+        }
+    }
+}

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/conditions/ConditionScoreboard.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/conditions/ConditionScoreboard.java
@@ -71,7 +71,7 @@ public class ConditionScoreboard extends Condition<ConditionScoreboard> {
             EvalContext context = new EvalContext();
             for (Objective objective : scoreboard.getObjectives()) {
                 String varName = objective.getName();
-                context.setVariable(varName, objective.getScore(player));
+                context.setVariable(varName, objective.getScore(player).getScore());
             }
             if (check != null && !check.evaluate(context)) {
                 //Directly return if the check fails.
@@ -83,8 +83,8 @@ public class ConditionScoreboard extends Condition<ConditionScoreboard> {
                 if (objective != null) {
                     //Set an eval context with just the specified value of this objective
                     EvalContext valueContext = new EvalContext();
-                    valueContext.setVariable("value", objective.getScore(player));
-                    if (!entry.getValue().evaluate(context)) {
+                    valueContext.setVariable("value", objective.getScore(player).getScore());
+                    if (!entry.getValue().evaluate(valueContext)) {
                         return false;
                     }
                 } else if (failOnMissingObjective) {

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -229,6 +229,15 @@
         "&7Set the advancements a player",
         "&7requires to craft the recipe."
       ]
+    },
+    "player_scoreboard": {
+      "name": "Player Scoreboard",
+      "description": [
+        "&7Evaluate scoreboard values",
+        "&7required to craft the recipe.",
+        "&cMust be configured in the ",
+        "&crecipe JSON Config!"
+      ]
     }
   },
   "inventories": {


### PR DESCRIPTION
Implements a new recipe condition to player recipes, that makes it possible to evaluate player scores in the scoreboard.

### Properties
`check` – The general check that is called before the specific objective checks. If this one fails then the next ones are skipped and the condition is not valid.
`objectiveChecks` – A map of objective names and their corresponding checks.    
`failOnMissingObjective` – If true the condition fails when one of the objectives in the `objectiveChecks` is not present for that player.   

## Json structure
Example:
```json5
{
      "key" : "customcrafting:player_scoreboard",
      "objectiveChecks" : {
        //Check specifically for the objective "test_value"
        "test_value" : {
          "key" : "wolfyutilities:equal", //Checks if "this" is equal to "that"
          "this" : {
            //A constant value
            "key" : "wolfyutilities:int/const",
            "value" : 67
          },
          "that" : {
            //The context variable from the condition
            //Here it is the value of the "test_value" objective, called "value"
            "key" : "wolfyutilities:int/var",
            "var" : "value"
          }
        }
      },
      //Since this option is enabled, this condition fails if the "test_value" objective is not available.
      "failOnMissingObjective" : true,
      //The general check works similar, but the context contains the scores of all objectives
      "check" : {
          "key" : "wolfyutilities:equal", //Checks if "this" is equal to "that"
          "this" : {
            //A constant value
            "key" : "wolfyutilities:int/const",
            "value" : 67
          },
          "that" : {
            //The context variable from the condition
            //Here we have to reference the objective name "test_value", as the context contains all objectives.
            "key" : "wolfyutilities:int/var",
            "var" : "test_value"
          }
      }
}
```

### Checks 
The checks require a boolean value, which you can achieve by using Operators and ValueProviders (Available since WolfyUtilities 3.16.3.0).  

#### Operators:
##### Comparison
Those require two identical value providers and evaluate into a boolean value.
* wolfyutilities:equal
* wolfyutilities:not_equal
* wolfyutilities:greater
* wolfyutilities:greater_equal
* wolfyutilities:less
* wolfyutilities:less_equal
##### Logical: 
Those require one or two boolean inputs, so you can use the comparison operators from top or nest another logical operator.
* wolfyutilities:and
* wolfyutilities:or
* wolfyutilities:not

#### Value Providers
See https://github.com/WolfyScript/WolfyUtilities/pull/76

Resolves #64 – Scoreboard Score Crafting Condition