### PR TITLE
Fixed Crafting Recipe Behaviour & Duplications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>com.wolfyscript.customcrafting</groupId>
     <artifactId>customcrafting-spigot</artifactId>
-    <version>3.16.3.3</version>
+    <version>3.16.4-SNAPSHOT</version>
 
     <properties>
         <!-- Generic properties -->

--- a/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/ButtonSlotResult.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/ButtonSlotResult.java
@@ -61,9 +61,9 @@ class ButtonSlotResult extends ItemInputButton<CCCache> {
                         }
                     }
                     return false;
-                } else if (!((InventoryClickEvent) event).getClick().equals(ClickType.DOUBLE_CLICK) && cacheEliteCraftingTable.getResult() != null && customCrafting.getCraftManager().has(event.getWhoClicked().getUniqueId())) {
+                } else if (!((InventoryClickEvent) event).getClick().equals(ClickType.DOUBLE_CLICK) && !ItemUtils.isAirOrNull(cacheEliteCraftingTable.getResult()) && customCrafting.getCraftManager().has(event.getWhoClicked().getUniqueId())) {
                     if (inventory.getWindow() instanceof CraftingWindow craftingWindow && (ItemUtils.isAirOrNull(clickEvent.getCursor()) || clickEvent.getCursor().isSimilar(cacheEliteCraftingTable.getResult()))) {
-                        customCrafting.getCraftManager().consumeRecipe(cacheEliteCraftingTable.getResult(), clickEvent);
+                        customCrafting.getCraftManager().consumeRecipe(clickEvent);
                         cacheEliteCraftingTable.setResult(null);
                         int invSlot;
                         for (int i = 0; i < craftingWindow.gridSize * craftingWindow.gridSize; i++) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
@@ -271,7 +271,7 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
                     if (ingredient != null) {
                         Optional<CustomItem> item = ingredient.check(invItem, this.checkAllNBT);
                         if (item.isPresent()) {
-                            dataMap.put(recipeSlot, new IngredientData(recipeSlot, ingredient, item.get(), invItem));
+                            dataMap.put(i, new IngredientData(recipeSlot, ingredient, item.get(), new ItemStack(invItem)));
                             i++;
                             continue;
                         }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
@@ -182,7 +182,7 @@ public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<
                 var ingredient = ingredients.get(key);
                 Optional<CustomItem> validItem = ingredient.check(item, isCheckNBT());
                 if (validItem.isPresent()) {
-                    dataMap.put(pos, new IngredientData(key, ingredient, validItem.get(), item));
+                    dataMap.put(pos, new IngredientData(key, ingredient, validItem.get(), new ItemStack(item)));
                     return key;
                 }
                 //Check failed. Let's add the key back into the queue. (To the end, so we don't check it again and again...)

--- a/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
@@ -204,6 +204,10 @@ public class CraftManager {
         return preCraftedRecipes.containsKey(uuid);
     }
 
+    public Optional<CraftingData> get(UUID uuid) {
+        return Optional.ofNullable(preCraftedRecipes.get(uuid));
+    }
+
     private int gridSize(ItemStack[] ingredients) {
         return switch (ingredients.length) {
             case 4 -> 2;

--- a/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
@@ -38,6 +38,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -104,16 +105,14 @@ public class CraftManager {
     /**
      * Consumes the active Recipe from the matrix and sets the correct item to the cursor.
      *
-     * @param result The result {@link ItemStack} from the inventory.
      * @param event  The {@link InventoryClickEvent} that caused this click.
      */
-    public void consumeRecipe(ItemStack result, InventoryClickEvent event) {
-        var inventory = event.getClickedInventory();
+    public void consumeRecipe(InventoryClickEvent event) {
         var player = (Player) event.getWhoClicked();
-        if (inventory != null && !ItemUtils.isAirOrNull(result) && has(player.getUniqueId())) {
+        if (event.getClickedInventory() instanceof CraftingInventory inventory && has(player.getUniqueId())) {
             var craftingData = preCraftedRecipes.get(player.getUniqueId());
             CraftingRecipe<?, ?> recipe = craftingData.getRecipe();
-            if (recipe != null && !ItemUtils.isAirOrNull(result)) {
+            if (recipe != null) {
                 Result recipeResult = craftingData.getResult();
                 editStatistics(player, inventory, recipe);
                 setPlayerCraftTime(player, recipe);
@@ -146,7 +145,7 @@ public class CraftManager {
         var result = recipeResult.getItem(craftingData, player, null);
         var inventory = event.getClickedInventory();
         int possible = event.isShiftClick() ? Math.min(InventoryUtils.getInventorySpace(player.getInventory(), result) / result.getAmount(), recipe.getAmountCraftable(craftingData)) : 1;
-        recipe.removeMatrix(player, event.getClickedInventory(), possible, craftingData);
+        recipe.removeMatrix(player, inventory, possible, craftingData);
         recipeResult.executeExtensions(inventory.getLocation() == null ? event.getWhoClicked().getLocation() : inventory.getLocation(), inventory.getLocation() != null, (Player) event.getWhoClicked(), possible);
         if (event.isShiftClick()) {
             if (possible > 0) {


### PR DESCRIPTION
* Fixed buggy behaviour of the CraftListener#onCraft method. The Matrix is cleared temporarily and then consumed and reset a tick later to prevent things like duplication. 
* Reduced the amount of recipe checks (This might not update the recipe when dropping items on already existing stacks, but improves performance)
* CraftManager#consumeRecipe no longer requires the result ItemStack. The check should be done beforehand!
* Fixed #115 – Dupe Bug
* Added CraftManager#get method
* Fixed Shaped Recipes not indexing ingredient data using the matrix slot, but recipe slot! 
* Crafting Recipe IngredientData will copy the items from the inventory now, so they no longer edit the items directly in the crafting matrix.