### PR TITLE
Fix Item Editor Durability Cost Disabled Text

### DIFF
--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -1422,7 +1422,7 @@
                 "message": "<yellow>Type in the durability cost, which will be subtracted from the item when used in the crafting grid</yellow>"
               },
               "disabled": {
-                "name": "<grey>Durab</grey>ility cost: <dark_red><b>Disabled</b></dark_red>",
+                "name": "<grey>Durability cost: <dark_red><b>Disabled</b></dark_red></grey>",
                 "lore": [
                   "<red>Item must not be stackable!</red>",
                   "<red>Replacement must be disabled!</red>"


### PR DESCRIPTION
Corrects the grey closing tag placement to correct the text switching white mid way through as below.

![2023-02-24_10-33-42](https://user-images.githubusercontent.com/10000712/221063350-550d7f0f-de29-4cb2-9eda-851e12403b02.png)
