### PR TITLE
Recipe Book: Configuarable Recipe Type Titles

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/configs/MainConfig.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/MainConfig.java
@@ -23,6 +23,7 @@
 package me.wolfyscript.customcrafting.configs;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
+import me.wolfyscript.customcrafting.recipes.RecipeType;
 import me.wolfyscript.utilities.api.config.ConfigAPI;
 import me.wolfyscript.utilities.api.config.YamlConfiguration;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -40,6 +41,10 @@ public class MainConfig extends YamlConfiguration {
 
     @Override
     public void init() {
+    }
+
+    public String getRecipeBookTypeName(RecipeType<?> recipeType) {
+        return getString("recipe_book.recipe_type_titles." + recipeType.getId());
     }
 
     public boolean isGUIDrawBackground() {

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeOverview.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeOverview.java
@@ -44,6 +44,7 @@ import me.wolfyscript.utilities.api.inventory.gui.button.CallbackButtonRender;
 import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.PlayerHeadUtils;
+import me.wolfyscript.utilities.util.reflection.InventoryUpdate;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -171,6 +172,7 @@ public class MenuRecipeOverview extends CCWindow {
                     //A new prepare can be queued by using book.setPrepareRecipe(true)
                     recipeBookCache.applyRecipeToButtons(event.getGuiHandler(), customRecipe);
                     recipeBookCache.setPrepareRecipe(false);
+                    InventoryUpdate.updateInventory(wolfyUtilities.getCore(), player, onUpdateTitle(player, event.getInventory(), event.getGuiHandler()));
                 }
                 customRecipe.renderMenu(this, event);
                 boolean elite = RecipeType.Container.ELITE_CRAFTING.isInstance(customRecipe);

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuSingleRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuSingleRecipe.java
@@ -22,21 +22,28 @@
 
 package me.wolfyscript.customcrafting.gui.recipebook;
 
+import com.wolfyscript.utilities.bukkit.TagResolverUtil;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.data.CCPlayerData;
 import me.wolfyscript.customcrafting.gui.CCWindow;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.customcrafting.utils.PlayerUtil;
+import me.wolfyscript.lib.net.kyori.adventure.text.Component;
+import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.Tag;
+import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
 import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryView;
 
 import java.util.Optional;
+import org.jetbrains.annotations.Nullable;
 
 public class MenuSingleRecipe extends CCWindow {
 
@@ -49,6 +56,22 @@ public class MenuSingleRecipe extends CCWindow {
     @Override
     public void onInit() {
 
+    }
+    @Override
+    public Component onUpdateTitle(Player player, @Nullable GUIInventory<CCCache> inventory, GuiHandler<CCCache> guiHandler) {
+        Optional<CustomRecipe<?>> recipeOptional = guiHandler.getCustomCache().getCacheRecipeView().getRecipe();
+        if (recipeOptional.isPresent()) {
+            CustomRecipe<?> customRecipe = recipeOptional.get();
+            final TagResolver papiResolver = TagResolverUtil.papi(player);
+            final TagResolver langResolver = TagResolver.resolver("translate", (args, context) -> {
+                String text = args.popOr("The <translate> tag requires exactly one argument! The path to the language entry!").value();
+                return Tag.selfClosingInserting(getChat().translated(text, papiResolver));
+            });
+            String text = customCrafting.getConfigHandler().getConfig().getRecipeBookTypeName(customRecipe.getRecipeType());
+            TagResolver recipeTypeTitle = Placeholder.component("recipe_type_title", getChat().getMiniMessage().deserialize(text, papiResolver, langResolver));
+            return wolfyUtilities.getLanguageAPI().getComponent("inventories." + getNamespacedKey().getNamespace() + "." + getNamespacedKey().getKey() + ".gui_name", recipeTypeTitle, TagResolverUtil.papi(player));
+        }
+        return super.onUpdateTitle(player, inventory, guiHandler);
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -91,6 +91,22 @@ recipe_book:
   reset: true
   # If closed and opened again, it'll open up the recipe and menu the player last left on.
   keep_last_open: true
+  # The title of the single recipe menu
+  recipe_type_titles:
+    crafting_shaped: "<translate:recipe.type.crafting.crafting_shaped>"
+    crafting_shapeless: "<translate:recipe.type.crafting.crafting_shapeless>"
+    elite_crafting_shaped: "<translate:recipe.type.crafting.elite_crafting_shaped>"
+    elite_crafting_shapeless: "<translate:recipe.type.crafting.crafting_shaped>"
+    furnace: "<translate:recipe.type.cooking.furnace>"
+    blast_furnace: "<translate:recipe.type.cooking.blast_furnace>"
+    smoker: "<translate:recipe.type.cooking.smoker>"
+    campfire: "<translate:recipe.type.cooking.campfire>"
+    smithing: "<translate:recipe.type.smithing>"
+    anvil: "<translate:recipe.type.anvil>"
+    cauldron: "<translate:recipe.type.cauldron>"
+    stonecutter: "<translate:recipe.type.stonecutter>"
+    grindstone: "<translate:recipe.type.grindstone>"
+    brewing_stand: "<translate:recipe.type.brewing_stand>"
 
 custom_items:
   # Use this option if you have saved CustomItems and your players got them in their inventory. Each time a Player joins the server it will try to update the CustomItems.

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -3260,7 +3260,7 @@
         }
       },
       "recipe_book": {
-        "gui_name": "<dark_grey><b><recipe_type_title></b></dark_grey>",
+        "gui_name": "<recipe_type_title>",
         "items": {
           "next_recipe": {
             "name": "<grey><b>» Next</b></grey>",
@@ -3285,7 +3285,7 @@
     },
     "recipe_view": {
       "single_recipe": {
-        "gui_name": "<dark_grey><b>Recipe Book</b></dark_grey>"
+        "gui_name": "<recipe_type_title>"
       }
     },
     "recipe_book_editor": {

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -65,6 +65,30 @@
       }
     }
   },
+  "recipe": {
+    "type": {
+      "crafting" : {
+        "crafting_shaped": "Shaped Crafting Recipe",
+        "crafting_shapeless": "Shapeless Crafting Recipe"
+      },
+      "elite_crafting" : {
+        "elite_crafting_shaped": "Shaped Elite Crafting Recipe",
+        "elite_crafting_shapeless": "Shapeless Elite Crafting Recipe"
+      },
+      "cooking" : {
+        "furnace": "Smelting Recipe",
+        "blast_furnace": "Blasting Recipe",
+        "smoker": "Smoking Recipe",
+        "campfire": "Campfire Recipe"
+      },
+      "brewing_stand" : "Brewing Recipe",
+      "anvil" : "Anvil Recipe",
+      "stonecutter" : "Stonecutter Recipe",
+      "grindstone" : "Grindstone Recipe",
+      "smithing" : "Smithing Recipe",
+      "cauldron" : "Cauldron Recipe"
+    }
+  },
   "msg": {
     "auto_save": {
       "start": "   Auto save data   ",
@@ -3236,7 +3260,7 @@
         }
       },
       "recipe_book": {
-        "gui_name": "<dark_grey><b>Recipe Book</b></dark_grey>",
+        "gui_name": "<dark_grey><b><recipe_type_title></b></dark_grey>",
         "items": {
           "next_recipe": {
             "name": "<grey><b>» Next</b></grey>",


### PR DESCRIPTION
With this update the menu to view recipes uses type specific titles instead of the generic "Recipe Book" title.
Those titles can be configured in the config. The default will fetch the type name from the language file.

```yml
recipe_book:
  recipe_type_titles:
    crafting_shaped: <translate:recipe.type.crafting.crafting_shaped>
    crafting_shapeless: <translate:recipe.type.crafting.crafting_shapeless>
    elite_crafting_shaped: <translate:recipe.type.crafting.elite_crafting_shaped>
    elite_crafting_shapeless: <translate:recipe.type.crafting.crafting_shaped>
    furnace: <translate:recipe.type.cooking.furnace>
    blast_furnace: <translate:recipe.type.cooking.blast_furnace>
    smoker: <translate:recipe.type.cooking.smoker>
    campfire: <translate:recipe.type.cooking.campfire>
    smithing: <translate:recipe.type.smithing>
    anvil: <translate:recipe.type.anvil>
    cauldron: <translate:recipe.type.cauldron>
    stonecutter: <translate:recipe.type.stonecutter>
    grindstone: <translate:recipe.type.grindstone>
    brewing_stand: <translate:recipe.type.brewing_stand>
``` 