### PR TITLE
Toggle Auto Recipe Discover On Player Login

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCache.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCache.java
@@ -45,6 +45,7 @@ public abstract class RecipeCache<R extends CustomRecipe<?>> {
     protected boolean checkAllNBT;
     protected boolean hidden;
     protected boolean vanillaBook;
+    protected boolean autoDiscover;
 
     protected RecipePriority priority;
     protected Conditions conditions;
@@ -121,6 +122,14 @@ public abstract class RecipeCache<R extends CustomRecipe<?>> {
         return vanillaBook;
     }
 
+    public void setAutoDiscover(boolean autoDiscover) {
+        this.autoDiscover = autoDiscover;
+    }
+
+    public boolean isAutoDiscover() {
+        return autoDiscover;
+    }
+
     public RecipePriority getPriority() {
         return priority;
     }
@@ -178,6 +187,7 @@ public abstract class RecipeCache<R extends CustomRecipe<?>> {
         recipe.setPriority(priority);
         if (recipe instanceof ICustomVanillaRecipe<?> vanillaRecipe) {
             vanillaRecipe.setVisibleVanillaBook(vanillaBook);
+            vanillaRecipe.setAutoDiscover(autoDiscover);
         }
         return recipe;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/ClusterRecipeCreator.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/ClusterRecipeCreator.java
@@ -24,6 +24,7 @@ package me.wolfyscript.customcrafting.gui.recipe_creator;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
+import me.wolfyscript.customcrafting.data.cache.recipe_creator.RecipeCache;
 import me.wolfyscript.customcrafting.gui.CCCluster;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
@@ -137,10 +138,35 @@ public class ClusterRecipeCreator extends CCCluster {
                     StringUtil.copyPartialMatches(args[0], customCrafting.getRegistries().getRecipes().groups(), results);
                     return results;
                 }).register();
+        getButtonBuilder().multiChoice(VANILLA_BOOK.getKey())
+                // State: vanilla = true, auto_discover = true
+                .addState(state -> state.subKey("vanilla_book_discover").icon(Material.GRASS_BLOCK).action((cache, handler, player, inventory, i, event) -> {
+                    cache.getRecipeCreatorCache().getRecipeCache().setVanillaBook(true);
+                    cache.getRecipeCreatorCache().getRecipeCache().setAutoDiscover(false);
+                    return true;
+                }))
+                // State: vanilla = true, auto_discover = false
+                .addState(state -> state.subKey("vanilla_book_no_discover").icon(Material.GRASS_BLOCK).action((cache, handler, player, inventory, i, event) -> {
+                    cache.getRecipeCreatorCache().getRecipeCache().setVanillaBook(false);
+                    cache.getRecipeCreatorCache().getRecipeCache().setAutoDiscover(false);
+                    return true;
+                }))
+                // State: vanilla = false, auto_discover = false
+                .addState(state -> state.subKey("no_vanilla_book").icon(Material.GRASS_BLOCK).action((cache, handler, player, inventory, i, event) -> {
+                    cache.getRecipeCreatorCache().getRecipeCache().setVanillaBook(true);
+                    cache.getRecipeCreatorCache().getRecipeCache().setAutoDiscover(true);
+                    return true;
+                }))
+                .stateFunction((cache, guiHandler, player, inventory, i) -> {
+                    RecipeCache<?> recipeCache = cache.getRecipeCreatorCache().getRecipeCache();
+                    if (recipeCache.isVanillaBook() && recipeCache.isAutoDiscover()) {
+                        return 0;
+                    }
+                    return recipeCache.isVanillaBook() ? 1 : 2;
+                }).register();
         registerButton(new ButtonExactMeta());
         registerButton(new ButtonPriority());
         registerButton(new ButtonHidden());
-        registerButton(new ButtonVanillaBook());
         registerSaveButtons();
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/ClusterRecipeCreator.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/ClusterRecipeCreator.java
@@ -32,6 +32,8 @@ import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Plac
 import me.wolfyscript.utilities.api.inventory.gui.InventoryAPI;
 import me.wolfyscript.utilities.api.inventory.gui.button.CallbackButtonRender;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.version.ServerVersion;
+import me.wolfyscript.utilities.util.version.WUVersion;
 import org.bukkit.Material;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.util.StringUtil;
@@ -138,32 +140,38 @@ public class ClusterRecipeCreator extends CCCluster {
                     StringUtil.copyPartialMatches(args[0], customCrafting.getRegistries().getRecipes().groups(), results);
                     return results;
                 }).register();
