### PR TITLE
Fixed Item Input Slots in Elite Crafting Table

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/gui/InteractionUtils.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/InteractionUtils.java
@@ -104,11 +104,10 @@ public class InteractionUtils {
     private static ItemStack placeStack(InventoryClickEvent clickEvent, Function<ItemStack, Integer> amount) {
         if (!ItemUtils.isAirOrNull(clickEvent.getCurrentItem())) return clickEvent.getCurrentItem();
         // Current is null, so no reference to the inventory stack.
-        ItemStack stack = clickEvent.getCursor().clone();
+        ItemStack stack = new ItemStack(Objects.requireNonNull(clickEvent.getCursor()));
         stack.setAmount(amount.apply(stack));
         clickEvent.setCurrentItem(stack);
         return stack;
     }
-
 
 }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/CraftingWindow.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/CraftingWindow.java
@@ -105,7 +105,7 @@ abstract class CraftingWindow extends CCWindow {
                         }
                         CacheEliteCraftingTable cacheEliteCraftingTable = cache.getEliteWorkbench();
                         if (cacheEliteCraftingTable.getContents() != null) {
-                            return InteractionUtils.applyItemFromInteractionEvent(slot, event, CRAFTING_SLOTS_MAP.get(cacheEliteCraftingTable.getCurrentGridSize()), itemStack -> cacheEliteCraftingTable.getContents()[recipeSlot] = inventory.getItem(slot));
+                            return InteractionUtils.applyItemFromInteractionEvent(slot, event, CRAFTING_SLOTS_MAP.get(cacheEliteCraftingTable.getCurrentGridSize()), itemStack -> cacheEliteCraftingTable.getContents()[recipeSlot] = itemStack);
                         }
                         return true;
                     }).postAction((cache, guiHandler, player, inventory, itemStack, slot, inventoryInteractEvent) -> {


### PR DESCRIPTION
This fixes an issue that occurs when placing items into the grid of any Elite Crafting Table.