### PR TITLE
Include Default recipes in the vanilla recipe book

### DIFF
--- a/src/main/resources/data/customcrafting/recipes/advanced_crafting_table.json
+++ b/src/main/resources/data/customcrafting/recipes/advanced_crafting_table.json
@@ -2,7 +2,7 @@
   "@type" : "customcrafting:crafting_shaped",
   "group" : "",
   "hidden" : false,
-  "vanillaBook" : false,
+  "vanillaBook" : true,
   "priority" : "NORMAL",
   "checkNBT" : true,
   "conditions" : {

--- a/src/main/resources/data/customcrafting/recipes/recipe_book.json
+++ b/src/main/resources/data/customcrafting/recipes/recipe_book.json
@@ -2,7 +2,7 @@
   "@type" : "customcrafting:crafting_shapeless",
   "group" : "",
   "hidden" : false,
-  "vanillaBook" : false,
+  "vanillaBook" : true,
   "priority" : "NORMAL",
   "checkNBT" : true,
   "conditions" : {


### PR DESCRIPTION
Fixed – The default recipes for the advanced crafting and recipe book are not shown in the vanilla recipe book.