### PR TITLE
Fix Disappearing Ingredients When Using Recipe Book Recipe Completion

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/CustomCrafting.java
@@ -416,7 +416,7 @@ public class CustomCrafting extends JavaPlugin {
         pM.registerEvents(new EliteWorkbenchListener(api), this);
         pM.registerEvents(new GrindStoneListener(this), this);
         pM.registerEvents(new BrewingStandListener(api, this), this);
-        pM.registerEvents(new RecipeBookListener(), this);
+        pM.registerEvents(new RecipeBookListener(this), this);
         pM.registerEvents(new SmithingListener(this), this);
         if (ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 20, 0))) {
             pM.registerEvents(new Campfire1_20Listener(this), this);

--- a/src/main/java/me/wolfyscript/customcrafting/compatibility/protocollib/ProtocolLib.java
+++ b/src/main/java/me/wolfyscript/customcrafting/compatibility/protocollib/ProtocolLib.java
@@ -105,25 +105,27 @@ public class ProtocolLib {
             }
         });
 
-        protocolManager.addPacketListener(new PacketAdapter(customCrafting, ListenerPriority.HIGH, PacketType.Play.Client.AUTO_RECIPE) {
-            @Override
-            public void onPacketReceiving(PacketEvent event) {
-                //Call the PrepareItemCraftEvent one more time, if the recipe is a custom recipe, to update the last ingredient in the grid
-                //Issue #136 – Items disappear when using recipe book on crafting table.
-                NamespacedKey recipeId = NamespacedKey.of(event.getPacket().getMinecraftKeys().read(0).getFullKey());
-                if (customCrafting.getRegistries().getRecipes().has(recipeId)) {
-                    Player player = event.getPlayer();
-                    if (player.getOpenInventory().getTopInventory() instanceof CraftingInventory craftingInventory) {
-                        Runnable callPreEvent = () -> Bukkit.getPluginManager().callEvent(new PrepareItemCraftEvent(craftingInventory, event.getPlayer().getOpenInventory(), false));
-                        if (event.isAsync()) {
-                            Bukkit.getScheduler().runTask(customCrafting, callPreEvent);
-                        } else {
-                            callPreEvent.run();
+        if (!customCrafting.isPaper()) {
+            protocolManager.addPacketListener(new PacketAdapter(customCrafting, ListenerPriority.HIGH, PacketType.Play.Client.AUTO_RECIPE) {
+                @Override
+                public void onPacketReceiving(PacketEvent event) {
+                    //Call the PrepareItemCraftEvent one more time, if the recipe is a custom recipe, to update the last ingredient in the grid
+                    //Issue #136 – Items disappear when using recipe book on crafting table.
+                    NamespacedKey recipeId = NamespacedKey.of(event.getPacket().getMinecraftKeys().read(0).getFullKey());
+                    if (customCrafting.getRegistries().getRecipes().has(recipeId)) {
+                        Player player = event.getPlayer();
+                        if (player.getOpenInventory().getTopInventory() instanceof CraftingInventory craftingInventory) {
+                            Runnable callPreEvent = () -> Bukkit.getPluginManager().callEvent(new PrepareItemCraftEvent(craftingInventory, event.getPlayer().getOpenInventory(), false));
+                            if (event.isAsync()) {
+                                Bukkit.getScheduler().runTask(customCrafting, callPreEvent);
+                            } else {
+                                callPreEvent.run();
+                            }
                         }
                     }
                 }
-            }
-        });
+            });
+        }
 
         //Prevent spam clicking of the recipe book, which might cause lag when players are using auto-clickers
         if (!customCrafting.getApi().getCore().getCompatibilityManager().getPlugins().hasIntegration("ItemsAdder")) {

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/RecipeBookListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/RecipeBookListener.java
@@ -22,17 +22,32 @@
 
 package me.wolfyscript.customcrafting.listeners;
 
+import com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent;
+import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.gui.recipebook.ClusterRecipeBook;
 import me.wolfyscript.customcrafting.gui.recipebook.ClusterRecipeView;
+import me.wolfyscript.customcrafting.recipes.ICustomVanillaRecipe;
 import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 
 import java.util.Objects;
+import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.inventory.CraftingInventory;
 
 public class RecipeBookListener implements Listener {
+
+    private CustomCrafting customCrafting;
+
+    public RecipeBookListener(CustomCrafting customCrafting) {
+        this.customCrafting = customCrafting;
+        if (customCrafting.isPaper()) {
+            Bukkit.getPluginManager().registerEvents(new PaperListener(), customCrafting);
+        }
+    }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     private void onClickBottomInv(InventoryClickEvent event) {
@@ -43,4 +58,17 @@ public class RecipeBookListener implements Listener {
             }
         }
     }
+
+    public class PaperListener implements Listener {
+
+        @EventHandler
+        public void onRecipeBookClick(PlayerRecipeBookClickEvent event) {
+            if (!ICustomVanillaRecipe.isDisplayRecipe(event.getRecipe())) return;
+            if (event.getPlayer().getOpenInventory().getTopInventory() instanceof CraftingInventory craftingInventory) {
+                Bukkit.getScheduler().runTask(customCrafting, () -> Bukkit.getPluginManager().callEvent(new PrepareItemCraftEvent(craftingInventory, event.getPlayer().getOpenInventory(), false)));
+            }
+        }
+
+    }
+
 }


### PR DESCRIPTION
When clicking on recipes in the vanilla recipe book it sometimes causes the last ingredient to not be deteced by CC and is completely removed when collecting the result.

This PR fixes this issue on Paper servers and on servers using the ProtocolLib plugin.
If the server is neither a Paper server nor has the plugin ProtocolLib installed the issue will persist.