### PR TITLE
Fixed Recipe/Custom Item Loading on non-unix systems

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
@@ -115,6 +115,10 @@ public class LocalStorageLoader extends ResourceLoader {
      */
     private NamespacedKey keyFromFile(String namespace, Path path) {
         String pathString = path.toString();
+        if (!File.separator.equals("/")) {
+            // #205: Required to work with Windows file separators (And possibly other separators).
+            pathString = pathString.replace(File.separatorChar, '/');
+        }
         return new NamespacedKey(customCrafting, namespace + "/" + pathString.substring(0, pathString.lastIndexOf(".")));
     }
 


### PR DESCRIPTION
Only slashes ('/') are allowed inside keys, so non-unix separators caused issues when creating the keys from files.
This fix simply replaces all non-unix separators with slashes. 