### PR TITLE
Recipe Groups are IDs and only used internally

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/ClusterRecipeCreator.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/ClusterRecipeCreator.java
@@ -132,6 +132,10 @@ public class ClusterRecipeCreator extends CCCluster {
                 }).render((cache, guiHandler, player, guiInventory, itemStack, i) -> CallbackButtonRender.UpdateResult.of(Placeholder.parsed("group", cache.getRecipeCreatorCache().getRecipeCache().getGroup()))))
                 .inputAction((guiHandler, player, s, args) -> {
                     if (args.length > 0) {
+                        if (args[0].contains("§")) { // Do not allow legacy color codes in group id! This is an internal id, not something displayed to players!
+                            getChat().sendMessage(player, translatedMsgKey("group_id.invalid"));
+                            return true;
+                        }
                         guiHandler.getCustomCache().getRecipeCreatorCache().getRecipeCache().setGroup(args[0]);
                     }
                     return false;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -247,8 +247,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
 
     public void setGroup(String group) {
         group = Objects.requireNonNull(group, "");
-        Preconditions.checkArgument(!group.contains("§")); // Do not allow legacy color codes in group id! This is an internal id, not something displayed to players!
-        this.group = group;
+        this.group = group.replace("§", ""); // Do not allow legacy color codes in group id! This is an internal id, not something displayed to players!
     }
 
     public Conditions getConditions() {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -246,7 +246,9 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     }
 
     public void setGroup(String group) {
-        this.group = Objects.requireNonNullElse(group, "");
+        group = Objects.requireNonNull(group, "");
+        Preconditions.checkArgument(!group.contains("§")); // Do not allow legacy color codes in group id! This is an internal id, not something displayed to players!
+        this.group = group;
     }
 
     public Conditions getConditions() {

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -2052,6 +2052,9 @@
       "global_messages": {
         "override": "<white>Type the folder and key of the recipe",
         "valid_number": "<red>Type in a valid number!</red>",
+        "group_id": {
+          "invalid" : "<red>The group contains an invalid character. Please note that color codes are not necessary as the ids are only used internally!"
+        },
         "save": {
           "input": "<white>Type in the <hover:show_text:'Recipes are saved as follows: <yellow>/data/<folder>/recipes/<recipe_name>.conf</yellow><br><br>The folder can be used to group your recipes and nested folders are allowed!<br>Input your folder and name like this: <yellow>/wui <folder> <name></yellow><br><br><red>Make sure the folder and name only contain: <br> - lowercase letters,<br> - numbers,<br> - underscores,<br> - or dashes!<br>Use <yellow>/wui </yellow>to get input assistance, like tab completions!</red>'><yellow>folder and recipe name</yellow></hover>, under which to save the recipe",
           "key": {

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -2036,16 +2036,17 @@
           ]
         },
         "group": {
-          "name": "<grey>\u270E</grey>  <gold><b>Recipe Group</b></gold>",
+          "name": "<grey>\u270E</grey>  <gold><b>Recipe Group ID</b></gold>",
           "lore": [
             "<grey>Group: </grey><yellow>%group%</yellow>",
-            "<yellow>Recipes with the same group are</yellow>",
-            "<yellow>grouped together in the recipe book.</yellow>",
+            "<yellow>Recipes with the same group id are</yellow>",
+            "<yellow>grouped together in one slot of the recipe book.</yellow>",
+            "<yellow>Similar to wood variants in vanilla Minecraft.</yellow>",
             "",
             "<grey>[<green>Left-Click</green>]</grey> <yellow>Input Group</yellow>",
             "<grey>[<green>Right-Click</green>]</grey> <yellow>Reset Group</yellow>"
           ],
-          "message": "<yellow>Type in the group name!</yellow>"
+          "message": "<yellow>Type in the group id!</yellow>"
         }
       },
       "global_messages": {


### PR DESCRIPTION
Group IDs are only used internally and never displayed to players, so they should not have any legacy color codes.
That means the paragraph § character can no longer be used, and will be removed from existing group ids.