### PR TITLE
Crafting Recipe Algo Improvements

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/listeners/CraftListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/CraftListener.java
@@ -83,10 +83,11 @@ public class CraftListener implements Listener {
                     //Clear Matrix to prevent duplication and buggy behaviour.
                     //This must not update the inventory yet, as that would call the PrepareItemCraftEvent, invalidating the recipe and preventing consumption of the recipe!
                     //But clearing it later can cause other issues too!
-                    //So lets just set the items to AIR...
-                    for (int i = 1; i < 10; i++) {
+                    //So lets just set the items to AIR and amount to 0...
+                    for (int i = 0; i < 10; i++) {
                         ItemStack item = inventory.getItem(i);
                         if (item != null) {
+                            item.setAmount(0);
                             item.setType(Material.AIR);
                         }
                     }
@@ -95,6 +96,7 @@ public class CraftListener implements Listener {
                     //...and finally update the inventory.
                     player.updateInventory();
                     //Reset Matrix with the re-calculated items. (1 tick later, to not cause duplication!)
+                    //This will result in a short flicker of the items in the inventory... still better than duplications, so the flickering won't be fixed!
                     Bukkit.getScheduler().runTaskLater(customCrafting, () -> {
                         craftingData.getIndexedBySlot().forEach((integer, ingredientData) -> inventory.setItem(integer + 1, ingredientData.itemStack()));
                         player.updateInventory();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
@@ -271,7 +271,8 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
                     if (ingredient != null) {
                         Optional<CustomItem> item = ingredient.check(invItem, this.checkAllNBT);
                         if (item.isPresent()) {
-                            dataMap.put(i, new IngredientData(recipeSlot, ingredient, item.get(), new ItemStack(invItem)));
+                            //In order to index the ingredients for the correct inventory slot we need to reverse the shape offset.
+                            dataMap.put(i + matrixData.getOffsetX() + (matrixData.getOffsetY() * 3), new IngredientData(recipeSlot, ingredient, item.get(), new ItemStack(invItem)));
                             i++;
                             continue;
                         }


### PR DESCRIPTION
With the previous changes in the behaviour of the crafting algorithm, the stacks are no longer edited directly and need to be re-applied to the matrix afterwards.
It appears that the original slots didn't match with the re-applied slots.

This PR makes sure that we try to determine the original matrix position of the stacks and re-apply them.
The MatrixData class saves a x, y offset of the stripped shape now, which can be used together with the index of the shape array to calculate the original matrix position of each stack.
This only works great for shaped recipes though, as shapeless recipes would require the original position for each ingredient. But the algorithm isn't saving that in any way and would be a lot more complex if it would.
Because of that, it uses the same calculation as the shaped recipes to estimate the position with the visual downside that items might still be rearranged automatically.