### PR TITLE
Unfiltered Recipe Book Categories

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/Category.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/Category.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.configs.recipebook;
 
+import com.google.common.base.Preconditions;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.cache.CacheEliteCraftingTable;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
@@ -37,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.jetbrains.annotations.Nullable;
 
 @JsonPropertyOrder({"id", "icon", "name", "description", "auto"})
 public class Category extends CategorySettings {
@@ -75,11 +77,13 @@ public class Category extends CategorySettings {
             return recipe == null ? null : new RecipeContainer(customCrafting, recipe);
         }).filter(Objects::nonNull).toList());
         containers.addAll(recipeContainers.stream().distinct().sorted().toList());
+
         //Index filters for quick filtering on runtime.
         filters.forEach(this::indexFilters);
     }
 
     public void indexFilters(CategoryFilter filter) {
+        Preconditions.checkNotNull(filter, "Filter cannot be null! Cannot filter containers with null Filter!");
         indexedFilters.put(filter, containers.stream().filter(filter::filter).toList());
     }
 
@@ -94,8 +98,15 @@ public class Category extends CategorySettings {
         return getContainers(filter).stream().filter(container -> container.canView(player)).toList();
     }
 
-    private List<RecipeContainer> getContainers(CategoryFilter filter) {
-        return indexedFilters.getOrDefault(filter, new ArrayList<>());
+    /**
+     * Returns the containers that are filtered by the specified filter.<br>
+     * In case no filter is provided or the category hasn't been filtered, then it returns the whole unfiltered list of recipe containers.
+     *
+     * @param filter The filter to get the containers for; or null to get an unfiltered list.
+     * @return The list of filtered containers; or unfiltered list of containers.
+     */
+    private List<RecipeContainer> getContainers(@Nullable CategoryFilter filter) {
+        return !indexedFilters.isEmpty() && filter != null ? indexedFilters.getOrDefault(filter, new ArrayList<>()) : containers;
     }
 
     @JsonGetter("auto")

--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/RecipeBookCache.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/RecipeBookCache.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.data.cache;
 
+import java.util.Optional;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.configs.recipebook.Category;
 import me.wolfyscript.customcrafting.configs.recipebook.CategoryFilter;
@@ -106,8 +107,8 @@ public class RecipeBookCache {
     }
 
     @NotNull
-    public CategoryFilter getCategoryFilter() {
-        return categoryFilter != null ? categoryFilter : customCrafting.getConfigHandler().getRecipeBookConfig().getFilter(0);
+    public Optional<CategoryFilter> getCategoryFilter() {
+        return Optional.ofNullable(categoryFilter != null ? categoryFilter : customCrafting.getConfigHandler().getRecipeBookConfig().getFilter(0));
     }
 
     public void setCategoryFilter(CategoryFilter categoryFilter) {

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ButtonCategoryItem.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ButtonCategoryItem.java
@@ -57,14 +57,16 @@ class ButtonCategoryItem extends Button<CCCache> {
             ButtonContainerRecipeBook.resetButtons(guiHandler);
             if (!recipeBookConfig.getSortedFilters().isEmpty()) {
                 RecipeBookCache bookCache = guiHandler.getCustomCache().getRecipeBookCache();
-                int currentIndex = recipeBookConfig.getSortedFilters().indexOf(bookCache.getCategoryFilter().getId());
-                int nextIndex;
-                if (clickEvent.isLeftClick()) {
-                    nextIndex = currentIndex < recipeBookConfig.getSortedFilters().size() - 1 ? currentIndex + 1 : 0;
-                } else {
-                    nextIndex = currentIndex > 0 ? currentIndex - 1 : recipeBookConfig.getSortedFilters().size() - 1;
-                }
-                bookCache.setCategoryFilter(recipeBookConfig.getFilter(nextIndex));
+                bookCache.getCategoryFilter().ifPresent(categoryFilter -> {
+                    int currentIndex = recipeBookConfig.getSortedFilters().indexOf(categoryFilter.getId());
+                    int nextIndex;
+                    if (clickEvent.isLeftClick()) {
+                        nextIndex = currentIndex < recipeBookConfig.getSortedFilters().size() - 1 ? currentIndex + 1 : 0;
+                    } else {
+                        nextIndex = currentIndex > 0 ? currentIndex - 1 : recipeBookConfig.getSortedFilters().size() - 1;
+                    }
+                    bookCache.setCategoryFilter(recipeBookConfig.getFilter(nextIndex));
+                });
             }
         }
         return true;
@@ -72,7 +74,7 @@ class ButtonCategoryItem extends Button<CCCache> {
 
     @Override
     public void render(GuiHandler<CCCache> guiHandler, Player player, GUIInventory<CCCache> guiInventory, Inventory inventory, ItemStack itemStack, int slot, boolean help) {
-        inventory.setItem(slot, guiHandler.getCustomCache().getRecipeBookCache().getCategoryFilter().createItemStack(customCrafting));
+        guiHandler.getCustomCache().getRecipeBookCache().getCategoryFilter().ifPresent(filter -> inventory.setItem(slot, filter.createItemStack(customCrafting)));
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ButtonContainerRecipeBook.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ButtonContainerRecipeBook.java
@@ -123,7 +123,7 @@ class ButtonContainerRecipeBook extends Button<CCCache> {
                 tasks.computeIfAbsent(guiHandler, thatGuiHandler ->
                         () -> {
                             var newBookCache = thatGuiHandler.getCustomCache().getRecipeBookCache();
-                            if (slot < inventory.getSize() && !displayItems.isEmpty() && openedPage == newBookCache.getPage() && currentFilter.equals(newBookCache.getCategoryFilter())) {
+                            if (slot < inventory.getSize() && !displayItems.isEmpty() && openedPage == newBookCache.getPage() && currentFilter.map(filter -> newBookCache.getCategoryFilter().map(filter::equals).orElse(false)).orElse(true)) {
                                 int variant = getTiming(thatGuiHandler);
                                 variant = variant < displayItems.size() - 1 ? ++variant : 0;
                                 guiInventory.setItem(slot, displayItems.get(variant));

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeBook.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeBook.java
@@ -134,7 +134,7 @@ public class MenuRecipeBook extends CCWindow {
                     event.setButton(i, ClusterMain.EMPTY);
                 }
             }
-            List<RecipeContainer> containers = recipeBookCache.getCategory() != null ? recipeBookCache.getCategory().getRecipeList(player, recipeBookCache.getCategoryFilter(), recipeBookCache.getEliteCraftingTable()) : new ArrayList<>();
+            List<RecipeContainer> containers = recipeBookCache.getCategory() != null ? recipeBookCache.getCategory().getRecipeList(player, recipeBookCache.getCategoryFilter().orElse(null), recipeBookCache.getEliteCraftingTable()) : new ArrayList<>();
             int maxPages = containers.size() / 45 + (containers.size() % 45 > 0 ? 1 : 0);
             if (recipeBookCache.getPage() >= maxPages) {
                 recipeBookCache.setPage(0);


### PR DESCRIPTION
It is now possible to remove all the Category Filters in the Recipe Book configuration without causing issues.
If there are no filters available it'll just simply display all the available recipe containers in a category without trying to filter them.