### PR TITLE
Fixed InteractionUtils causing glitchy behaviour in ECT and Cauldron GUI

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/gui/InteractionUtils.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/InteractionUtils.java
@@ -26,7 +26,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryInteractEvent;
@@ -110,11 +112,14 @@ public class InteractionUtils {
     }
 
     private static ItemStack placeStack(InventoryClickEvent clickEvent, Function<ItemStack, Integer> amount) {
+        // If there is already a stack in the slot then just return that, and it'll get updated automatically.
         if (!ItemUtils.isAirOrNull(clickEvent.getCurrentItem())) return clickEvent.getCurrentItem();
         // Current is null, so no reference to the inventory stack.
         ItemStack stack = new ItemStack(Objects.requireNonNull(clickEvent.getCursor()));
         stack.setAmount(amount.apply(stack));
-        clickEvent.setCurrentItem(stack);
+        // This is required to keep sync between the external stack apply method and inventory. Otherwise, the stacks would be different instances!
+        // And one tick later, so the event does not need to be cancelled.
+        Bukkit.getScheduler().runTask(CustomCrafting.inst(), () -> clickEvent.setCurrentItem(stack));
         return stack;
     }
 


### PR DESCRIPTION
This fixes glitchy behaviour when placing an item via right-click into a slot of the GUI.
Previously it either showed an invalid stack for a split second, or for non-stackable items it didn't update the cursor.