### PR TITLE
ProtocolLib v4 and v5 Cross Compatibility 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>4.8.0</version>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.7.0</version>
+            <version>5.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>

--- a/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
@@ -113,7 +113,7 @@ import me.wolfyscript.customcrafting.utils.CraftManager;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.customcrafting.utils.UpdateChecker;
 import me.wolfyscript.customcrafting.utils.cooking.CookingManager;
-import me.wolfyscript.customcrafting.utils.other_plugins.OtherPlugins;
+import me.wolfyscript.customcrafting.compatibility.OtherPlugins;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIncludeProperties;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializationFeature;
 import me.wolfyscript.lib.net.kyori.adventure.text.Component;

--- a/src/main/java/me/wolfyscript/customcrafting/compatibility/OtherPlugins.java
+++ b/src/main/java/me/wolfyscript/customcrafting/compatibility/OtherPlugins.java
@@ -20,9 +20,10 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package me.wolfyscript.customcrafting.utils.other_plugins;
+package me.wolfyscript.customcrafting.compatibility;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
+import me.wolfyscript.customcrafting.compatibility.protocollib.ProtocolLib;
 import me.wolfyscript.customcrafting.placeholderapi.PlaceHolder;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import org.bukkit.Bukkit;

--- a/src/main/java/me/wolfyscript/customcrafting/compatibility/protocollib/CrossCompFunction.java
+++ b/src/main/java/me/wolfyscript/customcrafting/compatibility/protocollib/CrossCompFunction.java
@@ -1,0 +1,31 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.compatibility.protocollib;
+
+import java.util.function.UnaryOperator;
+
+public abstract class CrossCompFunction<T> implements UnaryOperator<T>, java.util.function.Function<T, T> {
+
+    @Override
+    public abstract T apply(T s);
+}

--- a/src/main/java/me/wolfyscript/customcrafting/compatibility/protocollib/CrossCompFunction.java
+++ b/src/main/java/me/wolfyscript/customcrafting/compatibility/protocollib/CrossCompFunction.java
@@ -24,8 +24,9 @@ package me.wolfyscript.customcrafting.compatibility.protocollib;
 
 import java.util.function.UnaryOperator;
 
-public abstract class CrossCompFunction<T> implements UnaryOperator<T>, java.util.function.Function<T, T> {
+@FunctionalInterface
+public interface CrossCompFunction<T> extends UnaryOperator<T>, com.google.common.base.Function<T, T> {
 
     @Override
-    public abstract T apply(T s);
+    T apply(T s);
 }

--- a/src/main/java/me/wolfyscript/customcrafting/compatibility/protocollib/ProtocolLib.java
+++ b/src/main/java/me/wolfyscript/customcrafting/compatibility/protocollib/ProtocolLib.java
@@ -84,18 +84,8 @@ public class ProtocolLib {
             }
             return true;
         };
-        CrossCompFunction<List<MinecraftKey>> filterRecipeKeys = new CrossCompFunction<>() {
-            @Override
-            public List<MinecraftKey> apply(List<MinecraftKey> input) {
-                return filterAndAddMissingRecipes(input);
-            }
-        };
-        CrossCompFunction<List<RecipeWrapper>> filterWrappedRecipes = new CrossCompFunction<>() {
-            @Override
-            public List<RecipeWrapper> apply(List<RecipeWrapper> input) {
-                return input.stream().filter(recipeWrapper -> recipeFilter.apply(recipeWrapper.getKey())).collect(Collectors.toList());
-            }
-        };
+        CrossCompFunction<List<MinecraftKey>> filterRecipeKeys = this::filterAndAddMissingRecipes;
+        CrossCompFunction<List<RecipeWrapper>> filterWrappedRecipes = input -> input.stream().filter(recipeWrapper -> recipeFilter.apply(recipeWrapper.getKey())).collect(Collectors.toList());
         // Recipe packet that sends the discovered recipes to the client.
         protocolManager.addPacketListener(new PacketAdapter(customCrafting, ListenerPriority.HIGH, PacketType.Play.Server.RECIPES) {
             @Override


### PR DESCRIPTION
ProtocolLib had a few breaking changes, that caused NoSuchMethod exceptions when players were joining.

This adds a new CrossCompFunction that can be used in either v4 and v5.
The plugin must be compiled using 4.8.0 though.

Resolves #153 - ProtocolLib: Error When Players Join