-        getButtonBuilder().multiChoice(VANILLA_BOOK.getKey())
-                // State: vanilla = true, auto_discover = true
-                .addState(state -> state.subKey("vanilla_book_discover").icon(Material.GRASS_BLOCK).action((cache, handler, player, inventory, i, event) -> {
-                    cache.getRecipeCreatorCache().getRecipeCache().setVanillaBook(true);
-                    cache.getRecipeCreatorCache().getRecipeCache().setAutoDiscover(false);
-                    return true;
-                }))
-                // State: vanilla = true, auto_discover = false
-                .addState(state -> state.subKey("vanilla_book_no_discover").icon(Material.GRASS_BLOCK).action((cache, handler, player, inventory, i, event) -> {
-                    cache.getRecipeCreatorCache().getRecipeCache().setVanillaBook(false);
-                    cache.getRecipeCreatorCache().getRecipeCache().setAutoDiscover(false);
-                    return true;
-                }))
-                // State: vanilla = false, auto_discover = false
-                .addState(state -> state.subKey("no_vanilla_book").icon(Material.GRASS_BLOCK).action((cache, handler, player, inventory, i, event) -> {
-                    cache.getRecipeCreatorCache().getRecipeCache().setVanillaBook(true);
-                    cache.getRecipeCreatorCache().getRecipeCache().setAutoDiscover(true);
-                    return true;
-                }))
-                .stateFunction((cache, guiHandler, player, inventory, i) -> {
-                    RecipeCache<?> recipeCache = cache.getRecipeCreatorCache().getRecipeCache();
-                    if (recipeCache.isVanillaBook() && recipeCache.isAutoDiscover()) {
-                        return 0;
-                    }
-                    return recipeCache.isVanillaBook() ? 1 : 2;
-                }).register();
+
+        if (ServerVersion.getWUVersion().isAfterOrEq(WUVersion.of(4, 16, 6, 1))) {
+            getButtonBuilder().multiChoice(VANILLA_BOOK.getKey())
+                    // State: vanilla = true, auto_discover = true
+                    .addState(state -> state.subKey("vanilla_book_discover").icon(Material.GRASS_BLOCK).action((cache, handler, player, inventory, i, event) -> {
+                        cache.getRecipeCreatorCache().getRecipeCache().setVanillaBook(true);
+                        cache.getRecipeCreatorCache().getRecipeCache().setAutoDiscover(false);
+                        return true;
+                    }))
+                    // State: vanilla = true, auto_discover = false
+                    .addState(state -> state.subKey("vanilla_book_no_discover").icon(Material.GRASS_BLOCK).action((cache, handler, player, inventory, i, event) -> {
+                        cache.getRecipeCreatorCache().getRecipeCache().setVanillaBook(false);
+                        cache.getRecipeCreatorCache().getRecipeCache().setAutoDiscover(false);
+                        return true;
+                    }))
+                    // State: vanilla = false, auto_discover = false
+                    .addState(state -> state.subKey("no_vanilla_book").icon(Material.GRASS_BLOCK).action((cache, handler, player, inventory, i, event) -> {
+                        cache.getRecipeCreatorCache().getRecipeCache().setVanillaBook(true);
+                        cache.getRecipeCreatorCache().getRecipeCache().setAutoDiscover(true);
+                        return true;
+                    }))
+                    .stateFunction((cache, guiHandler, player, inventory, i) -> {
+                        RecipeCache<?> recipeCache = cache.getRecipeCreatorCache().getRecipeCache();
+                        if (recipeCache.isVanillaBook() && recipeCache.isAutoDiscover()) {
+                            return 0;
+                        }
+                        return recipeCache.isVanillaBook() ? 1 : 2;
+                    }).register();
+        } else {
+            registerButton(new ButtonVanillaBook());
+        }
+
         registerButton(new ButtonExactMeta());
         registerButton(new ButtonPriority());
         registerButton(new ButtonHidden());

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/CraftListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/CraftListener.java
@@ -164,7 +164,7 @@ public class CraftListener implements Listener {
         var player = event.getPlayer();
         List<org.bukkit.NamespacedKey> discoveredCustomRecipes = player.getDiscoveredRecipes().stream().filter(namespacedKey -> namespacedKey.getNamespace().equals(NamespacedKeyUtils.NAMESPACE)).toList();
         customCrafting.getRegistries().getRecipes().getAvailable(player).stream()
-                .filter(recipe -> recipe instanceof ICustomVanillaRecipe<?>)
+                .filter(recipe -> recipe instanceof ICustomVanillaRecipe<?> vanillaRecipe && vanillaRecipe.isAutoDiscover())
                 .map(recipe -> new org.bukkit.NamespacedKey(recipe.getNamespacedKey().getNamespace(), recipe.getNamespacedKey().getKey()))
                 .filter(namespacedKey -> !discoveredCustomRecipes.contains(namespacedKey))
                 .forEach(player::discoverRecipe);

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
@@ -83,4 +83,14 @@ public class CraftingRecipeShaped extends AbstractRecipeShaped<CraftingRecipeSha
     public void setVisibleVanillaBook(boolean vanillaBook) {
         this.vanillaBook = vanillaBook;
     }
+
+    @Override
+    public boolean isAutoDiscover() {
+        return autoDiscover;
+    }
+
+    @Override
+    public void setAutoDiscover(boolean autoDiscover) {
+        this.autoDiscover = autoDiscover;
+    }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
@@ -80,4 +80,14 @@ public class CraftingRecipeShapeless extends AbstractRecipeShapeless<CraftingRec
     public void setVisibleVanillaBook(boolean vanillaBook) {
         this.vanillaBook = vanillaBook;
     }
+
+    @Override
+    public boolean isAutoDiscover() {
+        return autoDiscover;
+    }
+
+    @Override
+    public void setAutoDiscover(boolean autoDiscover) {
+        this.autoDiscover = autoDiscover;
+    }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -80,6 +80,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     protected static final String KEY_RESULT = "result";
     protected static final String KEY_GROUP = "group";
     protected static final String KEY_VANILLA_BOOK = "vanillaBook";
+    protected static final String KEY_AUTO_DISCOVER = "autoDiscover";
     protected static final String KEY_PRIORITY = "priority";
     protected static final String KEY_EXACT_META = "exactItemMeta";
     protected static final String KEY_CONDITIONS = "conditions";
@@ -101,6 +102,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     protected boolean checkAllNBT;
     protected boolean hidden;
     protected boolean vanillaBook;
+    protected boolean autoDiscover;
     protected RecipePriority priority;
     protected Conditions conditions;
     protected String group;
@@ -126,6 +128,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
             this.conditions = new Conditions(customCrafting);
         }
         this.vanillaBook = node.path(KEY_VANILLA_BOOK).asBoolean(true);
