### PR TITLE
Recipe Sub-Command Fixes and Improvements

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/DeleteSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/DeleteSubCommand.java
@@ -29,7 +29,6 @@ import me.wolfyscript.customcrafting.utils.ChatUtils;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.lib.net.kyori.adventure.text.event.ClickEvent;
 import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
-import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -49,25 +48,32 @@ public class DeleteSubCommand extends AbstractSubCommand {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull String var3, @NotNull String[] args) {
-        if (sender instanceof Player player && ChatUtils.checkPerm(player, "customcrafting.cmd.recipes_delete") && args.length > 0) {
-            WolfyUtilities api = customCrafting.getApi();
-            NamespacedKey key = NamespacedKey.of(args[0]);
-            if (key != null) {
-                var chat = api.getChat();
-                CustomRecipe<?> customRecipe = customCrafting.getRegistries().getRecipes().get(key);
-                if (customRecipe != null) {
-                    chat.sendMessage(player, chat.translated("commands.recipes.delete.confirm", Placeholder.unparsed("recipe", customRecipe.getNamespacedKey().toString())));
-                    chat.sendMessage(player,
-                        chat.translated("commands.recipes.delete.confirmation")
-                            .clickEvent(chat.executable(player, true, (wolfyUtilities, player1) -> Bukkit.getScheduler().runTask(customCrafting, () -> customRecipe.delete(player))))
-                            .append(
-                                chat.translated("commands.recipes.delete.cancel")
-                                    .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/recipes delete "))
-                            )
-                    );
-                } else {
+        if (sender instanceof Player player && ChatUtils.checkPerm(player, "customcrafting.cmd.recipes_delete")) {
+            var chat = api.getChat();
+            if (args.length > 0) {
+                try {
+                    NamespacedKey key = NamespacedKey.of(args[0]);
+                    if (key != null) {
+                        CustomRecipe<?> customRecipe = customCrafting.getRegistries().getRecipes().get(key);
+                        if (customRecipe != null) {
+                            chat.sendMessage(player, chat.translated("commands.recipes.delete.confirm", Placeholder.unparsed("recipe", customRecipe.getNamespacedKey().toString())));
+                            chat.sendMessage(player,
+                                chat.translated("commands.recipes.delete.confirmation")
+                                    .clickEvent(chat.executable(player, true, (wolfyUtilities, player1) -> Bukkit.getScheduler().runTask(customCrafting, () -> customRecipe.delete(player))))
+                                    .append(
+                                        chat.translated("commands.recipes.delete.cancel")
+                                            .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/recipes delete "))
+                                    )
+                            );
+                        } else {
+                            chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
+                        }
+                    }
+                } catch (IllegalArgumentException ex) {
                     chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
                 }
+            } else {
+                chat.sendMessage(player, chat.translated("commands.recipes.delete.invalid_usage"));
             }
         }
         return true;

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/DeleteSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/DeleteSubCommand.java
@@ -27,11 +27,10 @@ import me.wolfyscript.customcrafting.commands.AbstractSubCommand;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.lib.net.kyori.adventure.text.event.ClickEvent;
+import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import me.wolfyscript.utilities.api.WolfyUtilities;
-import me.wolfyscript.utilities.api.chat.ClickData;
-import me.wolfyscript.utilities.api.chat.ClickEvent;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import me.wolfyscript.utilities.util.Pair;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -54,24 +53,20 @@ public class DeleteSubCommand extends AbstractSubCommand {
             WolfyUtilities api = customCrafting.getApi();
             NamespacedKey key = NamespacedKey.of(args[0]);
             if (key != null) {
+                var chat = api.getChat();
                 CustomRecipe<?> customRecipe = customCrafting.getRegistries().getRecipes().get(key);
                 if (customRecipe != null) {
-                    api.getChat().sendMessage(player, "$commands.recipes.delete.confirm$", new Pair<>("%recipe%", customRecipe.getNamespacedKey().toString()));
-                    api.getChat().sendActionMessage(player,
-                            new ClickData("$commands.recipes.delete.confirmation$",
-                                    (wolfyUtilities, player1) -> Bukkit.getScheduler().runTask(customCrafting, () -> customRecipe.delete(player)),
-                                    true
-                            ),
-                            new ClickData(
-                                    "$commands.recipes.delete.cancel$",
-                                    (wolfyUtilities, player1) -> {
-                                    },
-                                    true,
-                                    new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/recipes delete ")
+                    chat.sendMessage(player, chat.translated("commands.recipes.delete.confirm", Placeholder.unparsed("recipe", customRecipe.getNamespacedKey().toString())));
+                    chat.sendMessage(player,
+                        chat.translated("commands.recipes.delete.confirmation")
+                            .clickEvent(chat.executable(player, true, (wolfyUtilities, player1) -> Bukkit.getScheduler().runTask(customCrafting, () -> customRecipe.delete(player))))
+                            .append(
+                                chat.translated("commands.recipes.delete.cancel")
+                                    .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/recipes delete "))
                             )
                     );
                 } else {
-                    api.getChat().sendMessage((Player) sender, "$commands.recipes.invalid_recipe$", new Pair<>("%recipe%", args[0]));
+                    chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
                 }
             }
         }

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/EditSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/EditSubCommand.java
@@ -31,7 +31,6 @@ import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
-import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.Bukkit;
@@ -52,29 +51,34 @@ public class EditSubCommand extends AbstractSubCommand {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull String var3, @NotNull String[] args) {
-        if (sender instanceof Player player && ChatUtils.checkPerm(player, "customcrafting.cmd.recipes_edit") && args.length > 0) {
-            WolfyUtilities api = customCrafting.getApi();
-            if (args[0].contains(":")) {
-                NamespacedKey key = NamespacedKey.of(args[0]);
-                if (key != null) {
-                    var chat = api.getChat();
-                    CustomRecipe<?> customRecipe = customCrafting.getRegistries().getRecipes().get(key);
-                    if (customRecipe != null) {
-                        GuiHandler<CCCache> guiHandler = api.getInventoryAPI(CCCache.class).getGuiHandler(player);
-                        CCCache cache = guiHandler.getCustomCache();
-                        cache.setSetting(Setting.RECIPE_CREATOR);
-                        var creatorCache = cache.getRecipeCreatorCache();
-                        creatorCache.setRecipeType(customRecipe.getRecipeType());
-                        try {
-                            creatorCache.loadRecipeIntoCache(customRecipe);
-                            Bukkit.getScheduler().runTaskLater(customCrafting, () -> api.getInventoryAPI().openGui(player, new NamespacedKey(ClusterRecipeCreator.KEY, creatorCache.getRecipeType().getCreatorID())), 1);
-                        } catch (IllegalArgumentException ex) {
-                            chat.sendMessage(player, chat.translated("commands.recipes.edit.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
+        if (sender instanceof Player player && ChatUtils.checkPerm(player, "customcrafting.cmd.recipes_edit")) {
+            var chat = api.getChat();
+            if (args.length > 0) {
+                try {
+                    NamespacedKey key = NamespacedKey.of(args[0]);
+                    if (key != null) {
+                        CustomRecipe<?> customRecipe = customCrafting.getRegistries().getRecipes().get(key);
+                        if (customRecipe != null) {
+                            GuiHandler<CCCache> guiHandler = api.getInventoryAPI(CCCache.class).getGuiHandler(player);
+                            CCCache cache = guiHandler.getCustomCache();
+                            cache.setSetting(Setting.RECIPE_CREATOR);
+                            var creatorCache = cache.getRecipeCreatorCache();
+                            creatorCache.setRecipeType(customRecipe.getRecipeType());
+                            try {
+                                creatorCache.loadRecipeIntoCache(customRecipe);
+                                Bukkit.getScheduler().runTaskLater(customCrafting, () -> api.getInventoryAPI().openGui(player, new NamespacedKey(ClusterRecipeCreator.KEY, creatorCache.getRecipeType().getCreatorID())), 1);
+                            } catch (IllegalArgumentException ex) {
+                                chat.sendMessage(player, chat.translated("commands.recipes.edit.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
+                            }
+                        } else {
+                            chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
                         }
-                    } else {
-                        chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
                     }
+                } catch (IllegalArgumentException ex) {
+                    chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
                 }
+            } else {
+                chat.sendMessage(player, chat.translated("commands.recipes.edit.invalid_usage"));
             }
         }
         return true;

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/EditSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/EditSubCommand.java
@@ -30,10 +30,10 @@ import me.wolfyscript.customcrafting.gui.recipe_creator.ClusterRecipeCreator;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import me.wolfyscript.utilities.util.Pair;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -57,6 +57,7 @@ public class EditSubCommand extends AbstractSubCommand {
             if (args[0].contains(":")) {
                 NamespacedKey key = NamespacedKey.of(args[0]);
                 if (key != null) {
+                    var chat = api.getChat();
                     CustomRecipe<?> customRecipe = customCrafting.getRegistries().getRecipes().get(key);
                     if (customRecipe != null) {
                         GuiHandler<CCCache> guiHandler = api.getInventoryAPI(CCCache.class).getGuiHandler(player);
@@ -68,10 +69,10 @@ public class EditSubCommand extends AbstractSubCommand {
                             creatorCache.loadRecipeIntoCache(customRecipe);
                             Bukkit.getScheduler().runTaskLater(customCrafting, () -> api.getInventoryAPI().openGui(player, new NamespacedKey(ClusterRecipeCreator.KEY, creatorCache.getRecipeType().getCreatorID())), 1);
                         } catch (IllegalArgumentException ex) {
-                            api.getChat().sendMessage((Player) sender, "$commands.recipes.edit.invalid_recipe$", new Pair<>("%recipe%", args[0]));
+                            chat.sendMessage(player, chat.translated("commands.recipes.edit.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
                         }
                     } else {
-                        api.getChat().sendMessage((Player) sender, "$commands.recipes.invalid_recipe$", new Pair<>("%recipe%", args[0]));
+                        chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
                     }
                 }
             }

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/RecipeLookupCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/RecipeLookupCommand.java
@@ -31,10 +31,10 @@ import me.wolfyscript.customcrafting.recipes.conditions.Conditions;
 import me.wolfyscript.customcrafting.registry.RegistryRecipes;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import me.wolfyscript.utilities.util.Pair;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -61,6 +61,7 @@ public class RecipeLookupCommand extends AbstractSubCommand {
             if (args[0].contains(":")) {
                 NamespacedKey key = NamespacedKey.of(args[0]);
                 if (key != null) {
+                    var chat = api.getChat();
                     CustomRecipe<?> customRecipe = registryRecipes.get(key);
                     if (customRecipe != null) {
                         if (customRecipe.checkCondition("permission", Conditions.Data.of(player))) { //Make sure the player has access to the recipe
@@ -71,9 +72,9 @@ public class RecipeLookupCommand extends AbstractSubCommand {
                             Bukkit.getScheduler().runTaskLater(customCrafting, () -> guiHandler.openWindow(ClusterRecipeView.RECIPE_SINGLE), 1);
                             return true;
                         }
-                        api.getChat().sendMessage((Player) sender, "$commands.recipes.invalid_recipe_permission$", new Pair<>("%recipe%", args[0]));
+                        chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe_permission", Placeholder.unparsed("recipe", args[0])));
                     } else {
-                        api.getChat().sendMessage((Player) sender, "$commands.recipes.invalid_recipe$", new Pair<>("%recipe%", args[0]));
+                        chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
                     }
                 }
             }

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/RecipeLookupCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/RecipeLookupCommand.java
@@ -32,7 +32,6 @@ import me.wolfyscript.customcrafting.registry.RegistryRecipes;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
-import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.Bukkit;
@@ -56,27 +55,32 @@ public class RecipeLookupCommand extends AbstractSubCommand {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull String var3, @NotNull String[] args) {
-        if (sender instanceof Player player && ChatUtils.checkPerm(player, "customcrafting.cmd.recipes_lookup") && args.length > 0) {
-            WolfyUtilities api = customCrafting.getApi();
-            if (args[0].contains(":")) {
-                NamespacedKey key = NamespacedKey.of(args[0]);
-                if (key != null) {
-                    var chat = api.getChat();
-                    CustomRecipe<?> customRecipe = registryRecipes.get(key);
-                    if (customRecipe != null) {
-                        if (customRecipe.checkCondition("permission", Conditions.Data.of(player))) { //Make sure the player has access to the recipe
-                            GuiHandler<CCCache> guiHandler = api.getInventoryAPI(CCCache.class).getGuiHandler(player);
-                            CCCache cache = guiHandler.getCustomCache();
-                            cache.getCacheRecipeView().setRecipe(customRecipe);
-                            customRecipe.prepareMenu(guiHandler, guiHandler.getInvAPI().getGuiCluster(ClusterRecipeView.KEY));
-                            Bukkit.getScheduler().runTaskLater(customCrafting, () -> guiHandler.openWindow(ClusterRecipeView.RECIPE_SINGLE), 1);
-                            return true;
+        if (sender instanceof Player player && ChatUtils.checkPerm(player, "customcrafting.cmd.recipes_lookup")) {
+            var chat = api.getChat();
+            if (args.length > 0) {
+                try {
+                    NamespacedKey key = NamespacedKey.of(args[0]);
+                    if (key != null) {
+                        CustomRecipe<?> customRecipe = registryRecipes.get(key);
+                        if (customRecipe != null) {
+                            if (customRecipe.checkCondition("permission", Conditions.Data.of(player))) { //Make sure the player has access to the recipe
+                                GuiHandler<CCCache> guiHandler = api.getInventoryAPI(CCCache.class).getGuiHandler(player);
+                                CCCache cache = guiHandler.getCustomCache();
+                                cache.getCacheRecipeView().setRecipe(customRecipe);
+                                customRecipe.prepareMenu(guiHandler, guiHandler.getInvAPI().getGuiCluster(ClusterRecipeView.KEY));
+                                Bukkit.getScheduler().runTaskLater(customCrafting, () -> guiHandler.openWindow(ClusterRecipeView.RECIPE_SINGLE), 1);
+                                return true;
+                            }
+                            chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe_permission", Placeholder.unparsed("recipe", args[0])));
+                        } else {
+                            chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
                         }
-                        chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe_permission", Placeholder.unparsed("recipe", args[0])));
-                    } else {
-                        chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
                     }
+                } catch (IllegalArgumentException ex) {
+                    chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
                 }
+            } else {
+                chat.sendMessage(player, chat.translated("commands.recipes.lookup.invalid_usage"));
             }
         }
         return true;

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/ToggleSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/ToggleSubCommand.java
@@ -26,7 +26,7 @@ import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.commands.AbstractSubCommand;
 import me.wolfyscript.customcrafting.recipes.CraftingRecipe;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
-import me.wolfyscript.utilities.util.Pair;
+import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
@@ -47,18 +47,19 @@ public class ToggleSubCommand extends AbstractSubCommand {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull String var3, @NotNull String[] args) {
-        if (sender instanceof Player && ChatUtils.checkPerm(sender, "customcrafting.cmd.recipes_toggle") && args.length > 0) {
+        if (sender instanceof Player player && ChatUtils.checkPerm(sender, "customcrafting.cmd.recipes_toggle") && args.length > 0) {
             String id = args[0];
             if (id.contains(":")) {
+                var chat = api.getChat();
                 var namespacedKey = me.wolfyscript.utilities.util.NamespacedKey.of(id);
                 if (customCrafting.getDisableRecipesHandler().getRecipes().contains(namespacedKey)) {
-                    api.getChat().sendMessage((Player) sender, "$commands.recipes.toggle.enabled$", new Pair<>("%recipe%", args[0]));
+                    chat.sendMessage(player, chat.translated("commands.recipes.toggle.enabled", Placeholder.unparsed("recipe", args[0])));
                     customCrafting.getDisableRecipesHandler().getRecipes().remove(namespacedKey);
                 } else {
-                    api.getChat().sendMessage((Player) sender, "$commands.recipes.toggle.disabled$", new Pair<>("%recipe%", args[0]));
+                    chat.sendMessage(player, chat.translated("commands.recipes.toggle.disabled", Placeholder.unparsed("recipe", args[0])));
                     customCrafting.getDisableRecipesHandler().getRecipes().add(namespacedKey);
                     if (namespacedKey != null) {
-                        Bukkit.getOnlinePlayers().forEach(player -> player.undiscoverRecipe(new NamespacedKey(namespacedKey.getNamespace(), namespacedKey.getKey())));
+                        Bukkit.getOnlinePlayers().forEach(player1 -> player1.undiscoverRecipe(new NamespacedKey(namespacedKey.getNamespace(), namespacedKey.getKey())));
                     }
                 }
             }

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/ToggleSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/ToggleSubCommand.java
@@ -47,21 +47,26 @@ public class ToggleSubCommand extends AbstractSubCommand {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull String var3, @NotNull String[] args) {
-        if (sender instanceof Player player && ChatUtils.checkPerm(sender, "customcrafting.cmd.recipes_toggle") && args.length > 0) {
-            String id = args[0];
-            if (id.contains(":")) {
-                var chat = api.getChat();
-                var namespacedKey = me.wolfyscript.utilities.util.NamespacedKey.of(id);
-                if (customCrafting.getDisableRecipesHandler().getRecipes().contains(namespacedKey)) {
-                    chat.sendMessage(player, chat.translated("commands.recipes.toggle.enabled", Placeholder.unparsed("recipe", args[0])));
-                    customCrafting.getDisableRecipesHandler().getRecipes().remove(namespacedKey);
-                } else {
-                    chat.sendMessage(player, chat.translated("commands.recipes.toggle.disabled", Placeholder.unparsed("recipe", args[0])));
-                    customCrafting.getDisableRecipesHandler().getRecipes().add(namespacedKey);
-                    if (namespacedKey != null) {
-                        Bukkit.getOnlinePlayers().forEach(player1 -> player1.undiscoverRecipe(new NamespacedKey(namespacedKey.getNamespace(), namespacedKey.getKey())));
+        if (sender instanceof Player player && ChatUtils.checkPerm(sender, "customcrafting.cmd.recipes_toggle")) {
+            var chat = api.getChat();
+            if (args.length > 0) {
+                try {
+                    var namespacedKey = me.wolfyscript.utilities.util.NamespacedKey.of(args[0]);
+                    if (customCrafting.getDisableRecipesHandler().getRecipes().contains(namespacedKey)) {
+                        chat.sendMessage(player, chat.translated("commands.recipes.toggle.enabled", Placeholder.unparsed("recipe", args[0])));
+                        customCrafting.getDisableRecipesHandler().getRecipes().remove(namespacedKey);
+                    } else {
+                        chat.sendMessage(player, chat.translated("commands.recipes.toggle.disabled", Placeholder.unparsed("recipe", args[0])));
+                        customCrafting.getDisableRecipesHandler().getRecipes().add(namespacedKey);
+                        if (namespacedKey != null) {
+                            Bukkit.getOnlinePlayers().forEach(player1->player1.undiscoverRecipe(new NamespacedKey(namespacedKey.getNamespace(), namespacedKey.getKey())));
+                        }
                     }
+                } catch (IllegalArgumentException ex) {
+                    chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
                 }
+            } else {
+                chat.sendMessage(player, chat.translated("commands.recipes.toggle.invalid_usage"));
             }
         }
         return true;

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -184,16 +184,22 @@
     },
     "recipes": {
       "toggle": {
+        "invalid_usage": "<dark_red>Usage: </dark_red><red>/recipes toggle <recipe></red>",
         "enabled": "<yellow>Enabled recipe <green>%recipe%</green></yellow>",
         "disabled": "<yellow>Disabled recipe <red>%recipe%</red></yellow>"
       },
       "edit": {
+        "invalid_usage": "<dark_red>Usage: </dark_red><red>/recipes edit <recipe></red>",
         "invalid_recipe": "<red>Unsupported recipe type!</red>"
       },
       "delete": {
+        "invalid_usage": "<dark_red>Usage: </dark_red><red>/recipes delete <recipe></red>",
         "confirm": "<yellow>Do you really want to delete <gold>%recipe%? </gold></yellow>",
         "confirmation": "<grey>[<green>YES</green>]</grey> ",
         "cancel": "<grey>[<red>NO</red>]</grey>"
+      },
+      "lookup": {
+        "invalid_usage": "<dark_red>Usage: </dark_red><red>/recipes lookup <recipe></red>"
       },
       "invalid_recipe": "<red>The recipe <yellow>%recipe%</yellow> does not exist!</red>"
     },


### PR DESCRIPTION
1. Initially updated chat output to use the new methods which properly support colour tags.
2. Adds error handling for malformed but technically valid namespaced keys e.g. `example:`.
3. Add `invalid_usage` message output when no params are provided.