### PR TITLE
ItemCreator Modify Lore Line & MiniMessage support 

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabDisplayName.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabDisplayName.java
@@ -27,13 +27,13 @@ import me.wolfyscript.customcrafting.data.cache.items.Items;
 import me.wolfyscript.customcrafting.gui.item_creator.ButtonOption;
 import me.wolfyscript.customcrafting.gui.item_creator.MenuItemCreator;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.lib.net.kyori.adventure.platform.bukkit.BukkitComponentSerializer;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
 import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ActionButton;
 import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ChatInputButton;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import me.wolfyscript.utilities.util.chat.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -48,8 +48,8 @@ public class TabDisplayName extends ItemCreatorTabVanilla {
     @Override
     public void register(MenuItemCreator creator, WolfyUtilities api) {
         creator.registerButton(new ButtonOption(Material.NAME_TAG, this));
-        creator.registerButton(new ChatInputButton<>(KEY + ".set", Material.GREEN_CONCRETE, (guiHandler, player, s, strings) -> {
-            guiHandler.getCustomCache().getItems().getItem().setDisplayName(ChatColor.convert(s));
+        creator.registerButton(new ChatInputButton<>(KEY + ".set", Material.GREEN_CONCRETE, (guiHandler, player, s, args) -> {
+            guiHandler.getCustomCache().getItems().getItem().setDisplayName(BukkitComponentSerializer.legacy().serialize(api.getChat().getMiniMessage().deserialize(s)));
             return false;
         }));
         creator.registerButton(new ActionButton<>(KEY + ".remove", Material.RED_CONCRETE, (cache, guiHandler, player, inventory, i, event) -> {

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabLore.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabLore.java
@@ -28,13 +28,15 @@ import me.wolfyscript.customcrafting.gui.item_creator.ButtonOption;
 import me.wolfyscript.customcrafting.gui.item_creator.MenuItemCreator;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.lib.net.kyori.adventure.platform.bukkit.BukkitComponentSerializer;
+import me.wolfyscript.lib.net.kyori.adventure.text.Component;
+import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
 import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ActionButton;
 import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ChatInputButton;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import me.wolfyscript.utilities.util.chat.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -50,11 +52,11 @@ public class TabLore extends ItemCreatorTabVanilla {
     public void register(MenuItemCreator creator, WolfyUtilities api) {
         creator.registerButton(new ButtonOption(Material.WRITABLE_BOOK, this));
         creator.registerButton(new ChatInputButton<>(KEY + ".add", Material.WRITABLE_BOOK, (guiHandler, player, s, strings) -> {
-            guiHandler.getCustomCache().getItems().getItem().addLoreLine(s.equals("&empty") ? "" : ChatColor.convert(s));
+            guiHandler.getCustomCache().getItems().getItem().addLoreLine(BukkitComponentSerializer.legacy().serialize(api.getChat().getMiniMessage().deserialize(s, Placeholder.component("emtpy", Component.empty()))));
             return false;
         }));
-        creator.registerButton(new ActionButton<>(KEY + ".remove", Material.WRITTEN_BOOK, (cache, guiHandler, player, inventory, i, event) -> {
-            ChatUtils.sendLoreManager(player);
+        creator.registerButton(new ActionButton<>(KEY + ".edit", Material.WRITTEN_BOOK, (cache, guiHandler, player, inventory, i, event) -> {
+            ChatUtils.sendLoreEditor(player);
             guiHandler.close();
             return true;
         }));
@@ -63,6 +65,6 @@ public class TabLore extends ItemCreatorTabVanilla {
     @Override
     public void render(GuiUpdate<CCCache> update, CCCache cache, Items items, CustomItem customItem, ItemStack item) {
         update.setButton(30, KEY + ".add");
-        update.setButton(32, KEY + ".remove");
+        update.setButton(32, KEY + ".edit");
     }
 }

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -97,6 +97,17 @@
         "&ccontain the following characters [a-z 0-9 _ -]!",
         "&ePlease retype the folder and key!"
       ]
+    },
+    "chat_editor": {
+      "lore": {
+        "title": "<grey>-------------------[<green>Modify Lore</green>]------------------</grey>",
+        "line": {
+          "number": "<lore_line>. ",
+          "remove": "<hover:show_text:'<red><b>Remove line <lore_line></b></red>'><grey>[<red>-</red>]</grey></hover> ",
+          "edit": "<hover:show_text:'Edit line <lore_line>'><grey>[<yellow>✎</yellow>]</grey></hover> "
+        },
+        "input_new_lore": "<grey>[<gold>Line <lore_line></gold>] </grey><yellow>Input the new lore line <grey>(<yellow>Formatting: <click:open_url:'https://docs.adventure.kyori.net/minimessage/format.html'><u><gold>MiniMessage</gold></u></click></yellow>)</grey></yellow>"
+      }
     }
   },
   "commands": {
@@ -833,23 +844,23 @@
           },
           "display_name": {
             "option": {
-              "name": "&6Change name",
+              "name": "<gold>Change name",
               "lore": [
-                "&7Edit Display Name"
+                "<grey>Edit Display Name"
               ]
             },
             "set": {
-              "name": "&6Set Display Name",
+              "name": "<grey>✎ <gold><b>Set Display Name",
               "lore": [
-                "&7Change Display Name"
+                "<yellow>Change Display Name"
               ],
-              "message": "&eType in the name! Use &6&& &efor formatting codes!"
+              "message": "<yellow>Type in the new item name! <grey>(<yellow>Formatting: <click:open_url:'https://docs.adventure.kyori.net/minimessage/format.html'><u><gold>MiniMessage</gold></u></click></yellow>)</grey>"
             },
             "remove": {
-              "name": "&3Remove Display Name",
+              "name": "<grey>\u25B7 <gold><b>Remove Display Name",
               "lore": [
-                "&7Removes Display Name and",
-                "&7reset it to default"
+                "<yellow>Removes Display Name and",
+                "<yellow>reset it to default"
               ]
             }
           },
@@ -873,20 +884,18 @@
           },
           "lore": {
             "option": {
-              "name": "&6Edit Lore",
+              "name": "<gold>Edit Lore",
               "lore": [
-                "&7Add or Remove Lore lines"
+                "<yellow>Add or Remove Lore lines"
               ]
             },
             "add": {
-              "name": "&6Add Lore",
-              "help": [],
-              "message": "&eType in the lore! Use &6& &efor formatting codes!"
+              "name": "<grey>✎ <gold><b>Add Lore",
+              "message": "<yellow>Type in a new lore line </yellow><grey>(<yellow>Formatting: <click:open_url:'https://docs.adventure.kyori.net/minimessage/format.html'><u><gold>MiniMessage</gold></u></click></yellow>)</grey>"
             },
-            "remove": {
-              "name": "&4Remove Lore",
-              "help": [],
-              "message": "&eType in the line of the lore you want to remove!"
+            "edit": {
+              "name": "<grey>✎ <gold><b>Edit Lore",
+              "message": "<yellow>Remove & Edit specific lore lines"
             }
           },
           "flags": {


### PR DESCRIPTION
Replaces the lore line remove menu with a new lore modifier menu, that allows you to edit and remove single lore lines.
The input for lore lines and display name no longer use the `&` for color codes!
Instead it uses the MiniMessage format (https://docs.adventure.kyori.net/minimessage/format)

Resolves #65 – Modify Lore Line