### PR TITLE
Better Recipe Book Conversion from old config

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/handlers/ConfigHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/ConfigHandler.java
@@ -33,6 +33,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.apache.commons.io.FileUtils;
+import org.bukkit.util.FileUtil;
 
 public class ConfigHandler {
 
@@ -61,7 +63,13 @@ public class ConfigHandler {
             mainConfig.load();
         }
         loadLang();
-        loadRecipeBookConfig();
+        try {
+            loadRecipeBookConfig();
+        } catch (IOException e) {
+            customCrafting.getLogger().severe("Failed to load recipe_book.conf");
+            e.printStackTrace();
+            this.recipeBookConfig = new RecipeBookConfig(false);
+        }
         renameOldRecipesFolder();
         try {
             loadDefaults();
@@ -70,19 +78,17 @@ public class ConfigHandler {
         }
     }
 
-    public void loadRecipeBookConfig() {
+    public void loadRecipeBookConfig() throws IOException {
         var recipeBookFileJson = new File(customCrafting.getDataFolder(), "recipe_book.json");
         var recipeBookFile = new File(customCrafting.getDataFolder(), "recipe_book.conf");
         if (!recipeBookFileJson.exists() && !recipeBookFile.exists()) {
             customCrafting.saveResource("recipe_book.conf", true);
+        } else if (recipeBookFileJson.exists() && !recipeBookFile.exists()) {
+            // The old json file is used and there is no hocon file available, so let's rename it.
+            FileUtils.moveFile(recipeBookFileJson, recipeBookFile);
         }
-        try {
-            this.recipeBookConfig = customCrafting.getApi().getJacksonMapperUtil().getGlobalMapper().readValue(recipeBookFile.exists() ? recipeBookFile : recipeBookFileJson, RecipeBookConfig.class);
-        } catch (IOException e) {
-            customCrafting.getLogger().severe("Failed to load recipe_book.conf");
-            e.printStackTrace();
-            this.recipeBookConfig = new RecipeBookConfig(false);
-        }
+        // At this point both json and hocon file might be present (due to previous conversion logic), so just load the hocon variant.
+        this.recipeBookConfig = customCrafting.getApi().getJacksonMapperUtil().getGlobalMapper().readValue(recipeBookFile, RecipeBookConfig.class);
     }
 
     public void renameOldRecipesFolder() {


### PR DESCRIPTION
Instead of keeping the old recipe_book.json rename it.
In case there are both recipe_book.json and recipe_book.conf present, then it'll always load the hocon file.