+        this.autoDiscover = node.path(KEY_VANILLA_BOOK).asBoolean(true);
         this.hidden = node.path(KEY_HIDDEN).asBoolean(false);
         //Sets the result of the recipe if one exists in the config
         if (node.has(KEY_RESULT) && !(this instanceof CustomRecipeStonecutter)) {
@@ -151,6 +154,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
         this.priority = RecipePriority.NORMAL;
         this.checkAllNBT = false;
         this.vanillaBook = true;
+        this.autoDiscover = true;
         this.conditions = new Conditions(customCrafting);
         this.hidden = false;
     }
@@ -169,6 +173,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
         this.namespacedKey = Objects.requireNonNull(customRecipe.namespacedKey, ERROR_MSG_KEY);
 
         this.vanillaBook = customRecipe.vanillaBook;
+        this.autoDiscover = customRecipe.autoDiscover;
         this.group = customRecipe.group;
         this.priority = customRecipe.priority;
         this.checkAllNBT = customRecipe.checkAllNBT;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
@@ -187,4 +187,14 @@ public abstract class CustomRecipeCooking<C extends CustomRecipeCooking<C, T>, T
     public void setVisibleVanillaBook(boolean vanillaBook) {
         this.vanillaBook = vanillaBook;
     }
+
+    @Override
+    public boolean isAutoDiscover() {
+        return autoDiscover;
+    }
+
+    @Override
+    public void setAutoDiscover(boolean autoDiscover) {
+        this.autoDiscover = autoDiscover;
+    }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
@@ -169,4 +169,14 @@ public class CustomRecipeStonecutter extends CustomRecipe<CustomRecipeStonecutte
     public void setVisibleVanillaBook(boolean vanillaBook) {
         this.vanillaBook = vanillaBook;
     }
