### PR TITLE
Togglable GUI Background Glass Panes

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/configs/MainConfig.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/MainConfig.java
@@ -42,6 +42,14 @@ public class MainConfig extends YamlConfiguration {
     public void init() {
     }
 
+    public boolean isGUIDrawBackground() {
+        return getBoolean("gui.draw_background", true);
+    }
+
+    public void setGUIDrawBackground(boolean drawBackground) {
+        set("gui.draw_background", drawBackground);
+    }
+
     public List<String> getCustomCraftingAlias() {
         return getStringList("commands.alias");
     }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/CCWindow.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/CCWindow.java
@@ -25,6 +25,7 @@ package me.wolfyscript.customcrafting.gui;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.data.CCPlayerData;
+import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
 import me.wolfyscript.customcrafting.utils.PlayerUtil;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
@@ -53,24 +54,26 @@ public abstract class CCWindow extends GuiWindow<CCCache> {
 
     @Override
     public void onUpdateAsync(GuiUpdate<CCCache> update) {
-        CCPlayerData store = PlayerUtil.getStore(update.getPlayer());
-        NamespacedKey gray = store.getDarkBackground();
-        if (getSize() > 9) {
-            NamespacedKey white = store.getLightBackground();
-            for (int i = 0; i < 9; i++) {
-                update.setButton(i, white);
+        if (customCrafting.getConfigHandler().getConfig().isGUIDrawBackground()) {
+            CCPlayerData store = PlayerUtil.getStore(update.getPlayer());
+            NamespacedKey gray = store.getDarkBackground();
+            if (getSize() > 9) {
+                NamespacedKey white = store.getLightBackground();
+                for (int i = 0; i < 9; i++) {
+                    update.setButton(i, white);
+                }
+                for (int i = 9; i < getSize() - 9; i++) {
+                    update.setButton(i, gray);
+                }
+                for (int i = getSize() - 9; i < getSize(); i++) {
+                    update.setButton(i, white);
+                }
+                update.setButton(8, ClusterMain.GUI_HELP);
+            } else {
+                for (int i = 0; i < 9; i++) {
+                    update.setButton(i, gray);
+                }
             }
-            for (int i = 9; i < getSize() - 9; i++) {
-                update.setButton(i, gray);
-            }
-            for (int i = getSize() - 9; i < getSize(); i++) {
-                update.setButton(i, white);
-            }
-            update.setButton(8, new NamespacedKey("none", "gui_help"));
-        } else {
-            for (int i = 0; i < 9; i++) {
-                update.setButton(i, gray);
-            }
-        }
+        } else if (getSize() > 9) update.setButton(8, ClusterMain.GUI_HELP);
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/CCWindow.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/CCWindow.java
@@ -68,12 +68,11 @@ public abstract class CCWindow extends GuiWindow<CCCache> {
                 for (int i = getSize() - 9; i < getSize(); i++) {
                     update.setButton(i, white);
                 }
-                update.setButton(8, ClusterMain.GUI_HELP);
             } else {
                 for (int i = 0; i < 9; i++) {
                     update.setButton(i, gray);
                 }
             }
-        } else if (getSize() > 9) update.setButton(8, ClusterMain.GUI_HELP);
+        }
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/MenuItemCreator.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/MenuItemCreator.java
@@ -217,7 +217,7 @@ public class MenuItemCreator extends CCWindow {
         event.setButton(4, ITEM_INPUT);
         CCPlayerData data = PlayerUtil.getStore(event.getPlayer());
         var gray = data.getLightBackground();
-        event.setButton(13, gray);
+        if (customCrafting.getConfigHandler().getConfig().isGUIDrawBackground()) event.setButton(13, gray);
         if (items.isRecipeItem()) {
             event.setButton(51, APPLY_ITEM);
         }
@@ -263,7 +263,7 @@ public class MenuItemCreator extends CCWindow {
                     i--;
                 }
                 j++;
-            } else {
+            } else if (customCrafting.getConfigHandler().getConfig().isGUIDrawBackground()) {
                 event.setButton(slot + i, gray);
             }
         }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/ClusterMain.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/ClusterMain.java
@@ -42,6 +42,7 @@ public class ClusterMain extends CCCluster {
 
     //Button keys
     public static final NamespacedKey BACK = new NamespacedKey(KEY, "back");
+    public static final NamespacedKey EMPTY = new NamespacedKey(KEY, "empty");
     public static final NamespacedKey BACK_BOTTOM = new NamespacedKey(KEY, "back_bottom");
     public static final NamespacedKey GUI_HELP = new NamespacedKey(KEY, "gui_help");
     public static final NamespacedKey GLASS_GRAY = new NamespacedKey(KEY, "glass_gray");
@@ -76,6 +77,7 @@ public class ClusterMain extends CCCluster {
     @Override
     public void onInit() {
         ButtonBuilder<CCCache> bb = getButtonBuilder();
+        bb.dummy(EMPTY.getKey()).state(s -> s.icon(Material.AIR)).register();
         bb.dummy(GLASS_GRAY.getKey()).state(state -> state.key(BACKGROUND.getKey()).icon(Material.GRAY_STAINED_GLASS_PANE)).register();
         bb.dummy(GLASS_BLACK.getKey()).state(state -> state.key(BACKGROUND.getKey()).icon(Material.BLACK_STAINED_GLASS_PANE)).register();
         bb.dummy(GLASS_RED.getKey()).state(state -> state.key(BACKGROUND.getKey()).icon(Material.RED_STAINED_GLASS_PANE)).register();

--- a/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/ClusterMain.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/ClusterMain.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.gui.main_gui;
 
+import com.wolfyscript.utilities.bukkit.TagResolverUtil;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.CCCluster;
@@ -30,6 +31,7 @@ import me.wolfyscript.lib.net.kyori.adventure.text.Component;
 import me.wolfyscript.lib.net.kyori.adventure.text.event.ClickEvent;
 import me.wolfyscript.utilities.api.inventory.gui.InventoryAPI;
 import me.wolfyscript.utilities.api.inventory.gui.button.ButtonAction;
+import me.wolfyscript.utilities.api.inventory.gui.button.CallbackButtonRender;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.PlayerHeadUtils;
 import org.bukkit.Material;
@@ -81,13 +83,12 @@ public class ClusterMain extends CCCluster {
         bb.dummy(GLASS_GREEN.getKey()).state(state -> state.key(BACKGROUND.getKey()).icon(Material.GREEN_STAINED_GLASS_PANE)).register();
         bb.dummy(GLASS_PURPLE.getKey()).state(state -> state.key(BACKGROUND.getKey()).icon(Material.PURPLE_STAINED_GLASS_PANE)).register();
         bb.dummy(GLASS_PINK.getKey()).state(state -> state.key(BACKGROUND.getKey()).icon(Material.PINK_STAINED_GLASS_PANE)).register();
-        bb.toggle(GUI_HELP.getKey()).enabledState(state -> state.subKey("enabled").icon(PlayerHeadUtils.getViaValue("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOGVlZjc4ZWRkNDdhNzI1ZmJmOGMyN2JiNmE3N2Q3ZTE1ZThlYmFjZDY1Yzc3ODgxZWM5ZWJmNzY4NmY3YzgifX19")).action((cache, guiHandler, player, guiInventory, i, event) -> {
-            guiHandler.setHelpEnabled(false);
-            return true;
-        })).disabledState(state -> state.subKey("disabled").icon(PlayerHeadUtils.getViaValue("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOGVlZjc4ZWRkNDdhNzI1ZmJmOGMyN2JiNmE3N2Q3ZTE1ZThlYmFjZDY1Yzc3ODgxZWM5ZWJmNzY4NmY3YzgifX19")).action((cache, guiHandler, player, guiInventory, i, event) -> {
-            guiHandler.setHelpEnabled(true);
-            return true;
-        })).register();
+        bb.dummy(GUI_HELP.getKey()).state(state -> state.key(GUI_HELP.getKey() + "_on").icon(PlayerHeadUtils.getViaValue("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOGVlZjc4ZWRkNDdhNzI1ZmJmOGMyN2JiNmE3N2Q3ZTE1ZThlYmFjZDY1Yzc3ODgxZWM5ZWJmNzY4NmY3YzgifX19"))
+                .render((cache, guiHandler, player, guiInv, stack, slot) -> {
+                    guiInv.getWindow().getHelpInformation();
+                    var window = guiInv.getWindow();
+                    return CallbackButtonRender.UpdateResult.of(TagResolverUtil.entries(guiHandler.getApi().getLanguageAPI().getComponents("inventories." + window.getCluster().getId() + "." + window.getNamespacedKey().getKey() + ".gui_help")));
+                })).register();
         final ButtonAction<CCCache> backAction = (cache, guiHandler, player, guiInventory, i, event) -> {
             guiHandler.openPreviousWindow();
             return true;

--- a/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuListCustomItem.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuListCustomItem.java
@@ -76,6 +76,7 @@ public class MenuListCustomItem extends CCWindow {
     public void onUpdateAsync(GuiUpdate<CCCache> update) {
         super.onUpdateAsync(update);
         update.setButton(0, "back");
+        update.setButton(8, ClusterMain.GUI_HELP);
         var items = update.getGuiHandler().getCustomCache().getItems();
         int maxPages;
         int page;

--- a/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuListRecipes.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuListRecipes.java
@@ -92,6 +92,7 @@ public class MenuListRecipes extends CCWindow {
         super.onUpdateAsync(event);
         GuiHandler<CCCache> guiHandler = event.getGuiHandler();
         event.setButton(0, "back");
+        event.setButton(8, ClusterMain.GUI_HELP);
 
         RegistryRecipes customRecipes = customCrafting.getRegistries().getRecipes();
         RecipeList recipeListCache = event.getGuiHandler().getCustomCache().getRecipeList();

--- a/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuMain.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuMain.java
@@ -113,9 +113,8 @@ public class MenuMain extends CCWindow {
         super.onUpdateAsync(event);
         CCPlayerData data = PlayerUtil.getStore(event.getPlayer());
         event.setButton(0, SETTINGS);
-        event.setButton(8, ClusterMain.GUI_HELP);
+        event.setButton(8, ClusterMain.PATREON);
 
-        event.setButton(4, ClusterMain.PATREON);
         event.setButton(48, ClusterMain.GITHUB);
         event.setButton(49, ClusterMain.YOUTUBE);
         event.setButton(50, ClusterMain.DISCORD);
@@ -139,8 +138,10 @@ public class MenuMain extends CCWindow {
             event.setButton(31, ELITE_CRAFTING);
             event.setButton(33, SMITHING);
         }
-        for (int i = 37; i < 44; i++) {
-            event.setButton(i, data.getLightBackground());
+        if (customCrafting.getConfigHandler().getConfig().isGUIDrawBackground()) {
+            for (int i = 37; i < 44; i++) {
+                event.setButton(i, data.getLightBackground());
+            }
         }
         event.setButton(36, ITEM_EDITOR);
         event.setButton(44, ClusterMain.RECIPE_LIST);

--- a/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuSettings.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuSettings.java
@@ -46,6 +46,7 @@ public class MenuSettings extends CCWindow {
     private static final String PRETTY_PRINTING = "pretty_printing";
     private static final String ADVANCED_CRAFTING_TABLE = "advanced_workbench";
     private static final String DEBUG = "debug";
+    private static final String DRAW_BACKGROUND = "draw_background";
 
     private static final String ENABLED = "enabled";
     private static final String DISABLED = "disabled";
@@ -107,6 +108,16 @@ public class MenuSettings extends CCWindow {
                     customCrafting.getConfigHandler().getConfig().save();
                     return true;
                 })).register();
+        bb.toggle(DRAW_BACKGROUND).stateFunction((ccCache, guiHandler, player, guiInventory, i) -> customCrafting.getConfigHandler().getConfig().isGUIDrawBackground())
+                .enabledState(state -> state.subKey(ENABLED).icon(Material.BLACK_STAINED_GLASS).action((cache, guiHandler, player, inventory, slot, event) -> {
+                    customCrafting.getConfigHandler().getConfig().setGUIDrawBackground(false);
+                    customCrafting.getConfigHandler().getConfig().save();
+                    return true;
+                })).disabledState(state -> state.subKey(DISABLED).icon(Material.BLACK_STAINED_GLASS).action((cache, guiHandler, player, inventory, slot, event) -> {
+                    customCrafting.getConfigHandler().getConfig().setGUIDrawBackground(true);
+                    customCrafting.getConfigHandler().getConfig().save();
+                    return true;
+                })).register();
     }
 
     @Override
@@ -131,7 +142,7 @@ public class MenuSettings extends CCWindow {
             event.setButton(12, ADVANCED_CRAFTING_TABLE);
             event.setButton(13, ButtonSettingsLanguage.KEY);
             event.setButton(14, "creator.reset_after_save");
-            event.setButton(15, "knowledgebook.workbench_filter_button");
+            event.setButton(15, DRAW_BACKGROUND);
         }
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/MenuIngredient.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/MenuIngredient.java
@@ -70,6 +70,7 @@ public class MenuIngredient extends CCWindow {
     public void onUpdateAsync(GuiUpdate<CCCache> update) {
         super.onUpdateAsync(update);
         update.setButton(0, "back");
+        update.setButton(8, ClusterMain.GUI_HELP);
         for (int i = 0; i < 36; i++) {
             update.setButton(9 + i, "item_container_" + i);
         }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/MenuItemEditor.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/MenuItemEditor.java
@@ -65,6 +65,7 @@ public class MenuItemEditor extends CCWindow {
     public void onUpdateAsync(GuiUpdate<CCCache> event) {
         super.onUpdateAsync(event);
         event.setButton(0, "back");
+        event.setButton(8, ClusterMain.GUI_HELP);
         event.setButton(21, ClusterMain.ITEM_LIST.getKey());
         event.setButton(23, "create_item");
     }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/MenuResult.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/MenuResult.java
@@ -64,6 +64,7 @@ public class MenuResult extends CCWindow {
     public void onUpdateAsync(GuiUpdate<CCCache> update) {
         super.onUpdateAsync(update);
         update.setButton(0, "back");
+        update.setButton(8, ClusterMain.GUI_HELP);
         for (int i = 0; i < 36; i++) {
             update.setButton(9 + i, "variant_container_" + i);
         }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/MenuTagSettings.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/MenuTagSettings.java
@@ -66,6 +66,7 @@ public class MenuTagSettings extends CCWindow {
         var tagsCache = update.getGuiHandler().getCustomCache().getRecipeCreatorCache().getTagSettingsCache();
         var recipeItemStack = tagsCache.getRecipeItemStack();
         update.setButton(0, ClusterMain.BACK);
+        update.setButton(8, ClusterMain.GUI_HELP);
         if (recipeItemStack != null) {
             NamespacedKey[] tags = recipeItemStack.getTags().toArray(new NamespacedKey[0]);
             int page = tagsCache.getListPage();

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreator.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreator.java
@@ -25,7 +25,9 @@ package me.wolfyscript.customcrafting.gui.recipe_creator;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.CCWindow;
+import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
 import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
+import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
 import me.wolfyscript.utilities.util.inventory.PlayerHeadUtils;
 
 public abstract class RecipeCreator extends CCWindow {
@@ -45,4 +47,9 @@ public abstract class RecipeCreator extends CCWindow {
         })).register();
     }
 
+    @Override
+    public void onUpdateAsync(GuiUpdate<CCCache> update) {
+        super.onUpdateAsync(update);
+        update.setButton(8, ClusterMain.GUI_HELP);
+    }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuMain.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuMain.java
@@ -30,8 +30,10 @@ import me.wolfyscript.customcrafting.gui.elite_crafting.EliteCraftingCluster;
 import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
 import me.wolfyscript.customcrafting.utils.PlayerUtil;
 import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
+import me.wolfyscript.utilities.api.inventory.gui.button.Button;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 
 class MenuMain extends CCWindow {
 
@@ -64,7 +66,11 @@ class MenuMain extends CCWindow {
     public void onUpdateAsync(GuiUpdate<CCCache> event) {
         super.onUpdateAsync(event);
         CCPlayerData data = PlayerUtil.getStore(event.getPlayer());
-        event.setButton(8, data.getLightBackground());
+        if (customCrafting.getConfigHandler().getConfig().isGUIDrawBackground()) {
+            event.setButton(8, data.getLightBackground());
+        } else {
+            event.setItem(8, new ItemStack(Material.AIR));
+        }
 
         var categories = customCrafting.getConfigHandler().getRecipeBookConfig();
         var sorted = categories.getSortedCategories();

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeBook.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeBook.java
@@ -38,6 +38,7 @@ import me.wolfyscript.utilities.api.inventory.gui.button.Button;
 import me.wolfyscript.utilities.api.inventory.gui.button.CallbackButtonRender;
 import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import me.wolfyscript.utilities.util.inventory.PlayerHeadUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -125,8 +126,14 @@ public class MenuRecipeBook extends CCWindow {
         NamespacedKey grayBtnKey = playerStore.getLightBackground();
         var recipeBookCache = event.getGuiHandler().getCustomCache().getRecipeBookCache();
         if (recipeBookCache.getSubFolder() == 0) {
-            for (int i = 0; i < 9; i++) {
-                event.setButton(i, playerStore.getDarkBackground());
+            if (customCrafting.getConfigHandler().getConfig().isGUIDrawBackground()) {
+                for (int i = 0; i < 9; i++) {
+                    event.setButton(i, playerStore.getDarkBackground());
+                }
+            } else {
+                for (int i = 0; i < 45; i++) {
+                    event.setButton(i, ClusterMain.EMPTY);
+                }
             }
             List<RecipeContainer> containers = recipeBookCache.getCategory() != null ? recipeBookCache.getCategory().getRecipeList(player, recipeBookCache.getCategoryFilter(), recipeBookCache.getEliteCraftingTable()) : new ArrayList<>();
             int maxPages = containers.size() / 45 + (containers.size() % 45 > 0 ? 1 : 0);
@@ -151,16 +158,18 @@ public class MenuRecipeBook extends CCWindow {
                 event.setButton(51, ClusterRecipeBook.NEXT_PAGE);
             }
         } else {
-            for (int i = 1; i < 9; i++) {
-                event.setButton(i, grayBtnKey);
+            if (customCrafting.getConfigHandler().getConfig().isGUIDrawBackground()) {
+                for (int i = 1; i < 9; i++) {
+                    event.setButton(i, grayBtnKey);
+                }
+                for (int i = 1; i < 9; i++) {
+                    event.setButton(i, grayBtnKey);
+                }
+                for (int i = 36; i < 45; i++) {
+                    event.setButton(i, grayBtnKey);
+                }
             }
             List<CustomRecipe<?>> recipes = recipeBookCache.getSubFolderRecipes();
-            for (int i = 1; i < 9; i++) {
-                event.setButton(i, grayBtnKey);
-            }
-            for (int i = 36; i < 45; i++) {
-                event.setButton(i, grayBtnKey);
-            }
             int maxPages = recipes.size();
             if (recipeBookCache.getSubFolderPage() >= maxPages) {
                 recipeBookCache.setSubFolderPage(0);

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook_editor/EditorMain.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook_editor/EditorMain.java
@@ -25,18 +25,14 @@ package me.wolfyscript.customcrafting.gui.recipebook_editor;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.CCWindow;
+import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
 import me.wolfyscript.customcrafting.utils.PlayerUtil;
 import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
 import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
-import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ActionButton;
-import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
-import org.apache.commons.io.FileUtils;
 import org.bukkit.Material;
-import org.bukkit.util.FileUtil;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 
 public class EditorMain extends CCWindow {
 
@@ -84,7 +80,7 @@ public class EditorMain extends CCWindow {
     @Override
     public void onUpdateAsync(GuiUpdate<CCCache> update) {
         super.onUpdateAsync(update);
-        update.setButton(0, PlayerUtil.getStore(update.getPlayer()).getLightBackground());
+        update.setButton(0, customCrafting.getConfigHandler().getConfig().isGUIDrawBackground() ? PlayerUtil.getStore(update.getPlayer()).getLightBackground() : ClusterMain.EMPTY);
         update.setButton(20, CATEGORIES);
         update.setButton(24, FILTERS);
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,10 @@ debug: false
 # If you have any language file you would like to add to this plugin, then feel free to contact me.
 language: en_US
 
+gui:
+  # Specifies if the background glass panes should be placed into the gui. If disabled things like crafting grids/slots won't be apparent anymore! Best in combination with custom gui textures!
+  draw_background: true
+
 creator:
   # Configure if the stored values and items you put or configured in the GUI should be cleared after saving a recipe.
   reset_after_save: true

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -276,13 +276,14 @@
         "gui_help_on": {
           "name": "<white><b><u>[?] Information</u></b></white>",
           "lore": [
-            "%wolfyutilities.help%"
-          ]
-        },
-        "gui_help_off": {
-          "name": "<white><b><u>[?] Information</u></b></white>",
-          "lore": [
-            "%wolfyutilities.help%"
+            "<grey><list_entry:0></grey>",
+            "<grey><list_entry:1></grey>",
+            "<grey><list_entry:2></grey>",
+            "<grey><list_entry:3></grey>",
+            "<grey><list_entry:4></grey>",
+            "<grey><list_entry:5></grey>",
+            "<grey><list_entry:6></grey>",
+            "<grey><list_entry:7></grey>"
           ]
         },
         "patreon": {
@@ -606,6 +607,26 @@
                   "<grey>[<green>Click</green>] Reset contents after saving</grey>"
                 ]
               }
+            }
+          },
+          "draw_background": {
+            "enabled": {
+              "name": "<grey>\u25A0 </grey><gold><b>Background</b></gold>",
+              "lore": [
+                "<grey>Each GUI Menu has a Glass Pane Background</grey>",
+                "",
+                "<grey>[<green>Click</green>] Disable Glass Pane Background"
+              ]
+            },
+            "disabled": {
+              "name": "<grey>\u25A1 </grey><gold><b>Background</b></gold>",
+              "lore": [
+                "<grey>GUIs don't have any Glass Pane Background!</grey>",
+                "<red>This makes crafting grids and other input slots</red>",
+                "<red>invisible. A Custom Texture Menu should be used!</red>",
+                "",
+                "<grey>[<green>Click</green>] Enable Glass Pane Background"
+              ]
             }
           }
         }

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -3137,7 +3137,7 @@
         }
       },
       "main_menu": {
-        "gui_name": "<grey><b>Recipe Book</b></grey>",
+        "gui_name": "<dark_grey><b>Recipe Book</b></dark_grey>",
         "items": {
           "elite_workbench": {
             "name": "<gold>Elite Crafting Table Recipes</gold>"


### PR DESCRIPTION
Using the new config option `gui.draw_background` you can toggle the background glass panes of all the GUI menus.
Note that the Background is usually used to surround the crafting grid and other input buttons.
That means disabling the background makes them basically invisible. 
This feature is meant for custom textured GUI menus!