### PR TITLE
Fix Cauldron 1.16 Incompatibility & Cauldron GUI changes

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/data/persistent/CauldronBlockData.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/persistent/CauldronBlockData.java
@@ -42,6 +42,8 @@ import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonSetter;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
+import me.wolfyscript.utilities.util.version.MinecraftVersions;
+import me.wolfyscript.utilities.util.version.ServerVersion;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -270,7 +272,12 @@ public class CauldronBlockData extends CustomBlockData {
 
         public CauldronStatus(Block block) {
             this.block = block;
-            this.hasLava = block.getType().equals(Material.LAVA_CAULDRON);
+            if (ServerVersion.isBefore(MinecraftVersions.v1_17)) {
+                // Lava Cauldrons do not exist in pre 1.17
+                this.hasLava = false;
+            } else {
+                this.hasLava = block.getType().equals(Material.LAVA_CAULDRON);
+            }
             this.hasWater = !hasLava && block.getType().equals(Material.WATER_CAULDRON);
             final Block blockBelow = block.getLocation().subtract(0, 1, 0).getBlock();
             this.hasCampfire = blockBelow.getType().equals(Material.CAMPFIRE);

--- a/src/main/java/me/wolfyscript/customcrafting/gui/cauldron/CauldronWorkstationMenu.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/cauldron/CauldronWorkstationMenu.java
@@ -200,9 +200,9 @@ public class CauldronWorkstationMenu extends CCWindow {
             CauldronBlockData blockData = optionalCauldronBlockData.get();
             if (!blockData.isResultEmpty()) {
                 event.setButton(21, "result_0");
-                event.setButton(22, "result_1");
+                event.setButton(23, "result_1");
                 event.setButton(30, "result_2");
-                event.setButton(31, "result_3");
+                event.setButton(32, "result_3");
                 return;
             }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
@@ -281,24 +281,18 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
 
     public boolean checkRecipe(List<ItemStack> items, CauldronBlockData.CauldronStatus status) {
         if (!checkRecipeStatus(status)) return false;
-        int inputI = 0;
+        int ingredientIndex = 0;
         for (Ingredient ingredient : ingredients) {
-            ItemStack input = items.get(inputI);
+            ItemStack input = items.get(ingredientIndex);
             Optional<CustomItem> checkResult = ingredient.check(input, isCheckNBT());
             if (checkResult.isPresent()) {
-                if (checkResult.get().getAmount() == input.getAmount()) {
-                    inputI++;
-                    continue;
-                }
-                return false;
-            }
-            if (!ingredient.isAllowEmpty()) {
-                return false;
-            }
+                if (checkResult.get().getAmount() != input.getAmount()) return false;
+                ingredientIndex++;
+            } else if (!ingredient.isAllowEmpty()) return false;
         }
-        if (inputI < items.size()) {
+        if (ingredientIndex < items.size()) {
             // Make sure that there are no input items left.
-            return items.subList(inputI, items.size()).stream().allMatch(ItemUtils::isAirOrNull);
+            return items.subList(ingredientIndex, items.size()).stream().allMatch(ItemUtils::isAirOrNull);
         }
         return true;
     }


### PR DESCRIPTION
This fixes a 1.16 incompatibility of the cauldron interaction.
Additionally it splits the 4 result item slots in the Cauldron GUI into two 1x2 slots to better center them.