### PR TITLE
Custom Durability Tag Adventure MiniMsg placeholder support

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabCustomDurability.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabCustomDurability.java
@@ -83,7 +83,7 @@ public class TabCustomDurability extends ItemCreatorTab {
             return itemStack;
         }, (guiHandler, player, s, strings) -> {
             try {
-                guiHandler.getCustomCache().getItems().getItem().setCustomDurabilityTag("&r" + s);
+                guiHandler.getCustomCache().getItems().getItem().setCustomDurabilityTag(s);
             } catch (NumberFormatException ex) {
                 return true;
             }


### PR DESCRIPTION
Removed the legacy reset color code from the tag input.
Other Tag related issues are fixed in WolfyUtilities https://github.com/WolfyScript/WolfyUtils-Spigot/pull/7