### PR TITLE
Editing shaped/shapeless mode causes recipes to not save

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
@@ -79,6 +79,7 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
     private String[] shape;
     private final Symmetry symmetry;
 
+    @Deprecated
     protected AbstractRecipeShaped(NamespacedKey namespacedKey, JsonNode node, int gridSize, Class<S> settingsType) {
         super(namespacedKey, node, gridSize, settingsType);
         this.symmetry = Symmetry.ofLegacy(node.path(MIRROR_KEY));

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
@@ -66,6 +66,7 @@ public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<
     @JsonIgnore
     private boolean hasAllowedEmptyIngredient;
 
+    @Deprecated
     protected AbstractRecipeShapeless(NamespacedKey namespacedKey, JsonNode node, int gridSize, Class<S> settingsType) {
         super(namespacedKey, node, gridSize, settingsType);
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
@@ -77,6 +77,7 @@ public abstract class CraftingRecipe<C extends CraftingRecipe<C, S>, S extends C
 
     private final S settings;
 
+    @Deprecated
     protected CraftingRecipe(NamespacedKey namespacedKey, JsonNode node, int gridSize, Class<S> settingsType) {
         super(namespacedKey, node);
         this.ingredients = List.of();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
@@ -293,17 +293,4 @@ public abstract class CraftingRecipe<C extends CraftingRecipe<C, S>, S extends C
         byteBuf.writeCollection(ingredients, (buf, ingredient) -> buf.writeCollection(ingredient.getChoices(), (buf1, customItem) -> buf1.writeItemStack(customItem.create())));
     }
 
-    @Override
-    public boolean save(@Nullable Player player) {
-        boolean saveSuccessful = super.save(player);
-        if (saveSuccessful) {
-            //We need to delete the old recipe when the type changes between shapeless and shaped, because else it is present in two different folders!
-            CustomRecipe<?> oldRecipe = customCrafting.getRegistries().getRecipes().get(getNamespacedKey());
-            if (oldRecipe instanceof CraftingRecipe<?, ?> oldCraftingRecipe && oldCraftingRecipe.isShapeless() != isShapeless()) {
-                getAPI().getChat().sendMessage(player, ChatColor.YELLOW + "Recipe Type changed... deleting old recipe!");
-                oldCraftingRecipe.delete(player);
-            }
-        }
-        return saveSuccessful;
-    }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -86,6 +86,8 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     protected static final String KEY_HIDDEN = "hidden";
     protected static final String ERROR_MSG_KEY = "Not a valid key! The key cannot be null!";
 
+    protected final boolean loadedFromOldOrLegacy;
+
     @JsonProperty("@type")
     protected RecipeType<C> type;
     @JsonIgnore
@@ -112,7 +114,9 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
      * @param node          The json node read from the recipe file.
      * @deprecated Used only for deserializing recipes from old json files.
      */
+    @Deprecated
     protected CustomRecipe(NamespacedKey namespacedKey, JsonNode node) {
+        this.loadedFromOldOrLegacy = true;
         this.type = RecipeType.valueOfRecipe(this);
         this.namespacedKey = Objects.requireNonNull(namespacedKey, ERROR_MSG_KEY);
         this.customCrafting = CustomCrafting.inst(); //TODO: Dependency Injection (v5)
@@ -141,6 +145,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     }
 
     protected CustomRecipe(NamespacedKey key, CustomCrafting customCrafting, RecipeType<C> type) {
+        this.loadedFromOldOrLegacy = false;
         this.type = type == null ? RecipeType.valueOfRecipe(this) : type;
         Preconditions.checkArgument(this.type != null, "Error constructing Recipe Object \"" + getClass().getName() + "\": Missing RecipeType!");
         this.namespacedKey = Objects.requireNonNull(key, ERROR_MSG_KEY);
@@ -165,6 +170,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
      * @param customRecipe The other CustomRecipe. Can be from another type, but must have the same ResultTarget.
      */
     protected CustomRecipe(CustomRecipe<C> customRecipe) {
+        this.loadedFromOldOrLegacy = customRecipe.loadedFromOldOrLegacy;
         this.type = customRecipe.type;
         this.customCrafting = customRecipe.customCrafting;
         this.mapper = customCrafting.getApi().getJacksonMapperUtil().getGlobalMapper();


### PR DESCRIPTION
Fixed an issue for Crafting Recipes, that causes recipes to not save properly, when changing the type from shaped to shapeless or other way around.