### PR TITLE
Fix not being able to reenable recipes

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/compatibility/protocollib/ProtocolLib.java
+++ b/src/main/java/me/wolfyscript/customcrafting/compatibility/protocollib/ProtocolLib.java
@@ -76,8 +76,9 @@ public class ProtocolLib {
 
     private void registerServerSide() {
         recipeFilter = minecraftKey -> {
-            if (minecraftKey.getPrefix().equals(NamespacedKeyUtils.NAMESPACE)) {
-                CustomRecipe<?> recipe = customCrafting.getRegistries().getRecipes().get(NamespacedKey.of(minecraftKey.getFullKey()));
+            if (minecraftKey.getKey().startsWith(ICustomVanillaRecipe.PLACEHOLDER_PREFIX)) return false;
+            if (minecraftKey.getKey().startsWith(ICustomVanillaRecipe.DISPLAY_PREFIX)) {
+                CustomRecipe<?> recipe = customCrafting.getRegistries().getRecipes().get(new NamespacedKey(minecraftKey.getPrefix(), minecraftKey.getKey().replace(ICustomVanillaRecipe.PLACEHOLDER_PREFIX, "").replace(ICustomVanillaRecipe.DISPLAY_PREFIX, "")));
                 if (recipe instanceof ICustomVanillaRecipe<?> vanillaRecipe && vanillaRecipe.isVisibleVanillaBook()) {
                     return !recipe.isHidden() && !recipe.isDisabled();
                 }

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/DisableRecipesHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/DisableRecipesHandler.java
@@ -96,6 +96,8 @@ public class DisableRecipesHandler {
         recipes.add(namespacedKey);
         if (recipe instanceof ICustomVanillaRecipe<?>) {
             Bukkit.removeRecipe(new org.bukkit.NamespacedKey(namespacedKey.getNamespace(), namespacedKey.getKey()));
+            Bukkit.removeRecipe(ICustomVanillaRecipe.toDisplayKey(namespacedKey).bukkit());
+            Bukkit.removeRecipe(ICustomVanillaRecipe.toPlaceholder(namespacedKey).bukkit());
         }
         saveDisabledRecipes();
     }

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/DisableRecipesHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/DisableRecipesHandler.java
@@ -141,7 +141,7 @@ public class DisableRecipesHandler {
             for (Player player1 : Bukkit.getOnlinePlayers()) {
                 player1.undiscoverRecipe(namespacedKey);
             }
-            if (!namespacedKey.getNamespace().equals(NamespacedKeyUtils.NAMESPACE)) {
+            if (!ICustomVanillaRecipe.isPlaceholderOrDisplayRecipe(namespacedKey)) {
                 recipes.add(NamespacedKey.fromBukkit(namespacedKey));
                 //Cache the recipe if it is a Bukkit recipe, so we can add it again at runtime, without the requirement to reload everything.
                 cachedRecipes.put(namespacedKey, bukkitRecipe);

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/cooking/Campfire1_20Listener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/cooking/Campfire1_20Listener.java
@@ -24,9 +24,9 @@ package me.wolfyscript.customcrafting.listeners.cooking;
 
 import java.util.Iterator;
 import me.wolfyscript.customcrafting.CustomCrafting;
+import me.wolfyscript.customcrafting.recipes.ICustomVanillaRecipe;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
 import me.wolfyscript.customcrafting.recipes.conditions.Conditions;
-import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -57,7 +57,7 @@ public class Campfire1_20Listener implements Listener {
                         () -> {
                             Iterator<Recipe> recipeIterator = customCrafting.getApi().getNmsUtil().getRecipeUtil().recipeIterator(me.wolfyscript.utilities.api.nms.inventory.RecipeType.CAMPFIRE_COOKING);
                             while (recipeIterator.hasNext()) {
-                                if (recipeIterator.next() instanceof CookingRecipe<?> recipe && !recipe.getKey().getNamespace().equals(NamespacedKeyUtils.NAMESPACE)) {
+                                if (recipeIterator.next() instanceof CookingRecipe<?> recipe && !ICustomVanillaRecipe.isPlaceholderOrDisplayRecipe(recipe.getKey())) {
                                     if (recipe.getInputChoice().test(source)) {
                                         // Found a vanilla or other plugin recipe that matches.
                                         event.setTotalCookTime(recipe.getCookingTime());

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/cooking/CampfireListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/cooking/CampfireListener.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.Objects;
 import java.util.Optional;
 import me.wolfyscript.customcrafting.CustomCrafting;
+import me.wolfyscript.customcrafting.recipes.ICustomVanillaRecipe;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
 import me.wolfyscript.customcrafting.recipes.conditions.Conditions;
 import me.wolfyscript.customcrafting.recipes.data.CampfireRecipeData;
@@ -70,7 +71,7 @@ public class CampfireListener implements Listener {
                         () -> {
                             Iterator<Recipe> recipeIterator = customCrafting.getApi().getNmsUtil().getRecipeUtil().recipeIterator(me.wolfyscript.utilities.api.nms.inventory.RecipeType.CAMPFIRE_COOKING);
                             while (recipeIterator.hasNext()) {
-                                if (recipeIterator.next() instanceof CookingRecipe<?> recipe && !recipe.getKey().getNamespace().equals(NamespacedKeyUtils.NAMESPACE)) {
+                                if (recipeIterator.next() instanceof CookingRecipe<?> recipe && !ICustomVanillaRecipe.isPlaceholderOrDisplayRecipe(recipe.getKey())) {
                                     if (recipe.getInputChoice().test(event.getItem())) {
                                         // Found a vanilla or other plugin recipe that matches.
                                         campfire.setCookTimeTotal(slot, recipe.getCookingTime());
@@ -115,7 +116,7 @@ public class CampfireListener implements Listener {
                 .ifPresentOrElse(campfireRecipeData -> campfireRecipeData.getRecipe().getResult().getItem(event.getBlock()).ifPresent(customItem -> event.setResult(customItem.create())), () -> {
                     Iterator<Recipe> recipeIterator = customCrafting.getApi().getNmsUtil().getRecipeUtil().recipeIterator(me.wolfyscript.utilities.api.nms.inventory.RecipeType.CAMPFIRE_COOKING);
                     while (recipeIterator.hasNext()) {
-                        if (recipeIterator.next() instanceof CookingRecipe<?> recipe && !recipe.getKey().getNamespace().equals(NamespacedKeyUtils.NAMESPACE)) {
+                        if (recipeIterator.next() instanceof CookingRecipe<?> recipe && !ICustomVanillaRecipe.isPlaceholderOrDisplayRecipe(recipe.getKey())) {
                             if (recipe.getInputChoice().test(event.getSource())) {
                                 // Found a vanilla or other plugin recipe that matches.
                                 event.setResult(recipe.getResult());

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/crafting/EventBasedCraftRecipeHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/crafting/EventBasedCraftRecipeHandler.java
@@ -24,6 +24,7 @@ package me.wolfyscript.customcrafting.listeners.crafting;
 
 import java.util.stream.Stream;
 import me.wolfyscript.customcrafting.CustomCrafting;
+import me.wolfyscript.customcrafting.recipes.ICustomVanillaRecipe;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
 import me.wolfyscript.customcrafting.recipes.conditions.Conditions;
 import me.wolfyscript.customcrafting.utils.CraftManager;
@@ -95,7 +96,7 @@ public class EventBasedCraftRecipeHandler implements Listener {
                         var namespacedKey = NamespacedKey.fromBukkit(((Keyed) e.getRecipe()).getKey());
                         // We need placeholder recipes that simply use material choices, because otherwise we can get duplication issues and buggy behaviour like flickering.
                         // Here we need to disable those placeholder recipes and check for a vanilla recipe the placeholder may override.
-                        if (namespacedKey.getKey().startsWith("cc_placeholder.")) {
+                        if (ICustomVanillaRecipe.isPlaceholderOrDisplayRecipe(((Keyed) e.getRecipe()).getKey())) {
                             // TODO: Can't determine the vanilla recipe! We may need NMS for that in the future. For now simply override vanilla recipes.
                             e.getInventory().setResult(ItemUtils.AIR);
                             Bukkit.getScheduler().runTask(customCrafting, player::updateInventory);

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/smithing/SmithingListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/smithing/SmithingListener.java
@@ -105,7 +105,7 @@ public class SmithingListener implements Listener {
                 }, () -> {
                     if (ItemUtils.isAirOrNull(event.getResult())) return;
                     Bukkit.getRecipesFor(event.getResult()).stream()
-                            .filter(recipe -> recipe instanceof SmithingRecipe smithingRecipe && !smithingRecipe.getKey().getNamespace().equals(NamespacedKeyUtils.NAMESPACE))
+                            .filter(recipe -> recipe instanceof SmithingRecipe smithingRecipe && !ICustomVanillaRecipe.isPlaceholderOrDisplayRecipe(smithingRecipe.getKey()))
                             .findFirst().ifPresentOrElse(recipe -> {
                                 // Valid vanilla recipe exists!
                                 if (recipe instanceof Keyed keyed) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
@@ -79,7 +79,7 @@ public class CraftingRecipeShaped extends AbstractRecipeShaped<CraftingRecipeSha
             Bukkit.addRecipe(placeholderRecipe);
 
             // Return display recipe
-            var recipe = new org.bukkit.inventory.ShapedRecipe(getNamespacedKey().bukkit(), getResult().getItemStack());
+            var recipe = new org.bukkit.inventory.ShapedRecipe(ICustomVanillaRecipe.toDisplayKey(getNamespacedKey()).bukkit(), getResult().getItemStack());
             recipe.shape(getShape());
             mappedIngredients.forEach((character, items) -> recipe.setIngredient(character, getExactRecipeChoiceFor(items)));
             recipe.setGroup(getGroup());

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
@@ -75,7 +75,7 @@ public class CraftingRecipeShapeless extends AbstractRecipeShapeless<CraftingRec
             Bukkit.addRecipe(placeholderShapelessRecipe);
 
             // Return display recipe
-            var shapelessRecipe = new org.bukkit.inventory.ShapelessRecipe(getNamespacedKey().bukkit(), getResult().getItemStack());
+            var shapelessRecipe = new org.bukkit.inventory.ShapelessRecipe(ICustomVanillaRecipe.toDisplayKey(getNamespacedKey()).bukkit(), getResult().getItemStack());
             for (Ingredient value : ingredients) {
                 shapelessRecipe.addIngredient(getExactRecipeChoiceFor(value));
             }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
@@ -58,7 +58,7 @@ public class CustomRecipeBlasting extends CustomRecipeCooking<CustomRecipeBlasti
         if (!getSource().isEmpty()) {
             BlastingRecipe placeholderRecipe = new BlastingRecipe(ICustomVanillaRecipe.toPlaceholder(getNamespacedKey()).bukkit(), getResult().getItemStack(), new RecipeChoice.MaterialChoice(getResult().getItemStack().getType()), getExp(), getCookingTime());
             Bukkit.addRecipe(placeholderRecipe);
-            return new BlastingRecipe(new org.bukkit.NamespacedKey(getNamespacedKey().getNamespace(), getNamespacedKey().getKey()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            return new BlastingRecipe(ICustomVanillaRecipe.toDisplayKey(getNamespacedKey()).bukkit(), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
         }
         return null;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
@@ -61,7 +61,7 @@ public class CustomRecipeFurnace extends CustomRecipeCooking<CustomRecipeFurnace
             FurnaceRecipe placeholderRecipe = new FurnaceRecipe(ICustomVanillaRecipe.toPlaceholder(getNamespacedKey()).bukkit(), getResult().getItemStack(), new RecipeChoice.MaterialChoice(getResult().getItemStack().getType()), getExp(), getCookingTime());
             Bukkit.addRecipe(placeholderRecipe);
             //registerRecipeIntoMinecraft(new FunctionalRecipeBuilderSmelting(getNamespacedKey(), getResult().getItemStack(), getRecipeChoice()));
-            return new FurnaceRecipe(new org.bukkit.NamespacedKey(getNamespacedKey().getNamespace(), getNamespacedKey().getKey()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            return new FurnaceRecipe(ICustomVanillaRecipe.toDisplayKey(getNamespacedKey()).bukkit(), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
         }
         return null;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
@@ -68,7 +68,7 @@ public class CustomRecipeSmoking extends CustomRecipeCooking<CustomRecipeSmoking
         if (!getSource().isEmpty()) {
             SmokingRecipe placeholderRecipe = new SmokingRecipe(ICustomVanillaRecipe.toPlaceholder(getNamespacedKey()).bukkit(), getResult().getItemStack(), new RecipeChoice.MaterialChoice(getResult().getItemStack().getType()), getExp(), getCookingTime());
             Bukkit.addRecipe(placeholderRecipe);
-            return new SmokingRecipe(new org.bukkit.NamespacedKey(getNamespacedKey().getNamespace(), getNamespacedKey().getKey()), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            return new SmokingRecipe(ICustomVanillaRecipe.toDisplayKey(getNamespacedKey()).bukkit(), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
         }
         return null;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
@@ -152,7 +152,7 @@ public class CustomRecipeStonecutter extends CustomRecipe<CustomRecipeStonecutte
     public StonecuttingRecipe getVanillaRecipe() {
         if (!getResult().isEmpty() && !getSource().isEmpty()) {
             RecipeChoice choice = isCheckNBT() ? new RecipeChoice.ExactChoice(getSource().getBukkitChoices()) : new RecipeChoice.MaterialChoice(getSource().getBukkitChoices().stream().map(ItemStack::getType).toList());
-            var recipe = new StonecuttingRecipe(new org.bukkit.NamespacedKey(getNamespacedKey().getNamespace(), getNamespacedKey().getKey()), getResult().getChoices().get(0).create(), choice);
+            var recipe = new StonecuttingRecipe(ICustomVanillaRecipe.toDisplayKey(getNamespacedKey()).bukkit(), getResult().getChoices().get(0).create(), choice);
             recipe.setGroup(group);
             return recipe;
         }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/ICustomVanillaRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/ICustomVanillaRecipe.java
@@ -47,7 +47,23 @@ public interface ICustomVanillaRecipe<T extends Recipe> {
     void setAutoDiscover(boolean autoDiscover);
 
     static NamespacedKey toPlaceholder(NamespacedKey recipeID) {
-        return new NamespacedKey(recipeID.getNamespace(), "cc_placeholder." + recipeID.getKey());
+        return new NamespacedKey(recipeID.getNamespace(), PLACEHOLDER_PREFIX + recipeID.getKey());
+    }
+
+    static NamespacedKey toDisplayKey(NamespacedKey recipeID) {
+        return new NamespacedKey(recipeID.getNamespace(), DISPLAY_PREFIX + recipeID.getKey());
+    }
+
+    static boolean isPlaceholderRecipe(org.bukkit.NamespacedKey bukkitKey) {
+        return bukkitKey.getKey().startsWith(PLACEHOLDER_PREFIX);
+    }
+
+    static boolean isDisplayRecipe(org.bukkit.NamespacedKey bukkitKey) {
+        return bukkitKey.getKey().startsWith(DISPLAY_PREFIX);
+    }
+
+    static boolean isPlaceholderOrDisplayRecipe(org.bukkit.NamespacedKey bukkitKey) {
+        return isPlaceholderRecipe(bukkitKey) || isDisplayRecipe(bukkitKey);
     }
 
 }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/ICustomVanillaRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/ICustomVanillaRecipe.java
@@ -28,6 +28,9 @@ import org.bukkit.inventory.Recipe;
 
 public interface ICustomVanillaRecipe<T extends Recipe> {
 
+    String PLACEHOLDER_PREFIX = "cc_placeholder.";
+    String DISPLAY_PREFIX = "cc_display.";
+
     @JsonIgnore
     T getVanillaRecipe();
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/ICustomVanillaRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/ICustomVanillaRecipe.java
@@ -66,4 +66,8 @@ public interface ICustomVanillaRecipe<T extends Recipe> {
         return isPlaceholderRecipe(bukkitKey) || isDisplayRecipe(bukkitKey);
     }
 
+    static NamespacedKey toOriginalKey(org.bukkit.NamespacedKey bukkitKey) {
+        return new NamespacedKey(bukkitKey.getNamespace(), bukkitKey.getKey().replace(PLACEHOLDER_PREFIX, "").replace(DISPLAY_PREFIX, ""));
+    }
+
 }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/BukkitSmeltAPIAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/BukkitSmeltAPIAdapter.java
@@ -23,10 +23,9 @@
 package me.wolfyscript.customcrafting.utils.cooking;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
+import me.wolfyscript.customcrafting.recipes.ICustomVanillaRecipe;
 import me.wolfyscript.customcrafting.recipes.data.CookingRecipeData;
-import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.utilities.api.nms.inventory.RecipeType;
-import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.Pair;
 import org.bukkit.block.Block;
 import org.bukkit.block.Furnace;
@@ -54,9 +53,9 @@ public class BukkitSmeltAPIAdapter extends SmeltAPIAdapter {
         });
         boolean customRecipe = false;
         while (recipeIterator.hasNext()) {
-            if (recipeIterator.next() instanceof CookingRecipe<?> recipe && recipe.getKey().getNamespace().equals(NamespacedKeyUtils.NAMESPACE) && recipe.getResult().isSimilar(event.getResult())) {
+            if (recipeIterator.next() instanceof CookingRecipe<?> recipe && ICustomVanillaRecipe.isPlaceholderRecipe(recipe.getKey()) && recipe.getResult().isSimilar(event.getResult())) {
                 customRecipe = true;
-                Pair<CookingRecipeData<?>, Boolean> data = processRecipe(event.getSource(), NamespacedKey.fromBukkit(recipe.getKey()), block);
+                Pair<CookingRecipeData<?>, Boolean> data = processRecipe(event.getSource(), ICustomVanillaRecipe.toOriginalKey(recipe.getKey()), block);
                 if (data.getKey() != null) {
                     return data;
                 }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/FurnaceListener1_17Adapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/FurnaceListener1_17Adapter.java
@@ -27,8 +27,8 @@ import java.util.Iterator;
 import java.util.Objects;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.CustomRecipeCooking;
+import me.wolfyscript.customcrafting.recipes.ICustomVanillaRecipe;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
-import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.Pair;
@@ -76,7 +76,7 @@ public class FurnaceListener1_17Adapter implements Listener {
                         default -> me.wolfyscript.utilities.api.nms.inventory.RecipeType.SMELTING;
                     });
                     while (recipeIterator.hasNext()) {
-                        if (recipeIterator.next() instanceof CookingRecipe<?> recipe && !recipe.getKey().getNamespace().equals(NamespacedKeyUtils.NAMESPACE)) {
+                        if (recipeIterator.next() instanceof CookingRecipe<?> recipe && !ICustomVanillaRecipe.isPlaceholderOrDisplayRecipe(recipe.getKey())) {
                             if (recipe.getInputChoice().test(event.getSource())) {
                                 NMSInventoryUtils.setCurrentRecipe(((Furnace) event.getBlock().getState()).getInventory(), new NamespacedKey(recipe.getKey().getNamespace(), recipe.getKey().getKey()));
 

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/PaperSmeltAPIAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/PaperSmeltAPIAdapter.java
@@ -23,9 +23,8 @@
 package me.wolfyscript.customcrafting.utils.cooking;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
+import me.wolfyscript.customcrafting.recipes.ICustomVanillaRecipe;
 import me.wolfyscript.customcrafting.recipes.data.CookingRecipeData;
-import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
-import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.Pair;
 import org.bukkit.block.Block;
 import org.bukkit.block.Furnace;
@@ -43,8 +42,8 @@ public class PaperSmeltAPIAdapter extends SmeltAPIAdapter {
     @Override
     public Pair<CookingRecipeData<?>, Boolean> process(FurnaceSmeltEvent event, Block block, Furnace furnace) {
         var recipe = event.getRecipe();
-        if (recipe != null && recipe.getKey().getNamespace().equals(NamespacedKeyUtils.NAMESPACE)) {
-            return processRecipe(event.getSource(), NamespacedKey.fromBukkit(recipe.getKey()), block);
+        if (recipe != null && ICustomVanillaRecipe.isPlaceholderOrDisplayRecipe(recipe.getKey())) {
+            return processRecipe(event.getSource(), ICustomVanillaRecipe.toOriginalKey(recipe.getKey()), block);
         }
         return new Pair<>(null, false);
     }


### PR DESCRIPTION
Due to the recent placeholder recipe additions, enabling/disabling recipes no longer worked.

This introduced display recipes and properly handles them. Like discovery, etc.
Both placeholder and display recipes are removed from Bukkit when disabled, so it allows for the recipes to be readded when enabled.