### PR TITLE
Fix Cauldron Ingredient Arrangement Inconsistency

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/gui/cauldron/CauldronWorkstationMenu.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/cauldron/CauldronWorkstationMenu.java
@@ -206,9 +206,9 @@ public class CauldronWorkstationMenu extends CCWindow {
                 return;
             }
 
-            event.setButton(10, "crafting.slot_" + 3);
+            event.setButton(10, "crafting.slot_" + 5);
             event.setButton(12, "crafting.slot_" + 4);
-            event.setButton(14, "crafting.slot_" + 5);
+            event.setButton(14, "crafting.slot_" + 3);
 
             event.setButton(20, "crafting.slot_" + 2);
             event.setButton(22, "crafting.slot_" + 1);

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorCauldron.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorCauldron.java
@@ -147,13 +147,11 @@ public class RecipeCreatorCauldron extends RecipeCreator {
         update.setButton(5, ClusterRecipeCreator.PRIORITY);
         update.setButton(7, ClusterRecipeCreator.EXACT_META);
 
-        update.setButton(9, "recipe.ingredient_3");
+        update.setButton(9, "recipe.ingredient_5");
         update.setButton(11, "recipe.ingredient_4");
-        update.setButton(13, "recipe.ingredient_5");
-
+        update.setButton(13, "recipe.ingredient_3");
         update.setButton(19, "recipe.ingredient_2");
         update.setButton(21, "recipe.ingredient_1");
-
         update.setButton(29, "recipe.ingredient_0");
 
         update.setButton(38, "cauldron");

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
@@ -417,15 +417,16 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
         var cluster = guiWindow.getCluster();
         CCPlayerData playerStore = PlayerUtil.getStore(event.getPlayer());
 
-        int slot = 10;
-        for (int i = 5; i > -1; i--) {
-            event.setButton(slot, ButtonContainerIngredient.key(cluster, i));
-            slot += i == 3 ? 9-3 : i == 1 ? 9-1 : 2;
-        }
+        event.setButton(10, ButtonContainerIngredient.key(cluster, 5));
+        event.setButton(12, ButtonContainerIngredient.key(cluster, 4));
+        event.setButton(14, ButtonContainerIngredient.key(cluster, 3));
+        event.setButton(20, ButtonContainerIngredient.key(cluster, 2));
+        event.setButton(22, ButtonContainerIngredient.key(cluster, 1));
+        event.setButton(30, ButtonContainerIngredient.key(cluster, 0));
 
         List<Condition<?>> conditions = getConditions().getValues().stream().filter(condition -> !condition.getNamespacedKey().equals(PermissionCondition.KEY)).toList();
         int startSlot = 9 / (conditions.size() + 1);
-        slot = 0;
+        int slot = 0;
         for (Condition<?> condition : conditions) {
             event.setButton(36 + startSlot + slot, new NamespacedKey(ClusterRecipeBook.KEY, "conditions." + condition.getId()));
             slot += 2;


### PR DESCRIPTION
There is an inconsistency in the arrangement of the cauldron ingredient slots between recipe book, creator and workstation gui.
The proper arrangement is from bottom to top, from right to left: 0, 1, 2, 3, 4, 5 (stack, last ingredient on top)