### PR TITLE
Update Database Sub-Command Completion Options

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/commands/cc_subcommands/DataBaseSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/cc_subcommands/DataBaseSubCommand.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 public class DataBaseSubCommand extends AbstractSubCommand {
 
-    private final List<String> DATABASE = Arrays.asList("export");
+    private final List<String> DATABASE = Arrays.asList("export_recipes", "export_items");
 
     public DataBaseSubCommand(CustomCrafting customCrafting) {
         super("database", new ArrayList<>(), customCrafting);


### PR DESCRIPTION
Update database sub-command tab completion options to match the expected arguments.
Replaces the single existing `export` suggestion with `export_recipes` and `export_items`.