### PR TITLE
Recipe Check NBT QOL Improvements

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCache.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCache.java
@@ -40,7 +40,7 @@ import org.bukkit.entity.Player;
 public abstract class RecipeCache<R extends CustomRecipe<?>> {
 
     protected NamespacedKey key;
-    protected boolean checkNBT;
+    protected boolean checkAllNBT;
     protected boolean hidden;
     protected boolean vanillaBook;
 
@@ -51,7 +51,7 @@ public abstract class RecipeCache<R extends CustomRecipe<?>> {
 
     protected RecipeCache() {
         this.key = null;
-        this.checkNBT = true;
+        this.checkAllNBT = false;
         this.hidden = false;
         this.vanillaBook = true;
         this.priority = RecipePriority.NORMAL;
@@ -62,7 +62,7 @@ public abstract class RecipeCache<R extends CustomRecipe<?>> {
 
     protected RecipeCache(R customRecipe) {
         this.key = customRecipe.getNamespacedKey();
-        this.checkNBT = customRecipe.isCheckNBT();
+        this.checkAllNBT = customRecipe.isCheckNBT();
         this.hidden = customRecipe.isHidden();
         this.vanillaBook = customRecipe instanceof ICustomVanillaRecipe<?> vanillaRecipe && vanillaRecipe.isVisibleVanillaBook();
         this.priority = customRecipe.getPriority();
@@ -85,20 +85,20 @@ public abstract class RecipeCache<R extends CustomRecipe<?>> {
 
     @Deprecated
     public boolean isExactMeta() {
-        return checkNBT;
+        return checkAllNBT;
     }
 
     @Deprecated
     public void setExactMeta(boolean checkNBT) {
-        this.checkNBT = checkNBT;
+        this.checkAllNBT = checkNBT;
     }
 
-    public void setCheckNBT(boolean checkNBT) {
-        this.checkNBT = checkNBT;
+    public void setCheckNBT(boolean checkAllNBT) {
+        this.checkAllNBT = checkAllNBT;
     }
 
     public boolean isCheckNBT() {
-        return checkNBT;
+        return checkAllNBT;
     }
 
     public boolean isHidden() {
@@ -170,7 +170,7 @@ public abstract class RecipeCache<R extends CustomRecipe<?>> {
         recipe.setConditions(conditions);
         recipe.setGroup(group);
         recipe.setHidden(hidden);
-        recipe.setCheckNBT(checkNBT);
+        recipe.setCheckNBT(checkAllNBT);
         recipe.setPriority(priority);
         if (recipe instanceof ICustomVanillaRecipe<?> vanillaRecipe) {
             vanillaRecipe.setVisibleVanillaBook(vanillaBook);

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/ButtonExactMeta.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/ButtonExactMeta.java
@@ -30,12 +30,14 @@ import org.bukkit.Material;
 class ButtonExactMeta extends ToggleButton<CCCache> {
 
     ButtonExactMeta() {
-        super(ClusterRecipeCreator.EXACT_META.getKey(), (cache, guiHandler, player, guiInventory, i) -> cache.getRecipeCreatorCache().getRecipeCache().isExactMeta(), new ButtonState<>(ClusterRecipeCreator.EXACT_META_ENABLED, Material.GREEN_CONCRETE, (cache, guiHandler, player, inventory, slot, event) -> {
-            cache.getRecipeCreatorCache().getRecipeCache().setExactMeta(false);
-            return true;
-        }), new ButtonState<>(ClusterRecipeCreator.EXACT_META_DISABLED, Material.RED_CONCRETE, (cache, guiHandler, player, inventory, slot, event) -> {
-            cache.getRecipeCreatorCache().getRecipeCache().setExactMeta(true);
-            return true;
-        }));
+        super(ClusterRecipeCreator.EXACT_META.getKey(), (cache, guiHandler, player, guiInventory, i) -> cache.getRecipeCreatorCache().getRecipeCache().isCheckNBT(),
+                new ButtonState<>(ClusterRecipeCreator.EXACT_META_ENABLED, Material.ITEM_FRAME, (cache, guiHandler, player, inventory, slot, event) -> {
+                    cache.getRecipeCreatorCache().getRecipeCache().setCheckNBT(false);
+                    return true;
+                }), new ButtonState<>(ClusterRecipeCreator.EXACT_META_DISABLED, Material.PAPER, (cache, guiHandler, player, inventory, slot, event) -> {
+                    cache.getRecipeCreatorCache().getRecipeCache().setCheckNBT(true);
+                    return true;
+                })
+        );
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/CauldronListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/CauldronListener.java
@@ -29,7 +29,6 @@ import me.wolfyscript.customcrafting.listeners.customevents.CauldronPreCookEvent
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.customcrafting.recipes.CustomRecipeCauldron;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
-import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.inventory.InventoryUtils;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
@@ -24,7 +24,6 @@ package me.wolfyscript.customcrafting.recipes;
 
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonGetter;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
-import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonSetter;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
@@ -270,7 +269,7 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
                 if (recipeSlot >= 0) {
                     var ingredient = ingredients.get(recipeSlot);
                     if (ingredient != null) {
-                        Optional<CustomItem> item = ingredient.check(invItem, this.checkNBT);
+                        Optional<CustomItem> item = ingredient.check(invItem, this.checkAllNBT);
                         if (item.isPresent()) {
                             dataMap.put(recipeSlot, new IngredientData(recipeSlot, ingredient, item.get(), invItem));
                             i++;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
@@ -24,7 +24,6 @@ package me.wolfyscript.customcrafting.recipes;
 
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonGetter;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
-import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonInclude;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonSetter;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -24,6 +24,7 @@ package me.wolfyscript.customcrafting.recipes;
 
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonAlias;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonAutoDetect;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonGetter;
@@ -88,7 +89,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     @JsonIgnore protected final WolfyUtilities api;
     @JsonIgnore protected final ObjectMapper mapper;
 
-    protected boolean checkNBT;
+    @JsonAlias("checkNBT") protected boolean checkAllNBT;
     protected boolean hidden;
     protected boolean vanillaBook;
     protected RecipePriority priority;
@@ -110,7 +111,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
         //Get fields from JsonNode
         this.group = node.path(KEY_GROUP).asText("");
         this.priority = mapper.convertValue(node.path(KEY_PRIORITY).asText("NORMAL"), RecipePriority.class);
-        this.checkNBT = node.path(KEY_EXACT_META).asBoolean(true);
+        this.checkAllNBT = node.path(KEY_EXACT_META).asBoolean(false);
         this.conditions = mapper.convertValue(node.path(KEY_CONDITIONS), Conditions.class);
         if (this.conditions == null) {
             this.conditions = new Conditions();
@@ -138,7 +139,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
 
         this.group = "";
         this.priority = RecipePriority.NORMAL;
-        this.checkNBT = true;
+        this.checkAllNBT = false;
         this.vanillaBook = true;
         this.conditions = new Conditions();
         this.hidden = false;
@@ -159,7 +160,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
         this.vanillaBook = customRecipe.vanillaBook;
         this.group = customRecipe.group;
         this.priority = customRecipe.priority;
-        this.checkNBT = customRecipe.checkNBT;
+        this.checkAllNBT = customRecipe.checkAllNBT;
         this.conditions = customRecipe.conditions;
         this.hidden = customRecipe.hidden;
         this.result = customRecipe.result.clone();
@@ -192,21 +193,21 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     @JsonIgnore
     @Deprecated
     public boolean isExactMeta() {
-        return checkNBT;
+        return checkAllNBT;
     }
 
     @JsonIgnore
     @Deprecated
     public void setExactMeta(boolean exactMeta) {
-        this.checkNBT = exactMeta;
+        this.checkAllNBT = exactMeta;
     }
 
-    public void setCheckNBT(boolean checkNBT) {
-        this.checkNBT = checkNBT;
+    public void setCheckNBT(boolean checkAllNBT) {
+        this.checkAllNBT = checkAllNBT;
     }
 
     public boolean isCheckNBT() {
-        return checkNBT;
+        return checkAllNBT;
     }
 
     public boolean isHidden() {
@@ -365,14 +366,14 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
             gen.writeBooleanField(KEY_VANILLA_BOOK, true);
         }
         gen.writeStringField(KEY_PRIORITY, priority.toString());
-        gen.writeBooleanField(KEY_EXACT_META, checkNBT);
+        gen.writeBooleanField(KEY_EXACT_META, checkAllNBT);
         gen.writeObjectField(KEY_CONDITIONS, conditions);
     }
 
     public void writeToBuf(MCByteBuf byteBuf) {
         byteBuf.writeUtf(getRecipeType().name());
         byteBuf.writeUtf(namespacedKey.toString());
-        byteBuf.writeBoolean(checkNBT);
+        byteBuf.writeBoolean(checkAllNBT);
         byteBuf.writeUtf(group);
         byteBuf.writeCollection(result.getChoices(), (mcByteBuf, customItem) -> mcByteBuf.writeItemStack(customItem.create()));
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
@@ -30,7 +30,6 @@ import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.common.base.Preconditions;
-import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
 import me.wolfyscript.customcrafting.gui.recipebook.ButtonContainerIngredient;

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/SmeltAPIAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/SmeltAPIAdapter.java
@@ -34,7 +34,6 @@ import me.wolfyscript.customcrafting.recipes.data.CookingRecipeData;
 import me.wolfyscript.customcrafting.recipes.data.FurnaceRecipeData;
 import me.wolfyscript.customcrafting.recipes.data.IngredientData;
 import me.wolfyscript.customcrafting.recipes.data.SmokerRecipeData;
-import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.Pair;

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -1845,26 +1845,28 @@
         },
         "exact_meta": {
           "enabled": {
-            "name": "&a\u25A0 &6&lCheck NBT",
+            "name": "&7\u25A0 &6&lFull NBT Check",
             "help": [],
             "lore": [
-              "&eItems need to be exactly the same!",
-              "&eI.e. the NBT of the ingredient &lmust",
-              "&ematch the NBT of item put into slot!",
+              "&eChecks the NBT of every",
+              "&eingredient.",
+              "&eIf the ingredient has no",
+              "&eNBT, then it only matches",
+              "&eitems without any NBT.",
               "",
-              "&7[&aClick&7] &7Ignore NBT"
+              "&7[&aClick&7] &7Default NBT Check"
             ]
           },
           "disabled": {
-            "name": "&a\u25A1 &6&lIgnore NBT",
+            "name": "&7\u25A1 &6&lDefault Item Check",
             "help": [],
             "lore": [
-              "&eItems without NBT will only",
-              "&ebe checked for their type!",
-              "&cWarning: Ingredients that have NBT",
-              "&care still checked for their NBT!",
+              "&eIngredients without NBT only",
+              "&eneed to match in type!",
+              "&cIngredients with NBT still",
+              "&cneed to match the input!",
               "",
-              "&7[&aClick&7] &7Check NBT"
+              "&7[&aClick&7] &7Full NBT Check"
             ]
           }
         },


### PR DESCRIPTION
Renamed `checkNBT` to `checkAllNBT` internally.  
Set default of `checkAllNBT` to `false`.

Renamed Buttons:
"Ignore NBT" -> "Default Item Check"  
"Check NBT" -> "Full NBT Check"