### PR TITLE
Fix Invalid Ingredient slots in 1.19 Smithing Recipes

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/listeners/smithing/SmithingListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/smithing/SmithingListener.java
@@ -66,9 +66,6 @@ public class SmithingListener implements Listener {
     private final CustomCrafting customCrafting;
 
     private static final boolean IS_1_20 = ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 20, 0));
-    private static final int RESULT_SLOT = IS_1_20 ? 3 : 2;
-    private static final int BASE_SLOT = IS_1_20 ? 1 : 0;
-    private static final int ADDITION_SLOT = IS_1_20 ? 2 : 1;
 
     public SmithingListener(CustomCrafting customCrafting) {
         this.customCrafting = customCrafting;
@@ -88,8 +85,8 @@ public class SmithingListener implements Listener {
         }
 
         var template = IS_1_20 ? inv.getItem(0) : null;
-        var base = inv.getItem(BASE_SLOT);
-        var addition = inv.getItem(ADDITION_SLOT);
+        var base = inv.getItem(CustomRecipeSmithing.BASE_SLOT);
+        var addition = inv.getItem(CustomRecipeSmithing.ADDITION_SLOT);
         preCraftedRecipes.put(player.getUniqueId(), null);
 
         customCrafting.getRegistries().getRecipes().getAvailable(RecipeType.SMITHING).stream()
@@ -125,7 +122,7 @@ public class SmithingListener implements Listener {
             event.setResult(baseCopy);
         } else {
             if (!adapters.isEmpty()) {
-                MergeOption option = new MergeOption(new int[]{BASE_SLOT});
+                MergeOption option = new MergeOption(new int[]{CustomRecipeSmithing.BASE_SLOT});
                 option.setAdapters(adapters);
                 // This acts as if we appended extra merge adapters to the end of the result.
                 // This makes it possible to implement the logic just once and not both in smithing listener and merge adapter.
@@ -142,7 +139,7 @@ public class SmithingListener implements Listener {
         var player = (Player) event.getWhoClicked();
         var action = event.getAction();
         var inventory = event.getClickedInventory();
-        if (event.getSlot() == RESULT_SLOT && !ItemUtils.isAirOrNull(event.getCurrentItem()) && action.equals(InventoryAction.NOTHING)) {
+        if (event.getSlot() == CustomRecipeSmithing.RESULT_SLOT && !ItemUtils.isAirOrNull(event.getCurrentItem()) && action.equals(InventoryAction.NOTHING)) {
             //Take out item!
             if (preCraftedRecipes.get(player.getUniqueId()) == null) {
                 //Vanilla Recipe
@@ -163,22 +160,22 @@ public class SmithingListener implements Listener {
             final var smithingData = preCraftedRecipes.get(player.getUniqueId());
             smithingData.getResult().executeExtensions(inventory.getLocation() != null ? inventory.getLocation() : player.getLocation(), inventory.getLocation() != null, player);
 
-            final var baseItem = Objects.requireNonNull(inventory.getItem(BASE_SLOT)).clone();
-            final var additionItem = Objects.requireNonNull(inventory.getItem(ADDITION_SLOT)).clone();
+            final var baseItem = Objects.requireNonNull(inventory.getItem(CustomRecipeSmithing.BASE_SLOT)).clone();
+            final var additionItem = Objects.requireNonNull(inventory.getItem(CustomRecipeSmithing.ADDITION_SLOT)).clone();
 
             if (smithingData.getTemplate() != null) {
                 final var templateItem = Objects.requireNonNull(inventory.getItem(0));
                 inventory.setItem(0, smithingData.getTemplate().shrink(templateItem, 1, true, inventory, null, null));
             }
-            inventory.setItem(BASE_SLOT, smithingData.getBase().shrink(baseItem, 1, true, inventory, null, null));
-            inventory.setItem(ADDITION_SLOT, smithingData.getAddition().shrink(additionItem, 1, true, inventory, null, null));
+            inventory.setItem(CustomRecipeSmithing.BASE_SLOT, smithingData.getBase().shrink(baseItem, 1, true, inventory, null, null));
+            inventory.setItem(CustomRecipeSmithing.ADDITION_SLOT, smithingData.getAddition().shrink(additionItem, 1, true, inventory, null, null));
 
             if (inventory.getLocation() != null) {
                 inventory.getLocation().getWorld().playSound(inventory.getLocation(), Sound.BLOCK_SMITHING_TABLE_USE, SoundCategory.BLOCKS, 1, 1);
             }
             preCraftedRecipes.remove(player.getUniqueId());
 
-            inventory.setItem(RESULT_SLOT, smithingData.getResult().getItem(smithingData, player, inventory.getLocation() != null ? inventory.getLocation().getBlock() : player.getLocation().getBlock()));
+            inventory.setItem(CustomRecipeSmithing.RESULT_SLOT, smithingData.getResult().getItem(smithingData, player, inventory.getLocation() != null ? inventory.getLocation().getBlock() : player.getLocation().getBlock()));
         }
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
@@ -73,6 +73,11 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> imp
     private static final String KEY_BASE = "base";
     private static final String KEY_ADDITION = "addition";
 
+    private static final boolean IS_1_20 = ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 20, 0));
+    public static final int RESULT_SLOT = IS_1_20 ? 3 : 2;
+    public static final int BASE_SLOT = IS_1_20 ? 1 : 0;
+    public static final int ADDITION_SLOT = IS_1_20 ? 2 : 1;
+
     private Ingredient template;
     private Ingredient base;
     private Ingredient addition;
@@ -97,7 +102,7 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> imp
     @JsonCreator
     public CustomRecipeSmithing(@JsonProperty("key") @JacksonInject("key") NamespacedKey key, @JacksonInject("customcrafting") CustomCrafting customCrafting) {
         super(key, customCrafting, RecipeType.SMITHING);
-        this.template = new Ingredient();
+        this.template = ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 20, 0)) ? new Ingredient(Material.NETHERITE_UPGRADE_SMITHING_TEMPLATE) : new Ingredient();
         this.base = new Ingredient();
         this.addition = new Ingredient();
         this.result = new Result();
@@ -142,12 +147,12 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> imp
 
         Optional<CustomItem> baseCustom = getBase().check(base, isCheckNBT());
         if (baseCustom.isPresent()) {
-            baseData = new IngredientData(1, 1, getBase(), baseCustom.get(), base);
+            baseData = new IngredientData(BASE_SLOT, BASE_SLOT, getBase(), baseCustom.get(), base);
         } else if (!getBase().isAllowEmpty()) return null;
 
         Optional<CustomItem> additionCustom = getAddition().check(addition, isCheckNBT());
         if (additionCustom.isPresent()) {
-            additionData = new IngredientData(1, 1, getAddition(), additionCustom.get(), base);
+            additionData = new IngredientData(ADDITION_SLOT, ADDITION_SLOT, getAddition(), additionCustom.get(), base);
         } else if (!getAddition().isAllowEmpty()) return null;
 
         return new SmithingData(this, new IngredientData[]{templateData, baseData, additionData});


### PR DESCRIPTION
When caching the recipe data for smithing recipes it used 1.20 ingredient slots on 1.19 servers causing issues with results.