### PR TITLE
EliteCrafting Table & RecipeBook QOL improvements 

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/Category.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/Category.java
@@ -26,7 +26,7 @@ import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonGetter;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonSetter;
 import me.wolfyscript.customcrafting.CustomCrafting;
-import me.wolfyscript.customcrafting.data.cache.EliteWorkbench;
+import me.wolfyscript.customcrafting.data.cache.CacheEliteCraftingTable;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.utilities.api.nms.network.MCByteBuf;
 import org.bukkit.entity.Player;
@@ -82,9 +82,9 @@ public class Category extends CategorySettings {
         return getRecipeList(player, filter, null);
     }
 
-    public List<RecipeContainer> getRecipeList(Player player, CategoryFilter filter, EliteWorkbench eliteWorkbench) {
-        if (eliteWorkbench != null) {
-            return getContainers(filter).stream().filter(container -> container.canView(player) && container.isValid(eliteWorkbench)).toList();
+    public List<RecipeContainer> getRecipeList(Player player, CategoryFilter filter, CacheEliteCraftingTable cacheEliteCraftingTable) {
+        if (cacheEliteCraftingTable != null) {
+            return getContainers(filter).stream().filter(container -> container.canView(player) && container.isValid(cacheEliteCraftingTable)).toList();
         }
         return getContainers(filter).stream().filter(container -> container.canView(player)).toList();
     }

--- a/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/RecipeContainer.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/RecipeContainer.java
@@ -23,7 +23,7 @@
 package me.wolfyscript.customcrafting.configs.recipebook;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
-import me.wolfyscript.customcrafting.data.cache.EliteWorkbench;
+import me.wolfyscript.customcrafting.data.cache.CacheEliteCraftingTable;
 import me.wolfyscript.customcrafting.recipes.*;
 import me.wolfyscript.customcrafting.recipes.conditions.Conditions;
 import me.wolfyscript.customcrafting.recipes.conditions.EliteWorkbenchCondition;
@@ -99,20 +99,20 @@ public class RecipeContainer implements Comparable<RecipeContainer> {
         return materials.isEmpty() || cachedRecipes.stream().anyMatch(recipe1 -> recipe1.getResult().getChoices().stream().anyMatch(customItem -> materials.contains(customItem.getItemStack().getType())));
     }
 
-    public boolean isValid(EliteWorkbench eliteWorkbench) {
-        var data = eliteWorkbench.getData();
+    public boolean isValid(CacheEliteCraftingTable cacheEliteCraftingTable) {
+        var data = cacheEliteCraftingTable.getData();
         return cachedRecipes.parallelStream().anyMatch(cachedRecipe -> {
             if (cachedRecipe instanceof CraftingRecipe<?, ?> && (RecipeType.Container.ELITE_CRAFTING.isInstance(cachedRecipe) || data.isAdvancedRecipes())) {
                 if (RecipeType.Container.ELITE_CRAFTING.isInstance(cachedRecipe)) {
                     Conditions conditions = cachedRecipe.getConditions();
-                    if (conditions.has(EliteWorkbenchCondition.KEY) && !conditions.getByType(EliteWorkbenchCondition.class).getEliteWorkbenches().contains(eliteWorkbench.getCustomItem().getNamespacedKey())) {
+                    if (conditions.has(EliteWorkbenchCondition.KEY) && !conditions.getByType(EliteWorkbenchCondition.class).getEliteWorkbenches().contains(cacheEliteCraftingTable.getCustomItem().getNamespacedKey())) {
                         return false;
                     }
                     if (cachedRecipe instanceof AbstractRecipeShapeless<?, ?> shapeless) {
-                        return shapeless.getIngredients().size() <= eliteWorkbench.getCurrentGridSize() * eliteWorkbench.getCurrentGridSize();
+                        return shapeless.getIngredients().size() <= cacheEliteCraftingTable.getCurrentGridSize() * cacheEliteCraftingTable.getCurrentGridSize();
                     } else {
                         CraftingRecipeEliteShaped recipe1 = (CraftingRecipeEliteShaped) cachedRecipe;
-                        return recipe1.getShape().length <= eliteWorkbench.getCurrentGridSize() && recipe1.getShape()[0].length() <= eliteWorkbench.getCurrentGridSize();
+                        return recipe1.getShape().length <= cacheEliteCraftingTable.getCurrentGridSize() && recipe1.getShape()[0].length() <= cacheEliteCraftingTable.getCurrentGridSize();
                     }
                 }
                 return true;

--- a/src/main/java/me/wolfyscript/customcrafting/data/CCCache.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/CCCache.java
@@ -49,7 +49,7 @@ public class CCCache extends CustomCache {
     private final PotionEffects potionEffectCache = new PotionEffects();
     private final RecipeBookCache recipeBookCache = new RecipeBookCache();
     private final CacheRecipeView cacheRecipeView = new CacheRecipeView();
-    private EliteWorkbench eliteWorkbench = new EliteWorkbench();
+    private CacheEliteCraftingTable cacheEliteCraftingTable = new CacheEliteCraftingTable();
     private final ChatLists chatLists = new ChatLists();
     private final ParticleCache particleCache = new ParticleCache();
     private final BrewingGUICache brewingGUICache = new BrewingGUICache();
@@ -137,12 +137,12 @@ public class CCCache extends CustomCache {
         return particleCache;
     }
 
-    public EliteWorkbench getEliteWorkbench() {
-        return eliteWorkbench;
+    public CacheEliteCraftingTable getEliteWorkbench() {
+        return cacheEliteCraftingTable;
     }
 
-    public void setEliteWorkbench(EliteWorkbench eliteWorkbench) {
-        this.eliteWorkbench = eliteWorkbench;
+    public void setEliteWorkbench(CacheEliteCraftingTable cacheEliteCraftingTable) {
+        this.cacheEliteCraftingTable = cacheEliteCraftingTable;
     }
 
     public BrewingGUICache getBrewingGUICache() {

--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/CacheEliteCraftingTable.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/CacheEliteCraftingTable.java
@@ -23,11 +23,13 @@
 package me.wolfyscript.customcrafting.data.cache;
 
 import me.wolfyscript.customcrafting.configs.custom_data.EliteWorkbenchData;
+import me.wolfyscript.customcrafting.configs.recipebook.Category;
+import me.wolfyscript.customcrafting.configs.recipebook.CategoryFilter;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
-public class EliteWorkbench {
+public class CacheEliteCraftingTable {
 
     private byte currentGridSize;
     private EliteWorkbenchData data;
@@ -35,7 +37,7 @@ public class EliteWorkbench {
     private ItemStack result;
     private ItemStack[] contents;
 
-    public EliteWorkbench() {
+    public CacheEliteCraftingTable() {
         this.contents = null;
         this.currentGridSize = 3;
         this.result = new ItemStack(Material.AIR);

--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/RecipeBookCache.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/RecipeBookCache.java
@@ -29,7 +29,6 @@ import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
-import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -40,7 +39,7 @@ import java.util.Map;
 public class RecipeBookCache {
 
     private final CustomCrafting customCrafting;
-    private EliteWorkbench eliteCraftingTable;
+    private CacheEliteCraftingTable eliteCraftingTable;
     private Category category;
     private CategoryFilter categoryFilter;
 
@@ -48,6 +47,8 @@ public class RecipeBookCache {
     private int subFolderPage;
     private Map<CustomItem, List<CustomRecipe<?>>> cachedSubFolderRecipes;
     private List<CustomItem> researchItems;
+
+    private boolean prepareRecipe;
 
     public RecipeBookCache() {
         this.customCrafting = CustomCrafting.inst();
@@ -58,6 +59,7 @@ public class RecipeBookCache {
         this.researchItems = new ArrayList<>();
         this.cachedSubFolderRecipes = new HashMap<>();
         this.eliteCraftingTable = null;
+        this.prepareRecipe = true;
     }
 
     public CustomRecipe<?> getCurrentRecipe() {
@@ -67,11 +69,19 @@ public class RecipeBookCache {
         return null;
     }
 
-    public EliteWorkbench getEliteCraftingTable() {
+    public void setPrepareRecipe(boolean prepareRecipe) {
+        this.prepareRecipe = prepareRecipe;
+    }
+
+    public boolean isPrepareRecipe() {
+        return prepareRecipe;
+    }
+
+    public CacheEliteCraftingTable getEliteCraftingTable() {
         return eliteCraftingTable;
     }
 
-    public void setEliteCraftingTable(EliteWorkbench eliteCraftingTable) {
+    public void setEliteCraftingTable(CacheEliteCraftingTable eliteCraftingTable) {
         this.eliteCraftingTable = eliteCraftingTable;
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/ButtonSlotCrafting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/ButtonSlotCrafting.java
@@ -24,7 +24,7 @@ package me.wolfyscript.customcrafting.gui.elite_crafting;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
-import me.wolfyscript.customcrafting.data.cache.EliteWorkbench;
+import me.wolfyscript.customcrafting.data.cache.CacheEliteCraftingTable;
 import me.wolfyscript.utilities.api.inventory.gui.button.ButtonState;
 import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ItemInputButton;
 import org.bukkit.Material;
@@ -37,15 +37,15 @@ class ButtonSlotCrafting extends ItemInputButton<CCCache> {
         super("crafting.slot_" + recipeSlot, new ButtonState<>("", Material.AIR,
                 (cache, guiHandler, player, inventory, slot, event) -> event instanceof InventoryClickEvent clickEvent && CraftingWindow.RESULT_SLOTS.contains(clickEvent.getSlot()),
                 (cache, guiHandler, player, inventory, itemStack, slot, b) -> {
-                    EliteWorkbench eliteWorkbench = cache.getEliteWorkbench();
-                    eliteWorkbench.getContents()[recipeSlot] = inventory.getItem(slot);
-                    ItemStack result = customCrafting.getCraftManager().preCheckRecipe(eliteWorkbench.getContents(), player, inventory, true, eliteWorkbench.getData().isAdvancedRecipes());
-                    eliteWorkbench.setResult(result);
+                    CacheEliteCraftingTable cacheEliteCraftingTable = cache.getEliteWorkbench();
+                    cacheEliteCraftingTable.getContents()[recipeSlot] = inventory.getItem(slot);
+                    ItemStack result = customCrafting.getCraftManager().preCheckRecipe(cacheEliteCraftingTable.getContents(), player, inventory, true, cacheEliteCraftingTable.getData().isAdvancedRecipes());
+                    cacheEliteCraftingTable.setResult(result);
                 }, null,
                 (hashMap, cache, guiHandler, player, inventory, itemStack, slot, help) -> {
-                    EliteWorkbench eliteWorkbench = cache.getEliteWorkbench();
-                    if (eliteWorkbench.getContents() != null) {
-                        ItemStack slotItem = eliteWorkbench.getContents()[recipeSlot];
+                    CacheEliteCraftingTable cacheEliteCraftingTable = cache.getEliteWorkbench();
+                    if (cacheEliteCraftingTable.getContents() != null) {
+                        ItemStack slotItem = cacheEliteCraftingTable.getContents()[recipeSlot];
                         return slotItem == null ? new ItemStack(Material.AIR) : slotItem;
                     }
                     return new ItemStack(Material.AIR);

--- a/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/ButtonSlotResult.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/ButtonSlotResult.java
@@ -25,7 +25,7 @@ package me.wolfyscript.customcrafting.gui.elite_crafting;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.configs.custom_data.EliteWorkbenchData;
 import me.wolfyscript.customcrafting.data.CCCache;
-import me.wolfyscript.customcrafting.data.cache.EliteWorkbench;
+import me.wolfyscript.customcrafting.data.cache.CacheEliteCraftingTable;
 import me.wolfyscript.utilities.api.inventory.gui.button.ButtonState;
 import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ItemInputButton;
 import me.wolfyscript.utilities.util.inventory.InventoryUtils;
@@ -40,35 +40,35 @@ class ButtonSlotResult extends ItemInputButton<CCCache> {
 
     ButtonSlotResult(CustomCrafting customCrafting) {
         super("result_slot", new ButtonState<>("", Material.AIR, (cache, guiHandler, player, inventory, slot, event) -> {
-            EliteWorkbench eliteWorkbench = cache.getEliteWorkbench();
+            CacheEliteCraftingTable cacheEliteCraftingTable = cache.getEliteWorkbench();
             if (event instanceof InventoryClickEvent clickEvent && inventory.getWindow() instanceof CraftingWindow) {
                 if (!CraftingWindow.RESULT_SLOTS.contains(slot)) {
                     return true;
                 }
                 if (clickEvent.getAction().equals(InventoryAction.MOVE_TO_OTHER_INVENTORY) && event.getView().getBottomInventory().equals(clickEvent.getClickedInventory())) {
                     ItemStack itemStack = clickEvent.getCurrentItem() != null ? clickEvent.getCurrentItem().clone() : new ItemStack(Material.AIR);
-                    if (!InventoryUtils.hasInventorySpace(eliteWorkbench.getContents(), itemStack)) {
+                    if (!InventoryUtils.hasInventorySpace(cacheEliteCraftingTable.getContents(), itemStack)) {
                         return true;
                     }
-                    for (int i = 0; i < eliteWorkbench.getCurrentGridSize() * eliteWorkbench.getCurrentGridSize(); i++) {
-                        ItemStack item = eliteWorkbench.getContents()[i];
+                    for (int i = 0; i < cacheEliteCraftingTable.getCurrentGridSize() * cacheEliteCraftingTable.getCurrentGridSize(); i++) {
+                        ItemStack item = cacheEliteCraftingTable.getContents()[i];
                         if (item == null) {
-                            eliteWorkbench.getContents()[i] = itemStack;
+                            cacheEliteCraftingTable.getContents()[i] = itemStack;
                             break;
                         } else if ((item.isSimilar(itemStack) || itemStack.isSimilar(item)) && item.getAmount() + itemStack.getAmount() <= itemStack.getMaxStackSize()) {
-                            eliteWorkbench.getContents()[i].setAmount(item.getAmount() + itemStack.getAmount());
+                            cacheEliteCraftingTable.getContents()[i].setAmount(item.getAmount() + itemStack.getAmount());
                             break;
                         }
                     }
                     return false;
-                } else if (!((InventoryClickEvent) event).getClick().equals(ClickType.DOUBLE_CLICK) && eliteWorkbench.getResult() != null && customCrafting.getCraftManager().has(event.getWhoClicked().getUniqueId())) {
-                    if (inventory.getWindow() instanceof CraftingWindow craftingWindow && (ItemUtils.isAirOrNull(clickEvent.getCursor()) || clickEvent.getCursor().isSimilar(eliteWorkbench.getResult()))) {
-                        customCrafting.getCraftManager().consumeRecipe(eliteWorkbench.getResult(), clickEvent);
-                        eliteWorkbench.setResult(null);
+                } else if (!((InventoryClickEvent) event).getClick().equals(ClickType.DOUBLE_CLICK) && cacheEliteCraftingTable.getResult() != null && customCrafting.getCraftManager().has(event.getWhoClicked().getUniqueId())) {
+                    if (inventory.getWindow() instanceof CraftingWindow craftingWindow && (ItemUtils.isAirOrNull(clickEvent.getCursor()) || clickEvent.getCursor().isSimilar(cacheEliteCraftingTable.getResult()))) {
+                        customCrafting.getCraftManager().consumeRecipe(cacheEliteCraftingTable.getResult(), clickEvent);
+                        cacheEliteCraftingTable.setResult(null);
                         int invSlot;
                         for (int i = 0; i < craftingWindow.gridSize * craftingWindow.gridSize; i++) {
                             invSlot = craftingWindow.getGridX() + i + (i / craftingWindow.gridSize) * (9 - craftingWindow.gridSize);
-                            inventory.setItem(invSlot, eliteWorkbench.getContents()[i]);
+                            inventory.setItem(invSlot, cacheEliteCraftingTable.getContents()[i]);
                         }
                         customCrafting.getCraftManager().remove(event.getWhoClicked().getUniqueId());
                     }
@@ -76,18 +76,18 @@ class ButtonSlotResult extends ItemInputButton<CCCache> {
             }
             return true;
         }, (cache, guiHandler, player, inventory, itemStack, slot, event) -> {
-            EliteWorkbench eliteWorkbench = cache.getEliteWorkbench();
+            CacheEliteCraftingTable cacheEliteCraftingTable = cache.getEliteWorkbench();
             if (inventory.getWindow() instanceof CraftingWindow) {
-                eliteWorkbench.setResult(null);
+                cacheEliteCraftingTable.setResult(null);
             }
         }, (cache, guiHandler, player, inventory, itemStack, slot, b) -> {
-            EliteWorkbench eliteWorkbench = cache.getEliteWorkbench();
-            EliteWorkbenchData eliteWorkbenchData = eliteWorkbench.getData();
-            ItemStack result = customCrafting.getCraftManager().preCheckRecipe(eliteWorkbench.getContents(), player, inventory, true, eliteWorkbenchData.isAdvancedRecipes());
-            eliteWorkbench.setResult(result);
+            CacheEliteCraftingTable cacheEliteCraftingTable = cache.getEliteWorkbench();
+            EliteWorkbenchData eliteWorkbenchData = cacheEliteCraftingTable.getData();
+            ItemStack result = customCrafting.getCraftManager().preCheckRecipe(cacheEliteCraftingTable.getContents(), player, inventory, true, eliteWorkbenchData.isAdvancedRecipes());
+            cacheEliteCraftingTable.setResult(result);
         }, (hashMap, cache, guiHandler, player, inventory, itemStack, slot, help) -> {
-            EliteWorkbench eliteWorkbench = cache.getEliteWorkbench();
-            return eliteWorkbench.getResult() != null ? eliteWorkbench.getResult() : new ItemStack(Material.AIR);
+            CacheEliteCraftingTable cacheEliteCraftingTable = cache.getEliteWorkbench();
+            return cacheEliteCraftingTable.getResult() != null ? cacheEliteCraftingTable.getResult() : new ItemStack(Material.AIR);
         }));
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/CraftingWindow.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/CraftingWindow.java
@@ -24,7 +24,7 @@ package me.wolfyscript.customcrafting.gui.elite_crafting;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
-import me.wolfyscript.customcrafting.data.cache.EliteWorkbench;
+import me.wolfyscript.customcrafting.data.cache.CacheEliteCraftingTable;
 import me.wolfyscript.customcrafting.gui.CCWindow;
 import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
 import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
@@ -73,10 +73,10 @@ abstract class CraftingWindow extends CCWindow {
             event.setButton(i, ClusterMain.GLASS_BLACK);
         }
         CCCache cache = event.getGuiHandler().getCustomCache();
-        EliteWorkbench eliteWorkbench = cache.getEliteWorkbench();
-        if (eliteWorkbench.getContents() == null || eliteWorkbench.getCurrentGridSize() <= 0) {
-            eliteWorkbench.setCurrentGridSize((byte) gridSize);
-            eliteWorkbench.setContents(new ItemStack[gridSize * gridSize]);
+        CacheEliteCraftingTable cacheEliteCraftingTable = cache.getEliteWorkbench();
+        if (cacheEliteCraftingTable.getContents() == null || cacheEliteCraftingTable.getCurrentGridSize() <= 0) {
+            cacheEliteCraftingTable.setCurrentGridSize((byte) gridSize);
+            cacheEliteCraftingTable.setContents(new ItemStack[gridSize * gridSize]);
         }
         int slot;
         for (int i = 0; i < gridSize * gridSize; i++) {
@@ -91,18 +91,18 @@ abstract class CraftingWindow extends CCWindow {
     public boolean onClose(GuiHandler<CCCache> guiHandler, GUIInventory<CCCache> guiInventory, InventoryView transaction) {
         Player player = guiHandler.getPlayer();
         CCCache cache = guiHandler.getCustomCache();
-        EliteWorkbench eliteWorkbench = cache.getEliteWorkbench();
-        if (eliteWorkbench.getContents() != null) {
-            for (ItemStack itemStack : eliteWorkbench.getContents()) {
+        CacheEliteCraftingTable cacheEliteCraftingTable = cache.getEliteWorkbench();
+        if (cacheEliteCraftingTable.getContents() != null) {
+            for (ItemStack itemStack : cacheEliteCraftingTable.getContents()) {
                 if (itemStack != null && !itemStack.getType().equals(Material.AIR)) {
                     player.getInventory().addItem(itemStack);
                 }
             }
         }
-        eliteWorkbench.setCustomItemAndData(null, null);
-        eliteWorkbench.setResult(new ItemStack(Material.AIR));
-        eliteWorkbench.setContents(null);
-        eliteWorkbench.setCurrentGridSize((byte) 0);
+        cacheEliteCraftingTable.setCustomItemAndData(null, null);
+        cacheEliteCraftingTable.setResult(new ItemStack(Material.AIR));
+        cacheEliteCraftingTable.setContents(null);
+        cacheEliteCraftingTable.setCurrentGridSize((byte) 0);
         return false;
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/EliteCraftingCluster.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/EliteCraftingCluster.java
@@ -26,6 +26,7 @@ import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.CCCluster;
 import me.wolfyscript.customcrafting.gui.recipebook.ButtonContainerIngredient;
+import me.wolfyscript.customcrafting.utils.PlayerUtil;
 import me.wolfyscript.utilities.api.inventory.gui.InventoryAPI;
 import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ActionButton;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -51,7 +52,7 @@ public class EliteCraftingCluster extends CCCluster {
         registerButton(new ActionButton<>(RECIPE_BOOK.getKey(), Material.KNOWLEDGE_BOOK, (cache, guiHandler, player, inventory, slot, event) -> {
             ButtonContainerIngredient.resetButtons(guiHandler);
             cache.getRecipeBookCache().setEliteCraftingTable(cache.getEliteWorkbench());
-            guiHandler.openCluster("recipe_book");
+            PlayerUtil.openRecipeBook(player);
             return true;
         }));
     }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ButtonContainerIngredient.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ButtonContainerIngredient.java
@@ -138,7 +138,7 @@ public class ButtonContainerIngredient extends Button<CCCache> {
                     book.setSubFolderPage(0);
                     book.addResearchItem(customItem);
                     book.setSubFolderRecipes(customItem, recipes);
-                    book.applyRecipeToButtons(guiHandler, recipes.get(0));
+                    book.setPrepareRecipe(true);
                 }
             }
         }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ButtonContainerRecipeBook.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ButtonContainerRecipeBook.java
@@ -103,7 +103,7 @@ class ButtonContainerRecipeBook extends Button<CCCache> {
             book.setSubFolderPage(0);
             book.addResearchItem(customItem);
             book.setSubFolderRecipes(customItem, recipes);
-            book.applyRecipeToButtons(guiHandler, recipes.get(0));
+            book.setPrepareRecipe(true);
             resetButtons(guiHandler);
         }
         return true;

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ClusterRecipeBook.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ClusterRecipeBook.java
@@ -25,7 +25,13 @@ package me.wolfyscript.customcrafting.gui.recipebook;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.CCCluster;
-import me.wolfyscript.customcrafting.recipes.*;
+import me.wolfyscript.customcrafting.gui.elite_crafting.EliteCraftingCluster;
+import me.wolfyscript.customcrafting.recipes.CustomRecipe;
+import me.wolfyscript.customcrafting.recipes.CustomRecipeAnvil;
+import me.wolfyscript.customcrafting.recipes.CustomRecipeBrewing;
+import me.wolfyscript.customcrafting.recipes.CustomRecipeCauldron;
+import me.wolfyscript.customcrafting.recipes.CustomRecipeCooking;
+import me.wolfyscript.customcrafting.recipes.RecipeType;
 import me.wolfyscript.customcrafting.recipes.conditions.Conditions;
 import me.wolfyscript.customcrafting.recipes.conditions.PermissionCondition;
 import me.wolfyscript.customcrafting.recipes.conditions.WeatherCondition;
@@ -39,7 +45,10 @@ import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ToggleButton;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.PlayerHeadUtils;
 import org.apache.commons.lang.StringUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 
 import java.util.ArrayList;
@@ -101,7 +110,7 @@ public class ClusterRecipeBook extends CCCluster {
                             book.setSubFolderRecipes(item, customCrafting.getRegistries().getRecipes().get(item));
                         }
                         if (!book.getSubFolderRecipes().isEmpty()) {
-                            book.applyRecipeToButtons(guiHandler, book.getSubFolderRecipes().get(0));
+                            book.setPrepareRecipe(true);
                         }
                         return true;
                     }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ClusterRecipeBook.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ClusterRecipeBook.java
@@ -102,7 +102,17 @@ public class ClusterRecipeBook extends CCCluster {
             if (event instanceof InventoryClickEvent clickEvent) {
                 var book = cache.getRecipeBookCache();
                 ButtonContainerIngredient.resetButtons(guiHandler);
-                if (clickEvent.isLeftClick()) {
+                if (clickEvent.getClick().equals(ClickType.MIDDLE)) {
+                    Bukkit.getScheduler().runTask(customCrafting, () -> {
+                        if (cache.getRecipeBookCache().hasEliteCraftingTable()) {
+                            guiHandler.openCluster(EliteCraftingCluster.KEY);
+                        } else {
+                            guiHandler.close();
+                        }
+                        cache.getRecipeBookCache().setEliteCraftingTable(null);
+                    });
+                    return true;
+                } else if (clickEvent.isLeftClick()) {
                     book.removePreviousResearchItem();
                     if (book.getSubFolder() > 0) {
                         CustomItem item = book.getResearchItem();

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeBook.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeBook.java
@@ -95,7 +95,7 @@ public class MenuRecipeBook extends CCWindow {
             int nextPage = book.getSubFolderPage() + 1;
             if (nextPage < book.getSubFolderRecipes().size()) {
                 book.setSubFolderPage(nextPage);
-                book.applyRecipeToButtons(guiHandler, book.getSubFolderRecipes().get(nextPage));
+                book.setPrepareRecipe(true);
             }
             return true;
         }, (values, cache, guiHandler, player, inventory, itemStack, slot, help) -> {
@@ -109,7 +109,7 @@ public class MenuRecipeBook extends CCWindow {
             ButtonContainerIngredient.resetButtons(guiHandler);
             if (book.getSubFolderPage() > 0) {
                 book.setSubFolderPage(book.getSubFolderPage() - 1);
-                book.applyRecipeToButtons(guiHandler, book.getSubFolderRecipes().get(book.getSubFolderPage()));
+                book.setPrepareRecipe(true);
             }
             return true;
         }, (values, cache, guiHandler, player, inventory, itemStack, slot, help) -> {
@@ -171,6 +171,11 @@ public class MenuRecipeBook extends CCWindow {
             }
             if (recipeBookCache.getSubFolderPage() < recipes.size()) {
                 CustomRecipe<?> customRecipe = recipes.get(recipeBookCache.getSubFolderPage());
+                if (recipeBookCache.isPrepareRecipe()) { //This makes sure we only prepare the recipe once
+                    //A new prepare can be queued by using book.setPrepareRecipe(true)
+                    recipeBookCache.applyRecipeToButtons(event.getGuiHandler(), customRecipe);
+                    recipeBookCache.setPrepareRecipe(false);
+                }
                 customRecipe.renderMenu(this, event);
                 boolean elite = RecipeType.Container.ELITE_CRAFTING.isInstance(customRecipe);
                 if (recipeBookCache.getSubFolderPage() > 0) {

--- a/src/main/java/me/wolfyscript/customcrafting/utils/PlayerUtil.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/PlayerUtil.java
@@ -52,16 +52,13 @@ public class PlayerUtil {
         CustomCrafting customCrafting = CustomCrafting.inst();
         InventoryAPI<CCCache> invAPI = customCrafting.getApi().getInventoryAPI(CCCache.class);
         var categories = customCrafting.getConfigHandler().getRecipeBookConfig();
-
+        var bookCache = invAPI.getGuiHandler(player).getCustomCache().getRecipeBookCache();
         // Open directly to the category if we only have one
+        bookCache.setPrepareRecipe(true);
         if (categories.getSortedCategories().size() == 1) {
-            invAPI.getGuiHandler(player).getCustomCache().getRecipeBookCache().setCategory(categories.getCategory(0));
+            bookCache.setCategory(categories.getCategory(0));
             invAPI.openGui(player, ClusterRecipeBook.RECIPE_BOOK);
-
-            return;
-        }
-
-        if (!categories.getSortedCategories().isEmpty()) {
+        } else if (!categories.getSortedCategories().isEmpty()) {
             invAPI.openCluster(player, ClusterRecipeBook.KEY);
         }
     }

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -3138,10 +3138,9 @@
         "back_to_list": {
           "name": "&7\u27A6 &6&lReturn",
           "lore": [
-            "&aLeft-Click",
-            "  &7»&r &eReturn to previous Recipe",
-            "&aRight-Click ",
-            "  &7»&r &eReturn to Recipe List"
+            "&aLeft-Click &7»&e Previous Recipe",
+            "&aRight-Click &7»&e Recipe List",
+            "&aMiddle-Click &7»&e &eClose Book"
           ]
         }
       },


### PR DESCRIPTION
Adds a new middle-click feature to the "Back to List" button in the recipe book, that closes the book directly without the need to go back. 
This is especially useful for the Elite Crafting Table, as you can directly go back to the craft menu and then go back and the previous selected page or recipe is still there.

Resolves #72 - Elite Crafting Table Recipe Book Issues