### PR TITLE
Block Entity Tag Merge Adapter

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
@@ -110,6 +110,7 @@ import me.wolfyscript.customcrafting.recipes.items.extension.ResultExtensionAdva
 import me.wolfyscript.customcrafting.recipes.items.extension.SoundResultExtension;
 import me.wolfyscript.customcrafting.recipes.items.target.MergeAdapter;
 import me.wolfyscript.customcrafting.recipes.items.target.adapters.BannerMergeAdapter;
+import me.wolfyscript.customcrafting.recipes.items.target.adapters.BlockEntityMergeAdapter;
 import me.wolfyscript.customcrafting.recipes.items.target.adapters.BookMetaMergeAdapter;
 import me.wolfyscript.customcrafting.recipes.items.target.adapters.DamageMergeAdapter;
 import me.wolfyscript.customcrafting.recipes.items.target.adapters.DisplayLoreMergeAdapter;
@@ -286,6 +287,7 @@ public class CustomCrafting extends JavaPlugin {
         if (ServerVersion.getWUVersion().isAfterOrEq(WUVersion.of(4, 16, 9, 6))) {
             resultMergeAdapters.register(new BookMetaMergeAdapter());
             resultMergeAdapters.register(new BannerMergeAdapter());
+            resultMergeAdapters.register(new BlockEntityMergeAdapter());
         }
 
         getLogger().info("Registering Recipe Conditions");

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/BlockEntityMergeAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/BlockEntityMergeAdapter.java
@@ -1,0 +1,71 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.recipes.items.target.adapters;
+
+import me.wolfyscript.customcrafting.recipes.data.IngredientData;
+import me.wolfyscript.customcrafting.recipes.data.RecipeData;
+import me.wolfyscript.customcrafting.recipes.items.target.MergeAdapter;
+import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BlockStateMeta;
+import org.jetbrains.annotations.Nullable;
+
+public class BlockEntityMergeAdapter extends MergeAdapter {
+
+    public BlockEntityMergeAdapter() {
+        super(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "block_entity"));
+    }
+
+    public BlockEntityMergeAdapter(BlockEntityMergeAdapter adapter) {
+        super(adapter);
+    }
+
+    @Override
+    public ItemStack merge(RecipeData<?> recipeData, @Nullable Player player, @Nullable Block block, CustomItem customResult, ItemStack result) {
+        var meta = result.getItemMeta();
+        if (meta instanceof BlockStateMeta blockStateMeta) {
+            for (IngredientData ingredientData : recipeData.getBySlots(slots)) {
+                var ingredientMeta = ingredientData.itemStack().getItemMeta();
+                if (ingredientMeta instanceof BlockStateMeta ingredientBlockStateMeta) {
+                    try {
+                        blockStateMeta.setBlockState(ingredientBlockStateMeta.getBlockState());
+                        break;
+                    } catch (IllegalArgumentException e) {
+                        // Ignore! Cannot apply incompatible block state!
+                    }
+                }
+            }
+            result.setItemMeta(blockStateMeta);
+        }
+        return result;
+    }
+
+    @Override
+    public MergeAdapter clone() {
+        return new BlockEntityMergeAdapter(this);
+    }
+}


### PR DESCRIPTION
This adapter makes it possible to copy the Block Entity State that is currently bound to an item to the result.
Useful for upgrading tile entities like Shulker Boxes and preserving the contents.

This is adapter does not have any additional properties, all that is required is the `key` property.
```json
{
  key : "customcrafting:block_entity"
}
```
