### PR TITLE
Fixed Recipe Lookup Command not clearing Ingredients

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/RecipeLookupCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/RecipeLookupCommand.java
@@ -25,6 +25,7 @@ package me.wolfyscript.customcrafting.commands.recipes;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.commands.AbstractSubCommand;
 import me.wolfyscript.customcrafting.data.CCCache;
+import me.wolfyscript.customcrafting.gui.recipebook.ButtonContainerIngredient;
 import me.wolfyscript.customcrafting.gui.recipebook.ClusterRecipeView;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.customcrafting.recipes.conditions.Conditions;
@@ -67,6 +68,7 @@ public class RecipeLookupCommand extends AbstractSubCommand {
                                 GuiHandler<CCCache> guiHandler = api.getInventoryAPI(CCCache.class).getGuiHandler(player);
                                 CCCache cache = guiHandler.getCustomCache();
                                 cache.getCacheRecipeView().setRecipe(customRecipe);
+                                ButtonContainerIngredient.resetButtons(guiHandler, ClusterRecipeView.KEY);
                                 customRecipe.prepareMenu(guiHandler, guiHandler.getInvAPI().getGuiCluster(ClusterRecipeView.KEY));
                                 Bukkit.getScheduler().runTaskLater(customCrafting, () -> guiHandler.openWindow(ClusterRecipeView.RECIPE_SINGLE), 1);
                                 return true;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
@@ -328,14 +328,17 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
             int ingredientIndex = 0;
             for (int r = columnOffset; r < maxGridDimension; r++) {
                 for (int c = rowOffset; c < maxGridDimension; c++) {
+                    final int currentIndex = i++;
                     if (c < rowLimit && r < columnLimit && ingredientIndex < ingredients.size()) {
-                        var ingredient = ingredients.get(ingredientIndex);
-                        if (ingredient != null) {
-                            ((ButtonContainerIngredient) cluster.getButton(ButtonContainerIngredient.key(i))).setVariants(guiHandler, ingredient);
+                        var ingredient = ingredients.get(ingredientIndex++);
+                        var btn = ((ButtonContainerIngredient) cluster.getButton(ButtonContainerIngredient.key(currentIndex)));
+                        if (btn == null) continue;
+                        if (ingredient == null) {
+                            btn.removeVariants(guiHandler);
+                            continue;
                         }
-                        ingredientIndex++;
+                        btn.setVariants(guiHandler, ingredient);
                     }
-                    i++;
                 }
                 i += rowOffset;
             }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
@@ -195,9 +195,13 @@ public abstract class CraftingRecipe<C extends CraftingRecipe<C, S>, S extends C
             ((ButtonContainerIngredient) cluster.getButton(ButtonContainerIngredient.key(maxIngredients))).setVariants(guiHandler, this.getResult());
             for (int i = 0; i < maxIngredients && i < ingredients.size(); i++) {
                 var ingredient = ingredients.get(i);
-                if (ingredient != null) {
-                    ((ButtonContainerIngredient) cluster.getButton(ButtonContainerIngredient.key(i))).setVariants(guiHandler, ingredient);
+                var btn = ((ButtonContainerIngredient) cluster.getButton(ButtonContainerIngredient.key(i)));
+                if (btn == null) continue;
+                if (ingredient == null) {
+                    btn.removeVariants(guiHandler);
+                    continue;
                 }
+                btn.setVariants(guiHandler, ingredient);
             }
         }
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
@@ -313,12 +313,12 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
         Ingredient inputRight = getInputRight();
         ((ButtonContainerIngredient) cluster.getButton(ButtonContainerIngredient.key(10))).setVariants(guiHandler, inputLeft);
         ((ButtonContainerIngredient) cluster.getButton(ButtonContainerIngredient.key(13))).setVariants(guiHandler, inputRight);
-        if (getMode().equals(CustomRecipeAnvil.Mode.RESULT)) {
-            ((ButtonContainerIngredient) cluster.getButton(ButtonContainerIngredient.key(34))).setVariants(guiHandler, getResult());
-        } else if (getMode().equals(CustomRecipeAnvil.Mode.DURABILITY)) {
-            ((ButtonContainerIngredient) cluster.getButton(ButtonContainerIngredient.key(34))).setVariants(guiHandler, inputLeft);
-        } else {
-            ((ButtonContainerIngredient) cluster.getButton(ButtonContainerIngredient.key(34))).setVariants(guiHandler, Collections.singletonList(new CustomItem(Material.AIR)));
+        var resultBtn = ((ButtonContainerIngredient) cluster.getButton(ButtonContainerIngredient.key(34)));
+        if (resultBtn == null) return;
+        switch (getRepairTask().getMode()) {
+            case RESULT -> resultBtn.setVariants(guiHandler, getResult());
+            case DURABILITY -> resultBtn.setVariants(guiHandler, inputLeft);
+            case NONE -> resultBtn.setVariants(guiHandler, Collections.singletonList(new CustomItem(Material.AIR)));
         }
     }
 


### PR DESCRIPTION
Fixed the Recipe Lookup Command keeping the ingredients from the previous open Recipe and not clearing them.