### PR TITLE
Crafting Optimizations & Fixes

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/CCRegistry.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CCRegistry.java
@@ -39,23 +39,25 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.stream.Stream;
 
-@Deprecated
+@Deprecated(forRemoval = true)
 public interface CCRegistry<T extends me.wolfyscript.utilities.util.Keyed> extends Registry<T> {
 
     /**
      * This Registry contains all the recipes of this plugin.
      */
+    @Deprecated(forRemoval = true)
     RecipeRegistry RECIPES = new RecipeRegistry();
+    @Deprecated(forRemoval = true)
     ItemCreatorTabRegistry ITEM_CREATOR_TABS = new ItemCreatorTabRegistry();
 
     /**
      * The custom Registry for the Recipes of CustomCrafting.
      * Providing a lot of functionality to get the recipes you need.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     final class RecipeRegistry extends WrapperRegistry<CustomRecipe<?>> {
 
-        @Deprecated
+        @Deprecated(forRemoval = true)
         private RecipeRegistry() {
             super(() -> CustomCrafting.inst().getRegistries().getRecipes());
         }
@@ -219,7 +221,7 @@ public interface CCRegistry<T extends me.wolfyscript.utilities.util.Keyed> exten
 
     }
 
-    @Deprecated
+    @Deprecated(forRemoval = true)
     final class ItemCreatorTabRegistry extends WrapperRegistry<ItemCreatorTab> {
 
         public ItemCreatorTabRegistry() {

--- a/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/RecipeContainer.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/RecipeContainer.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.configs.recipebook;
 
+import java.util.stream.Collectors;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.cache.CacheEliteCraftingTable;
 import me.wolfyscript.customcrafting.recipes.AbstractRecipeShapeless;
@@ -84,7 +85,7 @@ public class RecipeContainer implements Comparable<RecipeContainer> {
      * @return The recipes of this container the player has access to.
      */
     public List<CustomRecipe<?>> getRecipes(Player player) {
-        return recipes.getAvailable(cachedRecipes, player); //Possible strict caching in the future?! return cachedPlayerRecipes.computeIfAbsent(player.getUniqueId(), uuid -> Registry.RECIPES.getAvailable(cachedRecipes, player));
+        return recipes.filterAvailable(cachedRecipes.stream()).filter(recipe -> recipe.checkCondition("permission", Conditions.Data.of(player))).collect(Collectors.toList()); //Possible strict caching in the future?! return cachedPlayerRecipes.computeIfAbsent(player.getUniqueId(), uuid -> Registry.RECIPES.getAvailable(cachedRecipes, player));
     }
 
     /**

--- a/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/ButtonSlotResult.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/ButtonSlotResult.java
@@ -32,6 +32,7 @@ import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ItemInputButton
 import me.wolfyscript.utilities.util.inventory.InventoryUtils;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -82,15 +83,13 @@ class ButtonSlotResult extends ItemInputButton<CCCache> {
             }
         }, (cache, guiHandler, player, inventory, itemStack, slot, b) -> {
             CacheEliteCraftingTable cacheEliteCraftingTable = cache.getEliteWorkbench();
-            ItemStack result = customCrafting.getCraftManager().preCheckCraftingTable(
+            Block block = player.getTargetBlock(8);
+            cacheEliteCraftingTable.setResult(customCrafting.getCraftManager().checkCraftingMatrix(
                     cacheEliteCraftingTable.getContents(),
-                    player,
-                    inventory,
-                    Conditions.Data.of(player).setBlock(player.getTargetBlock(8)).setInventoryView(player.getOpenInventory()).setEliteCraftingTableSettings(cacheEliteCraftingTable.getSettings()),
+                    Conditions.Data.of(player).setBlock(block).setInventoryView(player.getOpenInventory()).setEliteCraftingTableSettings(cacheEliteCraftingTable.getSettings()),
                     RecipeType.Container.ELITE_CRAFTING,
                     cacheEliteCraftingTable.isAdvancedCraftingRecipes() ? RecipeType.Container.CRAFTING : null
-            );
-            cacheEliteCraftingTable.setResult(result);
+            ).map(data -> data.getResult().getItem(data, player, block)).orElse(null));
         }, (hashMap, cache, guiHandler, player, inventory, itemStack, slot, help) -> {
             CacheEliteCraftingTable cacheEliteCraftingTable = cache.getEliteWorkbench();
             return cacheEliteCraftingTable.getResult() != null ? cacheEliteCraftingTable.getResult() : new ItemStack(Material.AIR);

--- a/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/CraftingWindow.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/elite_crafting/CraftingWindow.java
@@ -42,6 +42,7 @@ import me.wolfyscript.utilities.api.inventory.gui.button.buttons.DummyButton;
 import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.InventoryView;
@@ -113,15 +114,15 @@ abstract class CraftingWindow extends CCWindow {
                     }).postAction((cache, guiHandler, player, inventory, itemStack, slot, inventoryInteractEvent) -> {
                         CacheEliteCraftingTable cacheEliteCraftingTable = cache.getEliteWorkbench();
                         if (cacheEliteCraftingTable.getContents() != null) {
-                            ItemStack result = customCrafting.getCraftManager().preCheckCraftingTable(
-                                    cacheEliteCraftingTable.getContents(),
-                                    player,
-                                    inventory,
-                                    Conditions.Data.of(player).setBlock(player.getTargetBlock(8)).setInventoryView(player.getOpenInventory()).setEliteCraftingTableSettings(cacheEliteCraftingTable.getSettings()),
-                                    RecipeType.Container.ELITE_CRAFTING,
-                                    cacheEliteCraftingTable.isAdvancedCraftingRecipes() ? RecipeType.Container.CRAFTING : null
-                            );
-                            cacheEliteCraftingTable.setResult(result);
+                            Block targetBlock = player.getTargetBlock(8);
+                            customCrafting.getCraftManager().checkCraftingMatrix(
+                                            cacheEliteCraftingTable.getContents(),
+                                            Conditions.Data.of(player).setBlock(targetBlock).setInventoryView(player.getOpenInventory()).setEliteCraftingTableSettings(cacheEliteCraftingTable.getSettings()),
+                                            RecipeType.Container.ELITE_CRAFTING,
+                                            cacheEliteCraftingTable.isAdvancedCraftingRecipes() ? RecipeType.Container.CRAFTING : null
+                                    )
+                                    .map(data -> data.getResult().getItem(data, player, targetBlock))
+                                    .ifPresent(cacheEliteCraftingTable::setResult);
                         } else {
                             cacheEliteCraftingTable.setResult(new ItemStack(Material.AIR));
                         }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
@@ -272,7 +272,7 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
 
     @Override
     public CraftingData check(CraftManager.MatrixData matrixData) {
-        if (fitsDimensions(matrixData)) {
+        if (!isDisabled() && fitsDimensions(matrixData)) {
             for (int[] entry : internalShape.getUniqueShapes()) {
                 var craftingData = checkShape(matrixData, entry);
                 if (craftingData != null) return craftingData;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
@@ -27,15 +27,10 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Streams;
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.data.CraftingData;
@@ -150,6 +145,7 @@ public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<
 
     @Override
     public CraftingData check(CraftManager.MatrixData matrixData) {
+        if (!fitsDimensions(matrixData)) return null;
         final IngredientData[] dataArray = new IngredientData[ingredients.size()];
         final List<Integer> selectedSlots = new ArrayList<>();
         final Multimap<Integer, Integer> checkedIndicesPerSlot = HashMultimap.create(ingredients.size(), ingredients.size());

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
@@ -145,7 +145,7 @@ public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<
 
     @Override
     public CraftingData check(CraftManager.MatrixData matrixData) {
-        if (!fitsDimensions(matrixData)) return null;
+        if (isDisabled() || !fitsDimensions(matrixData)) return null;
         final IngredientData[] dataArray = new IngredientData[ingredients.size()];
         final List<Integer> selectedSlots = new ArrayList<>();
         final Multimap<Integer, Integer> checkedIndicesPerSlot = HashMultimap.create(ingredients.size(), ingredients.size());

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -74,7 +74,7 @@ import java.util.Objects;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "@type")
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonPropertyOrder(value = {"@type", "group", "hidden", "vanillaBook", "priority", "checkNBT", "conditions"})
-public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
+public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed, Comparable<CustomRecipe<C>> {
 
     protected static final String KEY_RESULT = "result";
     protected static final String KEY_GROUP = "group";
@@ -378,6 +378,11 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed {
     public abstract void renderMenu(GuiWindow<CCCache> guiWindow, GuiUpdate<CCCache> event);
 
     public abstract void prepareMenu(GuiHandler<CCCache> guiHandler, GuiCluster<CCCache> cluster);
+
+    @Override
+    public int compareTo(@NotNull CustomRecipe<C> other) {
+        return getPriority().compareTo(other.getPriority());
+    }
 
     /**
      * Writes the recipe to json using the specified generator and provider.

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
@@ -144,7 +144,7 @@ public abstract class CustomRecipeCooking<C extends CustomRecipeCooking<C, T>, T
         builder.setCookingTime(getCookingTime());
         builder.setRecipeMatcher((inventory, world) -> {
             Location location = inventory.getLocation();
-            if (location != null && !checkConditions(new Conditions.Data(null, location.getBlock(), null))) return false;
+            if (location != null && !checkConditions(Conditions.Data.of(null, location.getBlock(), null))) return false;
             return getSource().test(inventory.getItem(0), isCheckNBT());
         });
         builder.setRecipeAssembler(inventory -> java.util.Optional.ofNullable(getResult().getItemStack()));

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/data/RecipeData.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/data/RecipeData.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.recipes.data;
 
+import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
@@ -30,6 +31,7 @@ import java.util.stream.Stream;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.customcrafting.recipes.items.Result;
 import me.wolfyscript.customcrafting.recipes.items.target.MergeOption;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -80,7 +82,8 @@ public abstract class RecipeData<R extends CustomRecipe<?>> {
         return result;
     }
 
-    public void setResult(Result result) {
+    public void setResult(@NotNull Result result) {
+        Preconditions.checkNotNull(result, "Cannot set null result to RecipeData!");
         this.result = result;
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
@@ -460,11 +460,8 @@ public final class CraftManager {
             }
             var width = right > left ? right - left : 0; // It should already be caught by the (top > bottom) check, but just make sure.
             var flatList = new ItemStack[itemMatrix.length * width];
-            var index = 0;
-            for (ItemStack[] row : itemMatrix) {
-                for (int i = left; i < right && i < row.length; i++) {
-                    flatList[index++] = row[i];
-                }
+            for (int i = 0; i < itemMatrix.length; i++) {
+                System.arraycopy(itemMatrix[i], left, flatList, i*width, width);
             }
             return new MatrixData(ingredients, flatList, itemMatrix.length, width, gridSize, left, top);
         }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/SmeltAPIAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/SmeltAPIAdapter.java
@@ -63,7 +63,7 @@ public abstract class SmeltAPIAdapter {
         if (customCrafting.getRegistries().getRecipes().get(recipeKey) instanceof CustomRecipeCooking<?, ?> cookingRecipe && cookingRecipe.validType(block.getType())) {
             Optional<CustomItem> customSource = cookingRecipe.getSource().check(source, cookingRecipe.isCheckNBT());
             if (customSource.isPresent()) {
-                if (cookingRecipe.checkConditions(new Conditions.Data(null, block, null))) {
+                if (cookingRecipe.checkConditions(Conditions.Data.of(null, block, null))) {
                     var data = new IngredientData(0, 0, cookingRecipe.getSource(), customSource.get(), source);
                     return new Pair<>(switch (cookingRecipe.getRecipeType().getType()) {
                         case FURNACE -> new FurnaceRecipeData((CustomRecipeFurnace) cookingRecipe, data);


### PR DESCRIPTION
* Reduced memory allocations in CraftManager#getIngredients by removing overhead of iterators and streams (measurable improvement of ~1 ms, on crafting grid interactions)
* Marked old registry classes for removal!
* Added CraftManager#checkCraftinMatrix and CraftManager#tryRecipe 
   that return the actual CraftingData for further custom handling.
   For example when trying to check against a matrix without a player.
* Fixed outdated Conditions.Data usages