### PR TITLE
Enable Stacktrace printing by default

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
@@ -345,13 +345,14 @@ public class CustomCrafting extends JavaPlugin {
     @Override
     public void onEnable() {
         this.api.initialize();
+        this.configHandler = new ConfigHandler(this);
+        this.configHandler.load();
+
         writeBanner();
         this.patreon.initialize();
         this.patreon.printPatreonCredits();
         writeSeparator();
 
-        this.configHandler = new ConfigHandler(this);
-        this.configHandler.load();
         this.pluginCompatibility.init();
         this.dataHandler = new DataHandler(this);
         this.disableRecipesHandler = new DisableRecipesHandler(this);
@@ -388,9 +389,12 @@ public class CustomCrafting extends JavaPlugin {
         getLogger().info("____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____ ");
         getLogger().info("|    |  | [__   |  |  | |\\/| |    |__/ |__| |___  |  | |\\ | | __ ");
         getLogger().info("|___ |__| ___]  |  |__| |  | |___ |  \\ |  | |     |  | | \\| |__]");
-        getLogger().info(() -> "    Version    | v" + version.getVersion());
-        getLogger().info(() -> "    WolfyUtils | v" + ServerVersion.getWUVersion().getVersion());
-        getLogger().info(() -> "    Bukkit     | " + Bukkit.getVersion() + "(API: " + Bukkit.getBukkitVersion() + ")");
+        getLogger().info(() -> "    Version      | v" + version.getVersion());
+        getLogger().info(() -> "    WolfyUtils   | v" + ServerVersion.getWUVersion().getVersion());
+        getLogger().info(() -> "    Bukkit       | " + Bukkit.getVersion() + "(API: " + Bukkit.getBukkitVersion() + ")");
+        if (!getConfigHandler().getConfig().isPrintingStacktrace()) {
+            getLogger().warning(() -> "    Print Errors | false (Required for Support! Enable `data.print_stacktrace` in config.yml!)");
+        }
     }
 
     public void writeSeparator() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -68,7 +68,7 @@ database:
 
 data:
   # Toggle if the stacktrace should be printed out if a recipe or item fails to load.
-  print_stacktrace: false
+  print_stacktrace: true
   # Do not change this number! It is used for internal conversion of items between Bukkit versions to make sure they are up-to-date.
   bukkit_version: 0
   # Do not change this number! It is used to update configs of recipes and items to new formats!


### PR DESCRIPTION
Change `data.print_stacktrace` to true by default.

From now on stacktraces need to be enabled whenever requesting support or submitting issues. The option to disable it may be removed in the future.