### PR TITLE
Added support for jitpack.io to project.

### DIFF
--- a/ensure-java-16.sh
+++ b/ensure-java-16.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+JV=`java -version 2>&1 >/dev/null | head -1`
+echo $JV | sed -E 's/^.*version "([^".]*)\.[^"]*".*$/\1/'
+
+if [ "$JV" != 16 ]; then
+	case "$1" in
+	install)
+		echo "Installing SDKMAN..."
+		curl -s "https://get.sdkman.io" | bash
+		source ~/.sdkman/bin/sdkman-init.sh
+		sdk version
+		sdk install java 16.0.2-open
+		;;
+	use)
+		echo "must source ~/.sdkman/bin/sdkman-init.sh"
+		exit 1
+		;;
+	esac
+fi

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,10 @@
+jdk:
+  - openjdk16
+before_install:
+  - echo "Before Install"
+  - bash ensure-java-16.sh install
+install:
+  - echo "Install"
+  - if ! bash ensure-java-16 use; then source ~/.sdkman/bin/sdkman-init.sh; fi
+  - java -version
+  - mvn install

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,17 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+        <repository>
             <id>wolfyscript-private</id>
             <url>https://maven.wolfyscript.com/repository/private/</url>
+        </repository>
+        <repository>
+            <id>wolfyscript-public</id>
+            <url>https://maven.wolfyscript.com/repository/public/</url>
         </repository>
         <repository>
             <id>dmulloy2-repo</id>
@@ -126,13 +135,14 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>${java.version}</release>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0-SNAPSHOT</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -172,6 +182,4 @@
             </resource>
         </resources>
     </build>
-
-
 </project>


### PR DESCRIPTION
I want to use your project as a shaded library in my own project and have to use jitpack.io for this purpose.
Since the build on jitpack was broken, I forked the project and fixed it. These are the changes I made. I hope this helps. Please go to [jitpack.io](https://jitpack.io) and delete the broken build of the master branch. (documentation [here](https://docs.jitpack.io/building/#rebuilding))

Changes:
- Updated maven-shade-plugin from 3.3.0-SNAPSHOT to 3.3.0
- Added maven central repository to pom.xml. That way the central repository has a higher priority than your private repository and there is less traffic to your private repository.
- Changed configuration of maven compiler plugin from `<release>16</release` to `<source>16</source><target>16</target>`
- Used jitpack.yml file to set java version to use. [Tutorial](https://leaves.one/2021/08/07/publish-package-on-jitpack-with-java16/)