### PR TITLE
Fixed Missing Recipe Delete Confirm/Delete Messages

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/ButtonContainerRecipeList.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/ButtonContainerRecipeList.java
@@ -118,10 +118,12 @@ class ButtonContainerRecipeList extends Button<CCCache> {
                 }
             } else {
                 window.sendMessage(guiHandler, window.translatedMsgKey("delete.confirm", Placeholder.unparsed("recipe", customRecipe.getNamespacedKey().toString())));
-                window.sendMessage(guiHandler, window.translatedMsgKey("inventories.none.recipe_list.messages.delete.confirmed").clickEvent(window.getChat().executable(player, true, (wolfyUtilities, player1) -> {
+                var confirmComp = window.translatedMsgKey("delete.confirmed").style(b -> b.clickEvent(window.getChat().executable(player, true, (wolfyUtilities, player1) -> {
                     guiHandler.openCluster();
-                    Bukkit.getScheduler().runTaskAsynchronously(customCrafting, () -> customRecipe.delete(player1));
-                })).append(window.translatedMsgKey("inventories.none.recipe_list.messages.delete.declined").clickEvent(window.getChat().executable(player, true, (wolfyUtilities, player1) -> guiHandler.openCluster()))));
+                    Bukkit.getScheduler().runTask(customCrafting, () -> customRecipe.delete(player1));
+                })).hoverEvent(window.translatedMsgKey("delete.confirm_hover")));
+                var declineComp = window.translatedMsgKey("delete.declined").style(b -> b.clickEvent(window.getChat().executable(player, true, (wolfyUtilities, player1) -> guiHandler.openCluster())).hoverEvent(window.translatedMsgKey("delete.decline_hover")));
+                window.sendMessage(guiHandler, confirmComp.append(Component.text(" – ")).append(declineComp));
             }
         } else if (customRecipe != null) {
             customCrafting.getDisableRecipesHandler().toggleRecipe(customRecipe);

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -484,8 +484,10 @@
           "invalid_recipe": "<red>This recipe is not from type %recipe_type%!</red>",
           "delete": {
             "confirm": "<yellow>Do you really want to delete <gold>%recipe%?</gold></yellow>",
-            "confirmed": "<grey>[<green>YES</green>]</grey>  ",
-            "declined": "<grey>[<red>NO</red>]</grey>"
+            "confirmed": "<grey>[<green>YES</green>]</grey>",
+            "confirm_hover": "<green>Yes, delete the recipe!</green>",
+            "declined": "<grey>[<red>NO</red>]</grey>",
+            "decline_hover": "<red>No, do not delete the recipe!</red>"
           }
         }
       },


### PR DESCRIPTION
Fixed missing recipe delete confirm/decline chat messages.
Added extra hover text to indicate what you are about to click.