### PR TITLE
Fix Error on interactions in Recipe Lookup Menu

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/RecipeBookCache.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/RecipeBookCache.java
@@ -158,7 +158,7 @@ public class RecipeBookCache {
     }
 
     public CustomItem getResearchItem() {
-        return getResearchItems().get(0);
+        return !getResearchItems().isEmpty() ? getResearchItems().get(0) : null;
     }
 
     public void applyRecipeToButtons(GuiHandler<CCCache> guiHandler, CustomRecipe<?> recipe) {


### PR DESCRIPTION
Fix IndexOutOfBoundsException in Recipe Lookup Menu that occured when clicking on ingredients or result slots.