### PR TITLE
Fix Recipe Book Single Category View

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/commands/cc_subcommands/ReloadSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/cc_subcommands/ReloadSubCommand.java
@@ -76,7 +76,7 @@ public class ReloadSubCommand extends AbstractSubCommand {
         dataHandler.load();
         configHandler.getRecipeBookConfig().index(customCrafting);
         sendMessage(sender, Component.text("Reloading GUIs", NamedTextColor.YELLOW));
-        ((MenuRecipeOverview) invAPI.getGuiWindow(ClusterRecipeBook.RECIPE_BOOK)).reset();
+        ((MenuRecipeOverview) invAPI.getGuiWindow(ClusterRecipeBook.RECIPE_OVERVIEW)).reset();
         ((MenuCategoryOverview) invAPI.getGuiWindow(ClusterRecipeBook.CATEGORY_OVERVIEW)).reset();
         invAPI.reset();
         sendMessage(sender, Component.text("Reload done!", NamedTextColor.GREEN));

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ButtonContainerRecipeBook.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ButtonContainerRecipeBook.java
@@ -106,7 +106,7 @@ class ButtonContainerRecipeBook extends Button<CCCache> {
             book.setPrepareRecipe(true);
             resetButtons(guiHandler);
         }
-        guiHandler.openWindow(ClusterRecipeBook.RECIPE_BOOK);
+        guiHandler.openWindow(ClusterRecipeBook.RECIPE_OVERVIEW);
         return true;
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ClusterRecipeBook.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ClusterRecipeBook.java
@@ -55,7 +55,7 @@ public class ClusterRecipeBook extends CCCluster {
     public static final String KEY = "recipe_book";
 
     public static final NamespacedKey MAIN_MENU = new NamespacedKey(KEY, "main_menu");
-    public static final NamespacedKey RECIPE_BOOK = new NamespacedKey(KEY, "recipe_book");
+    public static final NamespacedKey RECIPE_OVERVIEW = new NamespacedKey(KEY, "recipe_book");
     public static final NamespacedKey CATEGORY_OVERVIEW = new NamespacedKey(KEY, "category_overview");
 
     public static final NamespacedKey BACK_TO_LIST = new NamespacedKey(KEY, "back_to_list");

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeOverview.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeOverview.java
@@ -60,7 +60,7 @@ public class MenuRecipeOverview extends CCWindow {
     private final BukkitTask ingredientTask;
 
     MenuRecipeOverview(ClusterRecipeBook cluster, CustomCrafting customCrafting) {
-        super(cluster, ClusterRecipeBook.RECIPE_BOOK.getKey(), 54, customCrafting);
+        super(cluster, ClusterRecipeBook.RECIPE_OVERVIEW.getKey(), 54, customCrafting);
         this.ingredientTask = Bukkit.getScheduler().runTaskTimerAsynchronously(customCrafting, () -> {
             for (int i = 0; i < 37; i++) {
                 Button<CCCache> btn = cluster.getButton("ingredient.container_" + i);

--- a/src/main/java/me/wolfyscript/customcrafting/utils/PlayerUtil.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/PlayerUtil.java
@@ -66,7 +66,7 @@ public class PlayerUtil {
         bookCache.setPrepareRecipe(true);
         if (categories.getSortedCategories().size() == 1) {
             bookCache.setCategory(categories.getCategory(0));
-            invAPI.openGui(player, ClusterRecipeBook.RECIPE_BOOK);
+            invAPI.openGui(player, ClusterRecipeBook.CATEGORY_OVERVIEW);
         } else if (!categories.getSortedCategories().isEmpty()) {
             invAPI.openCluster(player, ClusterRecipeBook.KEY);
         }


### PR DESCRIPTION
Correct single category recipe book view GUI key. I based this off of the handling in `ButtonCategoryMain::execute()`.
Resolves the issue raised by a few users on the discord where running `/recipes` when only using a single recipe book category would result in a broken GUI.
e.g. [This post](https://discord.com/channels/477026331096514571/498358213842960394/1071877189609459785)
![](https://cdn.discordapp.com/attachments/498358213842960394/1071877189483638917/image.png)