### PR TITLE
Grindstone Recipe Logic Rewrite

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
@@ -72,13 +72,11 @@ public class GrindStoneListener implements Listener {
         var action = event.getAction();
         var inventory = event.getClickedInventory();
         if (event.getSlot() == 2 && !ItemUtils.isAirOrNull(inventory.getItem(2)) && (action.toString().startsWith("PICKUP_") || action.equals(InventoryAction.COLLECT_TO_CURSOR) || action.equals(InventoryAction.MOVE_TO_OTHER_INVENTORY))) {
-            //Take out item!
             if (preCraftedRecipes.get(player.getUniqueId()) == null) {
                 //Vanilla Recipe
                 return;
             }
             event.setCancelled(true);
-            var grindstoneData = preCraftedRecipes.get(player.getUniqueId());
 
             //Result taken out and placed on cursor or into the inventory.
             ItemStack result = event.getCurrentItem();
@@ -99,13 +97,13 @@ public class GrindStoneListener implements Listener {
 
             inventory.getLocation().getWorld().playSound(inventory.getLocation(), Sound.BLOCK_GRINDSTONE_USE, SoundCategory.BLOCKS, 1f, 1f);
 
+            var grindstoneData = preCraftedRecipes.get(player.getUniqueId());
             if (grindstoneData.getRecipe().getXp() > 0) { //Spawn xp
                 ExperienceOrb orb = (ExperienceOrb) player.getLocation().getWorld().spawnEntity(player.getLocation(), EntityType.EXPERIENCE_ORB);
                 orb.setExperience(grindstoneData.getRecipe().getXp());
             }
             grindstoneData.getResult().executeExtensions(inventory.getLocation() != null ? inventory.getLocation() : player.getLocation(), inventory.getLocation() != null, player);
 
-            //Custom Recipe
             CustomItem inputTop = grindstoneData.getInputTop();
             CustomItem inputBottom = grindstoneData.getInputBottom();
 
@@ -146,7 +144,8 @@ public class GrindStoneListener implements Listener {
         if (!event.getInventory().getType().equals(InventoryType.GRINDSTONE) || event.getInventorySlots().isEmpty())
             return;
         InventoryView view = event.getView();
-        if (event.getRawSlots().stream().noneMatch(integer -> view.getInventory(integer) instanceof GrindstoneInventory)) return;
+        if (event.getRawSlots().stream().noneMatch(integer -> view.getInventory(integer) instanceof GrindstoneInventory))
+            return;
         event.setCancelled(true);
     }
 
@@ -155,12 +154,12 @@ public class GrindStoneListener implements Listener {
         if (data != null) {
             inventory.setItem(2, data.getResult().getItem(player).orElse(new CustomItem(Material.AIR)).create());
             preCraftedRecipes.put(player.getUniqueId(), data);
-        } else {
-            for (ItemStack itemStack : new ItemStack[]{inventory.getItem(0), inventory.getItem(1)}) {
-                if (customCrafting.getApi().getRegistries().getCustomItems().getByItemStack(itemStack).map(CustomItem::isBlockVanillaRecipes).orElse(false)) {
-                    inventory.setItem(2, null);
-                    break;
-                }
+            return;
+        }
+        for (ItemStack itemStack : new ItemStack[]{inventory.getItem(0), inventory.getItem(1)}) {
+            if (customCrafting.getApi().getRegistries().getCustomItems().getByItemStack(itemStack).map(CustomItem::isBlockVanillaRecipes).orElse(false)) {
+                inventory.setItem(2, null);
+                return;
             }
         }
     }

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
@@ -141,10 +141,6 @@ public class GrindStoneListener implements Listener {
         Bukkit.getScheduler().runTask(customCrafting, player::updateInventory); // This is required for actions to be visible in the Grindstone inventory, otherwise it's very glitchy.
     }
 
-    private boolean canBePlacedIntoGrindstone(ItemStack itemStack, ItemStack other) {
-        return !itemStack.getEnchantments().isEmpty() && (ItemUtils.isAirOrNull(other) || itemStack.isSimilar(other));
-    }
-
     @EventHandler(ignoreCancelled = true)
     public void onDrag(InventoryDragEvent event) {
         if (!event.getInventory().getType().equals(InventoryType.GRINDSTONE) || event.getInventorySlots().isEmpty())

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
@@ -143,52 +143,13 @@ public class GrindStoneListener implements Listener {
         var action = event.getAction();
         var inventory = event.getClickedInventory();
         if (event.getSlot() != 2) {
-            //Place in items and click empty result slot
-            final ItemStack cursor = event.getCursor(); //And the item in the cursor
-            final ItemStack currentItem = event.getCurrentItem(); //We want to get the item in the slot
-
             if (event.getAction().toString().startsWith("PICKUP_") || action.equals(InventoryAction.COLLECT_TO_CURSOR) || action.equals(InventoryAction.MOVE_TO_OTHER_INVENTORY)) {
                 return;
             }
-            ItemStack calculatedCursor = cursor;
-            ItemStack calculatedCurrentItem = currentItem;
-            //Place item when the item is valid
-            event.setCancelled(true);
-            if (event.isRightClick()) {
-                //Dropping one item or pick up half
-                if (action.equals(InventoryAction.PICKUP_HALF) || action.equals(InventoryAction.PICKUP_SOME)) return;
-                //Dropping one item
-                if (ItemUtils.isAirOrNull(currentItem)) {
-                    calculatedCurrentItem = cursor.clone();
-                    calculatedCurrentItem.setAmount(1);
-                    calculatedCursor = cursor.clone();
-                    calculatedCursor.setAmount(cursor.getAmount() - 1);
-                } else if (currentItem.isSimilar(cursor) && currentItem.getAmount() < currentItem.getMaxStackSize() && cursor.getAmount() > 0) {
-                    calculatedCurrentItem = currentItem.clone();
-                    calculatedCurrentItem.setAmount(currentItem.getAmount() + 1);
-                    calculatedCursor = cursor.clone();
-                    calculatedCursor.setAmount(cursor.getAmount() - 1);
-                }
-            } else {
-                //Placing an item
-                if (ItemUtils.isAirOrNull(cursor)) return; //Make sure cursor contains item
-                if (!ItemUtils.isAirOrNull(currentItem)) {
-                    if (currentItem.isSimilar(cursor) || cursor.isSimilar(currentItem)) {
-                        int possibleAmount = currentItem.getMaxStackSize() - currentItem.getAmount();
-                        calculatedCurrentItem = currentItem.clone();
-                        calculatedCurrentItem.setAmount(currentItem.getAmount() + (Math.min(cursor.getAmount(), possibleAmount)));
-                        calculatedCursor = cursor.clone();
-                        calculatedCursor.setAmount(cursor.getAmount() - possibleAmount);
-                    } else if (!ItemUtils.isAirOrNull(cursor)) {
-                        calculatedCursor = currentItem.clone();
-                        calculatedCurrentItem = cursor.clone();
-                    }
-                } else {
-                    calculatedCursor = null;
-                    calculatedCurrentItem = cursor.clone();
-                }
-            }
-            Pair<CustomItem, GrindstoneData> checkResult = checkRecipe(calculatedCurrentItem, inventory.getItem(event.getSlot() == 0 ? 1 : 0), event.getSlot(), player, event.getView());
+
+            InventoryUtils.calculateClickedSlot(event);
+
+            Pair<CustomItem, GrindstoneData> checkResult = checkRecipe(inventory.getItem(0), inventory.getItem(1), event.getSlot(), player, event.getView());
             GrindstoneData data = null;
             if (checkResult != null) { //There exists a valid recipe with that ingredient
                 data = checkResult.getValue();

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
@@ -22,7 +22,10 @@
 
 package me.wolfyscript.customcrafting.listeners;
 
+import java.util.HashMap;
+import java.util.UUID;
 import me.wolfyscript.customcrafting.CustomCrafting;
+import me.wolfyscript.customcrafting.recipes.CustomRecipeGrindstone;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
 import me.wolfyscript.customcrafting.recipes.conditions.Conditions;
 import me.wolfyscript.customcrafting.recipes.data.GrindstoneData;
@@ -43,17 +46,12 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.InventoryInteractEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.GrindstoneInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
-
-import java.util.HashMap;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class GrindStoneListener implements Listener {
 

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
@@ -44,6 +44,8 @@ import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.GrindstoneInventory;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 
@@ -144,6 +146,8 @@ public class GrindStoneListener implements Listener {
     public void onDrag(InventoryDragEvent event) {
         if (!event.getInventory().getType().equals(InventoryType.GRINDSTONE) || event.getInventorySlots().isEmpty())
             return;
+        InventoryView view = event.getView();
+        if (event.getRawSlots().stream().noneMatch(integer -> view.getInventory(integer) instanceof GrindstoneInventory)) return;
         event.setCancelled(true);
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
@@ -107,13 +107,13 @@ public class GrindStoneListener implements Listener {
             if (!ItemUtils.isAirOrNull(inputTop)) {
                 ItemStack itemTop = inventory.getItem(0);
                 if (!ItemUtils.isAirOrNull(itemTop)) {
-                    inputTop.remove(itemTop, 1, inventory);
+                    inventory.setItem(0, inputTop.shrink(itemTop, 1, grindstoneData.getBySlot(0).ingredient().isReplaceWithRemains(), inventory, player, null));
                 }
             }
             if (!ItemUtils.isAirOrNull(inputBottom)) {
                 ItemStack itemBottom = inventory.getItem(1);
                 if (!ItemUtils.isAirOrNull(itemBottom)) {
-                    inputBottom.remove(itemBottom, 1, inventory);
+                    inventory.setItem(1, inputBottom.shrink(itemBottom, 1, grindstoneData.getBySlot(1).ingredient().isReplaceWithRemains(), inventory, player, null));
                 }
             }
             //Remove crafted recipe.

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/GrindStoneListener.java
@@ -37,6 +37,8 @@ import me.wolfyscript.utilities.util.inventory.InventoryUtils;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.Player;
@@ -94,6 +96,9 @@ public class GrindStoneListener implements Listener {
                     cursor.setAmount(cursor.getAmount() + result.getAmount());
                 }
             } else return;
+
+            inventory.getLocation().getWorld().playSound(inventory.getLocation(), Sound.BLOCK_GRINDSTONE_USE, SoundCategory.BLOCKS, 1f, 1f);
+
             if (grindstoneData.getRecipe().getXp() > 0) { //Spawn xp
                 ExperienceOrb orb = (ExperienceOrb) player.getLocation().getWorld().spawnEntity(player.getLocation(), EntityType.EXPERIENCE_ORB);
                 orb.setExperience(grindstoneData.getRecipe().getXp());

--- a/src/main/resources/data/customcrafting/items/advanced_crafting_table.conf
+++ b/src/main/resources/data/customcrafting/items/advanced_crafting_table.conf
@@ -39,7 +39,7 @@ equipmentSlots: [],
 consumed: true,
 blockVanillaEquip: false,
 blockPlacement: false,
-blockVanillaRecipes: false,
+blockVanillaRecipes: true,
 rarityPercentage: 1.0,
 permission: "",
 nbtChecks {


### PR DESCRIPTION
The logic to that checks for valid Grindstone recipes has been rewritten to fix issues.

## Changes
* The new logic allows a player to place any item into the Grindstone, which is against vanilla behaviour, but makes it more reliable.
* CustomItems that are blocked in vanilla recipes are no properly blocked in vanilla Grindstone "recipes"
* Custom Grindstone Recipes are playing a sound now.
* Item dragging is no longer blocked in bottom inventory.