### PR TITLE
Recipe Book "Keep Last Open" Toggle option

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/configs/MainConfig.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/MainConfig.java
@@ -90,6 +90,14 @@ public class MainConfig extends YamlConfiguration {
         set("recipe_book.reset", reset);
     }
 
+    public boolean isRecipeBookKeepLastOpen() {
+        return getBoolean("recipe_book.keep_last_open");
+    }
+
+    public void setRecipeBookKeepLastOpen(boolean keepLastOpen) {
+        set("recipe_book.keep_last_open", keepLastOpen);
+    }
+
     public boolean isAdvancedWorkbenchEnabled() {
         return getBoolean("crafting_table.enable");
     }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuSettings.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuSettings.java
@@ -47,6 +47,7 @@ public class MenuSettings extends CCWindow {
     private static final String ADVANCED_CRAFTING_TABLE = "advanced_workbench";
     private static final String DEBUG = "debug";
     private static final String DRAW_BACKGROUND = "draw_background";
+    private static final String RECIPE_BOOK_KEEP_LAST = "recipe_book_keep_last_open";
 
     private static final String ENABLED = "enabled";
     private static final String DISABLED = "disabled";
@@ -118,6 +119,16 @@ public class MenuSettings extends CCWindow {
                     customCrafting.getConfigHandler().getConfig().save();
                     return true;
                 })).register();
+        bb.toggle(RECIPE_BOOK_KEEP_LAST).stateFunction((ccCache, guiHandler, player, guiInventory, i) -> customCrafting.getConfigHandler().getConfig().isRecipeBookKeepLastOpen())
+                .enabledState(state -> state.subKey(ENABLED).icon(Material.KNOWLEDGE_BOOK).action((cache, guiHandler, player, inventory, slot, event) -> {
+                    customCrafting.getConfigHandler().getConfig().setRecipeBookKeepLastOpen(false);
+                    customCrafting.getConfigHandler().getConfig().save();
+                    return true;
+                })).disabledState(state -> state.subKey(DISABLED).icon(Material.KNOWLEDGE_BOOK).action((cache, guiHandler, player, inventory, slot, event) -> {
+                    customCrafting.getConfigHandler().getConfig().setRecipeBookKeepLastOpen(true);
+                    customCrafting.getConfigHandler().getConfig().save();
+                    return true;
+                })).register();
     }
 
     @Override
@@ -143,6 +154,7 @@ public class MenuSettings extends CCWindow {
             event.setButton(13, ButtonSettingsLanguage.KEY);
             event.setButton(14, "creator.reset_after_save");
             event.setButton(15, DRAW_BACKGROUND);
+            event.setButton(16, RECIPE_BOOK_KEEP_LAST);
         }
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/PlayerUtil.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/PlayerUtil.java
@@ -31,6 +31,7 @@ import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.entity.PlayerUtils;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.UUID;
 
 public class PlayerUtil {
@@ -53,6 +54,14 @@ public class PlayerUtil {
         InventoryAPI<CCCache> invAPI = customCrafting.getApi().getInventoryAPI(CCCache.class);
         var categories = customCrafting.getConfigHandler().getRecipeBookConfig();
         var bookCache = invAPI.getGuiHandler(player).getCustomCache().getRecipeBookCache();
+
+        //Reset the pages etc. so it opens up the recipe overview again
+        if (!customCrafting.getConfigHandler().getConfig().isRecipeBookKeepLastOpen()) {
+            bookCache.setResearchItems(new ArrayList<>());
+            bookCache.setSubFolderPage(0);
+            bookCache.setPage(0);
+        }
+
         // Open directly to the category if we only have one
         bookCache.setPrepareRecipe(true);
         if (categories.getSortedCategories().size() == 1) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -89,6 +89,8 @@ crafting_table:
 recipe_book:
   # If the recipe book item should be reset on each server start. This means the config is replaced with a new version.
   reset: true
+  # If closed and opened again, it'll open up the recipe and menu the player last left on.
+  keep_last_open: true
 
 custom_items:
   # Use this option if you have saved CustomItems and your players got them in their inventory. Each time a Player joins the server it will try to update the CustomItems.

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -628,6 +628,26 @@
                 "<grey>[<green>Click</green>] Enable Glass Pane Background"
               ]
             }
+          },
+          "recipe_book_keep_last_open": {
+            "enabled": {
+              "name": "<green>✔ </green><gold><b>Keep Last Open</b></gold>",
+              "lore": [
+                "<grey>When reopening the recipe book it opens</grey>",
+                "<grey>the menu the player last left on.</grey>",
+                "",
+                "<grey>[<green>Click</green>] Disable Keep Last Open"
+              ]
+            },
+            "disabled": {
+              "name": "<red>❌ </red><gold><b>Keep last Open</b></gold>",
+              "lore": [
+                "<grey>When reopening the recipe book it</grey>",
+                "<grey>always opens the recipe overview.</grey>",
+                "",
+                "<grey>[<green>Click</green>] Enable Keep Last Open"
+              ]
+            }
           }
         }
       },


### PR DESCRIPTION
Adds an option `recipe_book.keep_last_open` to change the behaviour when opening the recipe book.
If enabled it keeps the last recipes open when reopened, otherwise always opens the recipe overview.

Resolves #130 – GUI where you were last left on