### PR TITLE
Keep Shaped Crafting Recipes As Is

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
@@ -63,7 +63,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-@JsonPropertyOrder(value = {"@type", "group", "hidden", "vanillaBook", "priority", "checkNBT", "conditions", "symmetry", "shape", "ingredients"})
+@JsonPropertyOrder(value = {"@type", "group", "hidden", "vanillaBook", "priority", "checkNBT", "conditions", "symmetry", "keepShapeAsIs", "shape", "ingredients"})
 public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>, S extends CraftingRecipeSettings<S>> extends CraftingRecipe<C, S> {
 
     private static final String SHAPE_KEY = "shape";
@@ -75,6 +75,7 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
     protected Map<Character, Ingredient> mappedIngredients;
     @JsonIgnore
     private Shape internalShape;
+    private boolean keepShapeAsIs = false;
     private String[] shape;
     private final Symmetry symmetry;
 
@@ -92,19 +93,21 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
         setIngredients(loadedIngredients);
     }
 
-    protected AbstractRecipeShaped(NamespacedKey key, CustomCrafting customCrafting, Symmetry symmetry, String[] shape, int gridSize, S settings) {
-        this(key, customCrafting, symmetry, gridSize, settings);
+    protected AbstractRecipeShaped(NamespacedKey key, CustomCrafting customCrafting, Symmetry symmetry, boolean keepShapeAsIs, String[] shape, int gridSize, S settings) {
+        this(key, customCrafting, symmetry, keepShapeAsIs, gridSize, settings);
         setShape(shape);
     }
 
-    protected AbstractRecipeShaped(NamespacedKey key, CustomCrafting customCrafting, Symmetry symmetry, int gridSize, S settings) {
+    protected AbstractRecipeShaped(NamespacedKey key, CustomCrafting customCrafting, Symmetry symmetry, boolean keepShapeAsIs, int gridSize, S settings) {
         super(key, customCrafting, gridSize, settings);
+        this.keepShapeAsIs = keepShapeAsIs;
         this.symmetry = symmetry;
         this.mappedIngredients = new HashMap<>();
     }
 
     protected AbstractRecipeShaped(AbstractRecipeShaped<C, S> recipe) {
         super(recipe);
+        this.keepShapeAsIs = recipe.keepShapeAsIs;
         this.symmetry = recipe.symmetry.copy();
         this.mappedIngredients = new HashMap<>();
         setShape(recipe.shape.clone());
@@ -149,6 +152,10 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
         return shape;
     }
 
+    public boolean isKeepShapeAsIs() {
+        return keepShapeAsIs;
+    }
+
     /**
      * Sets the shape of the recipe and generates all the possible variations based on the mirror settings.<br>
      * <br>
@@ -169,7 +176,7 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
             Preconditions.checkArgument(currentWidth == -1 || currentWidth == row.length(), "Shape must be rectangular!");
             currentWidth = row.length();
         }
-        this.shape = RecipeUtil.formatShape(shape).toArray(new String[0]);
+        this.shape = keepShapeAsIs ? shape : RecipeUtil.formatShape(shape).toArray(new String[0]);
         var flattenShape = String.join("", this.shape);
         Preconditions.checkArgument(!flattenShape.isEmpty() && !flattenShape.isBlank(), "Shape must not be empty! (Shape: \"" + Arrays.toString(this.shape) + "\")!");
         Map<Character, Ingredient> newIngredients = new HashMap<>();
@@ -257,7 +264,10 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
 
     @Override
     public boolean fitsDimensions(@NotNull CraftManager.MatrixData matrixData) {
-        return ingredients.size() == matrixData.getMatrix().length && internalShape.height == matrixData.getHeight() && internalShape.width == matrixData.getWidth();
+        if (keepShapeAsIs) {
+            return ingredients.size() == matrixData.getOriginalMatrix().length && internalShape.getHeight() == matrixData.getGridSize() && internalShape.getWidth() == matrixData.getGridSize();
+        }
+        return ingredients.size() == matrixData.getMatrix().length && internalShape.getHeight() == matrixData.getHeight() && internalShape.getWidth() == matrixData.getWidth();
     }
 
     @Override
@@ -272,7 +282,8 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
     protected CraftingData checkShape(@NotNull CraftManager.MatrixData matrixData, int[] shape) {
         Map<Integer, IngredientData> dataMap = new HashMap<>();
         var i = 0;
-        for (ItemStack invItem : matrixData.getMatrix()) {
+        ItemStack[] matrix = keepShapeAsIs ? matrixData.getOriginalMatrix() : matrixData.getMatrix();
+        for (ItemStack invItem : matrix) {
             int recipeSlot = shape[i];
             if (invItem != null) {
                 if (recipeSlot >= 0) {
@@ -281,9 +292,15 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
                         Optional<CustomItem> item = ingredient.check(invItem, this.checkAllNBT);
                         if (item.isPresent()) {
                             //In order to index the ingredients for the correct inventory slot we need to reverse the shape offset.
-                            int row = i / getInternalShape().getWidth();
-                            int offset = matrixData.getOffsetX() + (matrixData.getOffsetY() * matrixData.getGridSize());
-                            dataMap.put(i + offset + (row * (matrixData.getGridSize() - matrixData.getWidth())), new IngredientData(recipeSlot, ingredient, item.get(), new ItemStack(invItem)));
+                            int estimatedSlot;
+                            if (keepShapeAsIs) {
+                                estimatedSlot = i;
+                            } else {
+                                int row = i / getInternalShape().getWidth();
+                                int offset = keepShapeAsIs ? 0 : matrixData.getOffsetX() + (matrixData.getOffsetY() * matrixData.getGridSize());
+                                estimatedSlot = i + offset + (row * (matrixData.getGridSize() - matrixData.getWidth()));
+                            }
+                            dataMap.put(estimatedSlot, new IngredientData(recipeSlot, ingredient, item.get(), new ItemStack(invItem)));
                             i++;
                             continue;
                         }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShaped.java
@@ -37,13 +37,13 @@ public class CraftingRecipeEliteShaped extends AbstractRecipeShaped<CraftingReci
     }
 
     @JsonCreator
-    public CraftingRecipeEliteShaped(@JsonProperty("key") @JacksonInject("key") NamespacedKey key, @JacksonInject("customcrafting") CustomCrafting customCrafting, @JsonProperty("symmetry") Symmetry symmetry, @JsonProperty("shape") String[] shape) {
-        super(key, customCrafting, symmetry, shape, 6, new EliteRecipeSettings());
+    public CraftingRecipeEliteShaped(@JsonProperty("key") @JacksonInject("key") NamespacedKey key, @JacksonInject("customcrafting") CustomCrafting customCrafting, @JsonProperty("symmetry") Symmetry symmetry, @JsonProperty(value = "keepShapeAsIs") boolean keepShapeAsIs, @JsonProperty("shape") String[] shape) {
+        super(key, customCrafting, symmetry, keepShapeAsIs, shape, 6, new EliteRecipeSettings());
     }
 
     @Deprecated
     public CraftingRecipeEliteShaped(NamespacedKey key) {
-        super(key, CustomCrafting.inst(), new Symmetry(), 6, new EliteRecipeSettings());
+        super(key, CustomCrafting.inst(), new Symmetry(), false, 6, new EliteRecipeSettings());
     }
 
     private CraftingRecipeEliteShaped(CraftingRecipeEliteShaped eliteCraftingRecipe) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
@@ -39,18 +39,18 @@ public class CraftingRecipeShaped extends AbstractRecipeShaped<CraftingRecipeSha
     }
 
     @JsonCreator
-    public CraftingRecipeShaped(@JsonProperty("key") @JacksonInject("key") NamespacedKey key, @JacksonInject("customcrafting") CustomCrafting customCrafting, @JsonProperty("symmetry") Symmetry symmetry, @JsonProperty("shape") String[] shape) {
-        super(key, customCrafting, symmetry, shape, 3, new AdvancedRecipeSettings());
+    public CraftingRecipeShaped(@JsonProperty("key") @JacksonInject("key") NamespacedKey key, @JacksonInject("customcrafting") CustomCrafting customCrafting, @JsonProperty("symmetry") Symmetry symmetry, @JsonProperty(value = "keepShapeAsIs") boolean keepShapeAsIs, @JsonProperty("shape") String[] shape) {
+        super(key, customCrafting, symmetry, keepShapeAsIs, shape, 3, new AdvancedRecipeSettings());
     }
 
     @Deprecated
     public CraftingRecipeShaped(NamespacedKey key, Symmetry symmetry, String[] shape) {
-        this(key, CustomCrafting.inst(), symmetry, shape);
+        this(key, CustomCrafting.inst(), symmetry, false, shape);
     }
 
     @Deprecated
     public CraftingRecipeShaped(NamespacedKey key) {
-        super(key, CustomCrafting.inst(), new Symmetry(), 3, new AdvancedRecipeSettings());
+        super(key, CustomCrafting.inst(), new Symmetry(), false, 3, new AdvancedRecipeSettings());
     }
 
     private CraftingRecipeShaped(CraftingRecipeShaped craftingRecipe) {

--- a/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
@@ -288,7 +288,7 @@ public class CraftManager {
         }
         var finalLeftPos = leftPos;
         var finalRightPos = rightPos + 1;
-        return new MatrixData(items.stream().flatMap(itemStacks -> itemStacks.subList(finalLeftPos, finalRightPos).stream()).toArray(ItemStack[]::new), items.size(), finalRightPos - finalLeftPos, gridSize, finalLeftPos, yPosOfFirstOccurrence);
+        return new MatrixData(ingredients, items.stream().flatMap(itemStacks -> itemStacks.subList(finalLeftPos, finalRightPos).stream()).toArray(ItemStack[]::new), items.size(), finalRightPos - finalLeftPos, gridSize, finalLeftPos, yPosOfFirstOccurrence);
     }
 
     /**
@@ -300,6 +300,7 @@ public class CraftManager {
     public static class MatrixData {
 
         private final ItemStack[] matrix;
+        private final ItemStack[] originalMatrix;
         private final int gridSize;
         private final int height;
         private final int width;
@@ -310,10 +311,11 @@ public class CraftManager {
 
         @Deprecated
         public MatrixData(ItemStack[] matrix, int height, int width) {
-            this(matrix, height, width, 3, 0, 0);
+            this(matrix, matrix, height, width, 3, 0, 0);
         }
 
-        public MatrixData(ItemStack[] matrix, int height, int width, int gridSize, int offsetX, int offsetY) {
+        public MatrixData(ItemStack[] originalMatrix, ItemStack[] matrix, int height, int width, int gridSize, int offsetX, int offsetY) {
+            this.originalMatrix = originalMatrix;
             this.matrix = matrix;
             this.height = height;
             this.width = width;
@@ -388,6 +390,10 @@ public class CraftManager {
          */
         public ItemStack[] getMatrix() {
             return matrix;
+        }
+
+        public ItemStack[] getOriginalMatrix() {
+            return originalMatrix;
         }
 
         @Override


### PR DESCRIPTION
Adds a new feature to keep the shape of shaped (elite) crafting recipes as it is specified.
If enabled the shape is not shrunken down and the items need to be at the exact specified position in the grid. 
The symmetry options do still apply and can be used together with this new feature. 