### PR TITLE
Fix Cauldron Recipe Lava Consumption

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/data/persistent/CauldronBlockData.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/persistent/CauldronBlockData.java
@@ -153,11 +153,12 @@ public class CauldronBlockData extends CustomBlockData {
             if (event.isCancelled()) {
                 passedTicks = 0;
             } else {
-                if (event.getRecipe().getFluidLevel() > 0 && block.getBlockData() instanceof Levelled levelled) {
-                    int newLevel = levelled.getLevel() - event.getRecipe().getFluidLevel();
+                if (event.getRecipe().getFluidLevel() > 0) {
+                    int level = CauldronUtils.getLevel(block);
+                    int newLevel = level - event.getRecipe().getFluidLevel();
                     if (newLevel <= 0) {
                         block.setType(Material.CAULDRON);
-                    } else {
+                    } else if (block.getBlockData() instanceof Levelled levelled) {
                         levelled.setLevel(newLevel);
                         block.setBlockData(levelled);
                     }


### PR DESCRIPTION
Lava Cauldrons are not levelled (do not have a liquid level), so they were not replaced by the empty cauldron block.
Behaviour: Lava will only be consumed when the required level of the recipe is set to 3 level.