### PR TITLE
Fix Recipe Book Title Update Error Upon Reopening

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ButtonContainerIngredient.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ButtonContainerIngredient.java
@@ -139,6 +139,9 @@ public class ButtonContainerIngredient extends Button<CCCache> {
                     book.addResearchItem(customItem);
                     book.setSubFolderRecipes(customItem, recipes);
                     book.setPrepareRecipe(true);
+                    if (inventory.getWindow() instanceof MenuRecipeOverview menuRecipeOverview) {
+                        menuRecipeOverview.updateTitle(guiHandler, player, inventory);
+                    }
                 }
             }
         }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ClusterRecipeBook.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/ClusterRecipeBook.java
@@ -128,6 +128,9 @@ public class ClusterRecipeBook extends CCCluster {
                         }
                         if (!book.getSubFolderRecipes().isEmpty()) {
                             book.setPrepareRecipe(true);
+                            if (guiInventory.getWindow() instanceof MenuRecipeOverview menuRecipeOverview) {
+                                menuRecipeOverview.updateTitle(guiHandler, player, guiInventory);
+                            }
                         }
                         return true;
                     }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeOverview.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeOverview.java
@@ -117,6 +117,7 @@ public class MenuRecipeOverview extends CCWindow {
             if (nextPage < book.getSubFolderRecipes().size()) {
                 book.setSubFolderPage(nextPage);
                 book.setPrepareRecipe(true);
+                updateTitle(guiHandler, player, guiInventory);
             }
             return true;
         }).render((cache, guiHandler, player, guiInventory, itemStack, i) -> {
@@ -129,6 +130,7 @@ public class MenuRecipeOverview extends CCWindow {
             if (book.getSubFolderPage() > 0) {
                 book.setSubFolderPage(book.getSubFolderPage() - 1);
                 book.setPrepareRecipe(true);
+                updateTitle(guiHandler, player, guiInventory);
             }
             return true;
         }).render((cache, guiHandler, player, guiInventory, itemStack, i) -> {

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeOverview.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeOverview.java
@@ -137,6 +137,18 @@ public class MenuRecipeOverview extends CCWindow {
         })).register();
     }
 
+    void updateTitle(GuiHandler<CCCache> guiHandler, Player player, GUIInventory<CCCache> inventory) {
+        if (ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 20, 0))) {
+            try {
+                player.getOpenInventory().setTitle(BukkitComponentSerializer.legacy().serialize(onUpdateTitle(player, inventory, guiHandler)));
+            } catch (IllegalArgumentException exception) {
+                // EMPTY! This shouldn't happen, just make sure to catch it.
+            }
+        } else {
+            InventoryUpdate.updateInventory(wolfyUtilities.getCore(), player, onUpdateTitle(player, inventory, guiHandler));
+        }
+    }
+
     @Override
     public void onUpdateAsync(GuiUpdate<CCCache> event) {
         super.onUpdateAsync(event);

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeOverview.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook/MenuRecipeOverview.java
@@ -176,11 +176,6 @@ public class MenuRecipeOverview extends CCWindow {
                     //A new prepare can be queued by using book.setPrepareRecipe(true)
                     recipeBookCache.applyRecipeToButtons(event.getGuiHandler(), customRecipe);
                     recipeBookCache.setPrepareRecipe(false);
-                    if (ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 20, 0))) {
-                        player.getOpenInventory().setTitle(BukkitComponentSerializer.legacy().serialize(onUpdateTitle(player, event.getInventory(), event.getGuiHandler())));
-                    } else {
-                        InventoryUpdate.updateInventory(wolfyUtilities.getCore(), player, onUpdateTitle(player, event.getInventory(), event.getGuiHandler()));
-                    }
                 }
                 customRecipe.renderMenu(this, event);
                 boolean elite = RecipeType.Container.ELITE_CRAFTING.isInstance(customRecipe);


### PR DESCRIPTION
This PR fixes #287 - Inventory title error

This error occured when having the `recipe_book.keep_last_open` enabled and reopening the recipe book after looking at a recipe.