### PR TITLE
Fix Paper incompatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.wolfyscript.wolfyutils.spigot</groupId>
             <artifactId>wolfyutils-spigot</artifactId>
-            <version>4.16.9.5-SNAPSHOT</version>
+            <version>4.16.10.1</version>
             <scope>provided</scope>
         </dependency>
         <!--

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabEliteCraftingTable.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabEliteCraftingTable.java
@@ -22,7 +22,6 @@
 
 package me.wolfyscript.customcrafting.gui.item_creator.tabs;
 
-import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.configs.custom_data.EliteWorkbenchData;
 import me.wolfyscript.customcrafting.configs.customitem.EliteCraftingTableSettings;
@@ -32,6 +31,7 @@ import me.wolfyscript.customcrafting.data.cache.items.ItemsButtonAction;
 import me.wolfyscript.customcrafting.gui.item_creator.ButtonOption;
 import me.wolfyscript.customcrafting.gui.item_creator.MenuItemCreator;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
@@ -154,7 +154,7 @@ public class TabEliteCraftingTable extends ItemCreatorTab {
 
     @Override
     public boolean shouldRender(GuiUpdate<CCCache> update, CCCache cache, Items items, CustomItem customItem, ItemStack item) {
-        return item.getType().isBlock() || (customItem.getApiReference() instanceof ItemsAdderRef iaRef && ((WolfyCoreBukkit) update.getGuiHandler().getWolfyUtils().getCore()).getCompatibilityManager().getPlugins().evaluateIfAvailable("ItemsAdder", ItemsAdderIntegration.class, ia -> ia.getStackInstance(iaRef.getItemID()).map(CustomStack::isBlock).orElse(false)));
+        return item.getType().isBlock() || (customItem.getApiReference() instanceof ItemsAdderRef iaRef && ((WolfyUtilCore) update.getGuiHandler().getWolfyUtils().getCore()).getCompatibilityManager().getPlugins().evaluateIfAvailable("ItemsAdder", ItemsAdderIntegration.class, ia -> ia.getStackInstance(iaRef.getItemID()).map(CustomStack::isBlock).orElse(false)));
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuMain.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuMain.java
@@ -23,7 +23,6 @@
 package me.wolfyscript.customcrafting.gui.main_gui;
 
 import com.wolfyscript.utilities.bukkit.TagResolverUtil;
-import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.data.CCPlayerData;

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/CauldronListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/CauldronListener.java
@@ -22,7 +22,6 @@
 
 package me.wolfyscript.customcrafting.listeners;
 
-import com.wolfyscript.utilities.bukkit.WolfyCoreBukkit;
 import com.wolfyscript.utilities.bukkit.persistent.world.BlockStorage;
 import com.wolfyscript.utilities.bukkit.persistent.world.WorldStorage;
 import me.wolfyscript.customcrafting.CustomCrafting;
@@ -74,7 +73,7 @@ public class CauldronListener implements Listener {
     }
 
     private boolean getCreateAndOpenGUI(Block clicked, final Player player) {
-        WorldStorage worldStorage = ((WolfyCoreBukkit) api.getCore()).getPersistentStorage().getOrCreateWorldStorage(clicked.getWorld());
+        WorldStorage worldStorage = api.getCore().getPersistentStorage().getOrCreateWorldStorage(clicked.getWorld());
         BlockStorage blockStorage = worldStorage.getOrCreateAndSetBlockStorage(clicked.getLocation());
         if (blockStorage.getData(CauldronBlockData.ID, CauldronBlockData.class).isEmpty()) {
             var cauldronBlockData = new CauldronBlockData(blockStorage.getPos(), blockStorage.getChunkStorage());


### PR DESCRIPTION
Removed any usage of WolfyCoreBukkit, because WolfyCore can be either Bukkit or Paper since 4.16.10.1 and cause a CastException otherwise.