### PR TITLE
Only Load Recipes/Items from visible & valid Files

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
@@ -125,6 +125,8 @@ public class LocalStorageLoader extends ResourceLoader {
     private void loadItemsInNamespace(String namespace) {
         var customItems = customCrafting.getApi().getRegistries().getCustomItems();
         readFiles(namespace, ITEMS_FOLDER, (relative, file, attrs) -> {
+            String fileName = file.toFile().getName();
+            if (fileName.startsWith(".") || (!fileName.endsWith(".json") && !fileName.endsWith(".conf"))) return FileVisitResult.CONTINUE;
             var namespacedKey = keyFromFile(namespace, relative);
             if (isReplaceData() || !customItems.has(namespacedKey)) {
                 try {
@@ -255,6 +257,8 @@ public class LocalStorageLoader extends ResourceLoader {
         private void loadRecipesInNamespace(String namespace) {
             var injectableValues = new InjectableValues.Std();
             readFiles(namespace, RECIPES_FOLDER, (relative, file, attrs) -> {
+                String fileName = file.toFile().getName();
+                if (fileName.startsWith(".") || (!fileName.endsWith(".json") && !fileName.endsWith(".conf"))) return FileVisitResult.CONTINUE;
                 var namespacedKey = keyFromFile(namespace, relative);
                 if (isReplaceData() || !customCrafting.getRegistries().getRecipes().has(namespacedKey)) {
                     try {
@@ -334,6 +338,7 @@ public class LocalStorageLoader extends ResourceLoader {
         protected void loadOldOrLegacyRecipeFiles(RecipeLoader<?> loader, List<File> files, String namespace) {
             for (File file : files) {
                 var name = file.getName();
+                if (name.startsWith(".") || (!name.endsWith(".json") && !name.endsWith(".conf"))) continue;
                 var namespacedKey = new NamespacedKey(customCrafting, namespace + "/" + name.substring(0, name.lastIndexOf(".")));
                 if (!customCrafting.getRegistries().getRecipes().has(namespacedKey)) {
                     try {

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
@@ -32,7 +32,6 @@ import me.wolfyscript.lib.com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.InjectableValues;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -125,8 +124,7 @@ public class LocalStorageLoader extends ResourceLoader {
     private void loadItemsInNamespace(String namespace) {
         var customItems = customCrafting.getApi().getRegistries().getCustomItems();
         readFiles(namespace, ITEMS_FOLDER, (relative, file, attrs) -> {
-            String fileName = file.toFile().getName();
-            if (fileName.startsWith(".") || (!fileName.endsWith(".json") && !fileName.endsWith(".conf"))) return FileVisitResult.CONTINUE;
+            if (isValidFile(file.toFile())) return FileVisitResult.CONTINUE;
             var namespacedKey = keyFromFile(namespace, relative);
             if (isReplaceData() || !customItems.has(namespacedKey)) {
                 try {
@@ -257,8 +255,7 @@ public class LocalStorageLoader extends ResourceLoader {
         private void loadRecipesInNamespace(String namespace) {
             var injectableValues = new InjectableValues.Std();
             readFiles(namespace, RECIPES_FOLDER, (relative, file, attrs) -> {
-                String fileName = file.toFile().getName();
-                if (fileName.startsWith(".") || (!fileName.endsWith(".json") && !fileName.endsWith(".conf"))) return FileVisitResult.CONTINUE;
+                if (isValidFile(file.toFile())) return FileVisitResult.CONTINUE;
                 var namespacedKey = keyFromFile(namespace, relative);
                 if (isReplaceData() || !customCrafting.getRegistries().getRecipes().has(namespacedKey)) {
                     try {
@@ -338,7 +335,7 @@ public class LocalStorageLoader extends ResourceLoader {
         protected void loadOldOrLegacyRecipeFiles(RecipeLoader<?> loader, List<File> files, String namespace) {
             for (File file : files) {
                 var name = file.getName();
-                if (name.startsWith(".") || (!name.endsWith(".json") && !name.endsWith(".conf"))) continue;
+                if (isValidFile(file)) continue;
                 var namespacedKey = new NamespacedKey(customCrafting, namespace + "/" + name.substring(0, name.lastIndexOf(".")));
                 if (!customCrafting.getRegistries().getRecipes().has(namespacedKey)) {
                     try {

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/ResourceLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/ResourceLoader.java
@@ -22,6 +22,7 @@
 
 package me.wolfyscript.customcrafting.handlers;
 
+import java.io.File;
 import java.io.IOException;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.configs.MainConfig;
@@ -32,7 +33,6 @@ import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -165,4 +165,10 @@ public abstract class ResourceLoader implements Comparable<ResourceLoader>, Keye
     public int compareTo(@NotNull ResourceLoader other) {
         return Integer.compare(other.priority, priority);
     }
+
+    public static boolean isValidFile(File file) {
+        String fileName = file.getName();
+        return fileName.startsWith(".") || (!fileName.endsWith(".json") && !fileName.endsWith(".conf"));
+    }
+
 }


### PR DESCRIPTION
Previously CC tried to load recipes and items from all kinds of files, including hidden `.` files and any file extension, that failed later on deserialization.