### PR TITLE
Fixed Recipe Book Empty GUI

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/utils/PlayerUtil.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/PlayerUtil.java
@@ -60,6 +60,10 @@ public class PlayerUtil {
             bookCache.setResearchItems(new ArrayList<>());
             bookCache.setSubFolderPage(0);
             bookCache.setPage(0);
+            if (bookCache.getCategory() != null) {
+                invAPI.openGui(player, ClusterRecipeBook.CATEGORY_OVERVIEW);
+                return;
+            }
         }
 
         // Open directly to the category if we only have one


### PR DESCRIPTION
This fixes an issue where the Recipe Book GUI is empty uppon reopening it while the `recipe_book.keep_last_open` config option is disabled.