### PR TITLE
Add Missing Fields to recipe_book.conf & Don't save on shutdown

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/CategoryFilter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/CategoryFilter.java
@@ -74,13 +74,13 @@ public class CategoryFilter extends CategorySettings {
         return sort;
     }
 
-    @JsonGetter
-    public Set<Material> getItems() {
-        return items;
+    @JsonGetter("items")
+    public Set<String> getItems() {
+        return items.stream().map(material -> material.getKey().toString().replace("minecraft:", "")).collect(Collectors.toSet());
     }
 
     @JsonAlias("materials")
-    @JsonSetter
+    @JsonSetter("items")
     public void setItems(Set<String> materials) {
         this.items = materials.stream().map(Material::matchMaterial).filter(Objects::nonNull).collect(Collectors.toSet());
         this.totalMaterials.addAll(this.items);

--- a/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/ContentSortation.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/recipebook/ContentSortation.java
@@ -29,7 +29,9 @@ import java.util.List;
 import java.util.Map;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonAutoDetect;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonGetter;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonInclude;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonSetter;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -73,9 +75,21 @@ public class ContentSortation {
         this.recipeOrdering.putAll(recipeOrdering);
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonGetter("recipes")
+    private Map<NamespacedKey, Integer> getRecipeOrder() {
+        return this.recipeOrdering;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonSetter("groups")
     public void addGroupOrdering(Map<String, Integer> groupOrdering) {
         this.groupOrdering.putAll(groupOrdering);
+    }
+
+    @JsonGetter("groups")
+    private Map<String, Integer> getGroupOrder() {
+        return this.groupOrdering;
     }
 
     public DefaultSortAlgo getDefaultSortAlgo() {
@@ -86,14 +100,17 @@ public class ContentSortation {
         return order;
     }
 
+    @JsonIgnore
     public Object2IntMap<NamespacedKey> getRecipeOrdering() {
         return recipeOrdering;
     }
 
+    @JsonIgnore
     public Object2IntMap<String> getGroupOrdering() {
         return groupOrdering;
     }
 
+    @JsonIgnore
     public void sortRecipeContainers(List<RecipeContainer> containers) {
         Comparator<RecipeContainer> comparator = switch (getDefaultSortAlgo()) {
             case NONE -> /* Keep the insertion order */ null;

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/ConfigHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/ConfigHandler.java
@@ -130,7 +130,6 @@ public class ConfigHandler {
         customCrafting.saveResource(recipePath + file + ".conf", true);
     }
 
-
     public void loadLang() {
         var chosenLang = mainConfig.getString("language");
         //Export all the available languages
@@ -151,9 +150,6 @@ public class ConfigHandler {
     }
 
     public void save() throws IOException {
-        if (this.recipeBookConfig != null && this.recipeBookConfig.isShouldSave()) {
-            customCrafting.getApi().getJacksonMapperUtil().getGlobalMapper().writer(getConfig().isPrettyPrinting() ? new DefaultPrettyPrinter() : null).writeValue(new File(customCrafting.getDataFolder(), "recipe_book.conf"), this.recipeBookConfig);
-        }
         getConfig().save();
     }
 


### PR DESCRIPTION
This fixes the issue where the newly added sort and item fields in the `recipe_book.conf` were not saved.
Additionally, from now on the `recipe_book.conf` will no longer be saved on shutdown.