### PR TITLE
Reduce Shapeless Recipe Check Memory Allocation

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
@@ -148,22 +148,24 @@ public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<
      * </p>
      * <p>
      *     The shapeless recipe algorithm tries to efficiently determine if the correct ingredients are used.<br>
-     *     <b>Problem: </b><br>
-     *     Shapeless recipes may have multiple ingredients with multiple variations.
-     *     So an item in the matrix may match multiple ingredients.
-     *     <br>
-     *     <b>Solution:</b><br>
-     *     The current algorithm acts as a tree that tries to eliminate the paths that cannot occur as far as possible.
      *     <p>
-     *     It begins at the first slot in the matrix (root) and continuos until it matches the last slot.
+     *         <h3>Problem:</h3>
+     *         Shapeless recipes may have multiple ingredients with multiple variations.
+     *         So an item in the matrix may match multiple ingredients.
+     *         Due to the non-deterministic initial order of the ingredients in the matrix, the proper order of used ingredients need to be determined when matching it.
+     *     </p>
+     *     <p>
+     *         <h3>Solution:</h3>
+     *         The current algorithm acts as a tree that tries to eliminate the paths that cannot occur as far as possible.
+     *         It begins at the first slot in the matrix (root) and continuos until it matches the last slot.
      *     </p>
      *     <p>
      *     For each slot it matches the item in that slot to the ingredients:
      *     <ul>
-     *         <li>The ingredient is marked as checked for the current slot.</li>
      *         <li>
      *             In case there is a valid ingredient:
      *             <ol>
+     *                 <li>The ingredient is marked as checked for the current slot.</li>
      *                 <li>The ingredient is mapped to the current slot.</li>
      *                 <li>The ingredient/slot pair is stored in the queue.</li>
      *                 <li>continuos to the next slot.</li>

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
@@ -23,13 +23,12 @@
 package me.wolfyscript.customcrafting.recipes;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Streams;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 import me.wolfyscript.customcrafting.CustomCrafting;
@@ -53,7 +52,7 @@ import org.bukkit.inventory.ItemStack;
 public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<C, S>, S extends CraftingRecipeSettings<S>> extends CraftingRecipe<C, S> {
 
     @JsonIgnore
-    private List<Integer> indexes;
+    private IntList indexes;
     @JsonIgnore
     private int combinations = 1;
     @JsonIgnore
@@ -120,7 +119,7 @@ public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<
         this.ingredients = ingredientsNew;
         this.nonEmptyIngredientSize = (int) this.ingredients.stream().filter(ingredient -> !ingredient.isAllowEmpty()).count();
         this.hasAllowedEmptyIngredient = this.nonEmptyIngredientSize != this.ingredients.size();
-        this.indexes = new ArrayList<>();
+        this.indexes = new IntArrayList(this.ingredients.size());
         for (int i = 0; i < this.ingredients.size(); i++) {
             indexes.add(i);
         }
@@ -147,23 +146,23 @@ public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<
     public CraftingData check(CraftManager.MatrixData matrixData) {
         if (isDisabled() || !fitsDimensions(matrixData)) return null;
         final IngredientData[] dataArray = new IngredientData[ingredients.size()];
-        final List<Integer> selectedSlots = new ArrayList<>();
-        final Multimap<Integer, Integer> checkedIndicesPerSlot = HashMultimap.create(ingredients.size(), ingredients.size());
         final ItemStack[] matrix = matrixData.getItems();
+        final IntList selectedSlots = new IntArrayList(matrix.length);
+        final int[] checkedIndicesPerSlot = new int[matrix.length];
         /*
         Previous implementation had the issue that it didn't go through all possible variations and therefore failed to verify the recipe if the items weren't arranged correctly.
         The new implementation should fix that. Of course at the cost of more calculation time... For 9 ingredients not that big of a deal, but for 36, well... that's why 3x3 recipe grids should be the max size possible.
          */
         for (int i = 0; i < matrix.length; ) { //First we go through all the items in the grid.
-            final Collection<Integer> checkedIndices = checkedIndicesPerSlot.get(i);
+            final int checkedIndices = checkedIndicesPerSlot[i];
             final int recipeSlot = checkIngredient(i, matrixData, selectedSlots, checkedIndices, dataArray, matrix[i]); //Get the slot of the ingredient or -1 if non is found.
             if (recipeSlot == -1) {
                 // Invalid ingredient. Does not match current matrix stack.
-                if (i == 0 || checkedIndices.size() == indexes.size()) { //We can directly end the check if it fails for the first slot.
+                if (i == 0 || countOfSetBits(checkedIndices) == indexes.size()) { //We can directly end the check if it fails for the first slot.
                     return null;
                 }
                 if (selectedSlots.size() > i) {
-                    selectedSlots.remove(i); //Add the previous selected recipe slot back into the queue.
+                    selectedSlots.rem(i); //Add the previous selected recipe slot back into the queue.
                 }
                 i--; //Go back to previous slot and recheck it.
                 continue;
@@ -172,23 +171,35 @@ public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<
             } else {
                 selectedSlots.add(recipeSlot); //Add the newly found slot to the used slots.
             }
-            checkedIndicesPerSlot.put(i, recipeSlot); // Ingredient matches current matrix stack, goto next slot
+            checkedIndicesPerSlot[i] = setBit(checkedIndices, recipeSlot); // Ingredient matches current matrix stack, goto next slot
             i++;
         }
         if ((selectedSlots.size() == ingredients.size())) {
             return new CraftingData(this, dataArray);
         }
         if (hasAllowedEmptyIngredient && matrixData.getStrippedSize() == selectedSlots.size()) { //The empty ingredients can be very tricky in shapeless recipes and shouldn't be used... but might as well implement it anyway.
-            if (indexes.stream().filter(index -> !selectedSlots.contains(index)).allMatch(index -> ingredients.get(index).isAllowEmpty())) {
+            if (indexes.intStream().filter(index -> !selectedSlots.contains(index)).allMatch(index -> ingredients.get(index).isAllowEmpty())) {
                 return new CraftingData(this, dataArray);
             }
         }
         return null;
     }
 
-    protected int checkIngredient(int pos, CraftManager.MatrixData matrixData, List<Integer> selectedSlots, Collection<Integer> checkedIndices, IngredientData[] dataArray, ItemStack item) {
+    private static int setBit(int bitSet, int index) {
+        return bitSet | (1<<index);
+    }
+
+    private static boolean getBit(int bitSet, int index) {
+        return (bitSet & (1<<index)) != 0;
+    }
+
+    private static int countOfSetBits(int bitSet) {
+        return Integer.bitCount(bitSet);
+    }
+
+    protected int checkIngredient(int pos, CraftManager.MatrixData matrixData, List<Integer> selectedSlots, Integer checkedIndices, IngredientData[] dataArray, ItemStack item) {
         for (int key : indexes) {
-            if (!selectedSlots.contains(key) && !checkedIndices.contains(key)) {
+            if (!selectedSlots.contains(key) && !getBit(checkedIndices, key)) {
                 final var ingredient = ingredients.get(key);
                 final var checkResult = ingredient.check(item, isCheckNBT());
                 if (checkResult.isPresent()) {


### PR DESCRIPTION
This reduces the memory allocation of the AbstractRecipeShapeless#check method by ~25-30%. 
That of course improves the overall memory allocation of the PreCraftEvent the more shapeless recipes are active.
Additionally, it may improve the performance a bit by reducing garbage collection time.