+
+    @Override
+    public boolean isAutoDiscover() {
+        return autoDiscover;
+    }
+
+    @Override
+    public void setAutoDiscover(boolean autoDiscover) {
+        this.autoDiscover = autoDiscover;
+    }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/ICustomVanillaRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/ICustomVanillaRecipe.java
@@ -36,4 +36,10 @@ public interface ICustomVanillaRecipe<T extends Recipe> {
     @JsonIgnore
     void setVisibleVanillaBook(boolean vanillaBook);
 
+    @JsonIgnore
+    boolean isAutoDiscover();
+
+    @JsonIgnore
+    void setAutoDiscover(boolean autoDiscover);
+
 }

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -1826,19 +1826,30 @@
           }
         },
         "vanilla_book": {
-          "enabled": {
-            "name": "<green>✔ </green><gold><b>Vanilla Recipe Book</b></gold>",
+          "vanilla_book_discover": {
+            "name": "<grey><b>\u274F </b></grey><gold><b>Vanilla Recipe Book & Auto Discover</b></gold>",
             "lore": [
               "<yellow>Recipe will be visible in the vanilla</yellow>",
-              "<yellow>recipe book. </yellow>",
+              "<yellow>recipe book and auto discovered on join! </yellow>",
+              "<red>NBT for ingredients will not be displayed & </red>",
+              "<red>ignored by the auto-completion!</red>",
+              "",
+              "<dark_grey>[<green>Click</green>]</dark_grey> <yellow>Disable Auto Discover</yellow>"
+            ]
+          },
+          "vanilla_book_no_discover" : {
+            "name": "<grey><b>\u274F </b></grey><gold><b>Vanilla Recipe Book</b></gold>",
+            "lore": [
+              "<yellow>Recipe will be visible in the vanilla</yellow>",
+              "<yellow>recipe book, but auto discovered!</yellow>",
               "<red>NBT for ingredients will not be displayed & </red>",
               "<red>ignored by the auto-completion!</red>",
               "",
               "<dark_grey>[<green>Click</green>]</dark_grey> <yellow>Disable Vanilla Recipe Book</yellow>"
             ]
           },
-          "disabled": {
-            "name": "<dark_red>❌ </dark_red><gold><b>Vanilla Recipe Book</b></gold>",
+          "no_vanilla_book": {
+            "name": "<grey><b>\u274F </b></grey><gold><b>No Vanilla Recipe Book</b></gold>",
             "lore": [
               "<yellow>Recipe is not visible in the vanilla</yellow>",
               "<yellow>recipe book. </yellow>",

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -1841,7 +1841,7 @@
             "name": "<grey><b>\u274F </b></grey><gold><b>Vanilla Recipe Book</b></gold>",
             "lore": [
               "<yellow>Recipe will be visible in the vanilla</yellow>",
-              "<yellow>recipe book, but auto discovered!</yellow>",
+              "<yellow>recipe book.</yellow>",
               "<red>NBT for ingredients will not be displayed & </red>",
               "<red>ignored by the auto-completion!</red>",
               "",
@@ -1854,7 +1854,7 @@
               "<yellow>Recipe is not visible in the vanilla</yellow>",
               "<yellow>recipe book. </yellow>",
               "",
-              "<dark_grey>[<green>Click</green>]</dark_grey> <yellow>Enable Vanilla Recipe Book</yellow>"
+              "<dark_grey>[<green>Click</green>]</dark_grey> <yellow>Enable Vanilla Recipe Book & Auto Discover</yellow>"
             ]
           }
         },


### PR DESCRIPTION
Adds a new option to each recipe to disable it from being automatically discovered when a player joins the server.

The Vanilla Recipe Book Button in the Recipe Creator was replaced with a new multi choice button that toggles between three states:
* Visible in Vanilla Recipe Book & Auto Discover
* Visible in Vanilla Recipe Book (no auto discover)
* Not visible in Vanilla Recipe (no auto discover, obviously) 