### PR TITLE
Default Recipes & Items Data Version Downgrade

### DIFF
--- a/src/main/resources/data/customcrafting/items/advanced_crafting_table.json
+++ b/src/main/resources/data/customcrafting/items/advanced_crafting_table.json
@@ -3,7 +3,7 @@
     "custom_amount" : 1,
     "item" : {
       "==" : "org.bukkit.inventory.ItemStack",
-      "v" : 2865,
+      "v" : 2566,
       "type" : "CRAFTING_TABLE",
       "meta" : {
         "==" : "ItemMeta",

--- a/src/main/resources/data/customcrafting/items/recipe_book.json
+++ b/src/main/resources/data/customcrafting/items/recipe_book.json
@@ -3,7 +3,7 @@
     "custom_amount" : 1,
     "item" : {
       "==" : "org.bukkit.inventory.ItemStack",
-      "v" : 2865,
+      "v" : 2566,
       "type" : "KNOWLEDGE_BOOK",
       "meta" : {
         "==" : "ItemMeta",

--- a/src/main/resources/data/customcrafting/recipes/advanced_crafting_table.json
+++ b/src/main/resources/data/customcrafting/recipes/advanced_crafting_table.json
@@ -20,7 +20,7 @@
         "custom_amount" : 1,
         "item" : {
           "==" : "org.bukkit.inventory.ItemStack",
-          "v" : 2865,
+          "v" : 2566,
           "type" : "GLOWSTONE_DUST"
         }
       } ],
@@ -33,7 +33,7 @@
         "custom_amount" : 1,
         "item" : {
           "==" : "org.bukkit.inventory.ItemStack",
-          "v" : 2865,
+          "v" : 2566,
           "type" : "CRAFTING_TABLE"
         }
       } ],
@@ -46,7 +46,7 @@
         "custom_amount" : 1,
         "item" : {
           "==" : "org.bukkit.inventory.ItemStack",
-          "v" : 2865,
+          "v" : 2566,
           "type" : "GOLD_INGOT"
         }
       } ],

--- a/src/main/resources/data/customcrafting/recipes/recipe_book.json
+++ b/src/main/resources/data/customcrafting/recipes/recipe_book.json
@@ -24,7 +24,7 @@
       "custom_amount" : 1,
       "item" : {
         "==" : "org.bukkit.inventory.ItemStack",
-        "v" : 2865,
+        "v" : 2566,
         "type" : "BOOK"
       }
     } ],
@@ -36,7 +36,7 @@
       "custom_amount" : 1,
       "item" : {
         "==" : "org.bukkit.inventory.ItemStack",
-        "v" : 2865,
+        "v" : 2566,
         "type" : "CRAFTING_TABLE"
       }
     } ],


### PR DESCRIPTION
Downgraded the data version of items used in the CustomItems and Recipes, so it works from 1.16 onwards.