### PR TITLE
Fix Campfire Interaction with Buckets, Flint and Steel, and more

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/listeners/cooking/CampfireListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/cooking/CampfireListener.java
@@ -65,7 +65,7 @@ public class CampfireListener implements Listener {
             return;
         if (ItemUtils.isAirOrNull(event.getItem())) return;
         Material itemType = event.getItem().getType();
-        if (itemType == Material.WATER_BUCKET || itemType == Material.FLINT_AND_STEEL || itemType.toString().endsWith("_SHOVEL"))
+        if (itemType == Material.FIRE_CHARGE || itemType == Material.WATER_BUCKET || itemType == Material.FLINT_AND_STEEL || itemType.toString().endsWith("_SHOVEL"))
             return;
 
         Campfire campfire = (Campfire) event.getClickedBlock().getState();

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/cooking/CampfireListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/cooking/CampfireListener.java
@@ -22,16 +22,12 @@
 
 package me.wolfyscript.customcrafting.listeners.cooking;
 
-import java.util.Iterator;
-import java.util.Objects;
-import java.util.Optional;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.ICustomVanillaRecipe;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
 import me.wolfyscript.customcrafting.recipes.conditions.Conditions;
 import me.wolfyscript.customcrafting.recipes.data.CampfireRecipeData;
 import me.wolfyscript.customcrafting.recipes.data.IngredientData;
-import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import org.bukkit.Material;
@@ -43,6 +39,10 @@ import org.bukkit.event.block.BlockCookEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.CookingRecipe;
 import org.bukkit.inventory.Recipe;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Handles campfire recipes without any NMS (which was used in previous versions of CC).
@@ -57,11 +57,16 @@ public class CampfireListener implements Listener {
         this.customCrafting = customCrafting;
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onInteractCampfire(PlayerInteractEvent event) {
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
-        if (event.getClickedBlock() == null || (event.getClickedBlock().getType() != Material.CAMPFIRE && event.getClickedBlock().getType() != Material.SOUL_CAMPFIRE)) return;
+        if (event.getClickedBlock() == null || (event.getClickedBlock().getType() != Material.CAMPFIRE && event.getClickedBlock().getType() != Material.SOUL_CAMPFIRE))
+            return;
         if (ItemUtils.isAirOrNull(event.getItem())) return;
+        Material itemType = event.getItem().getType();
+        if (itemType == Material.WATER_BUCKET || itemType == Material.FLINT_AND_STEEL || itemType.toString().endsWith("_SHOVEL"))
+            return;
+
         Campfire campfire = (Campfire) event.getClickedBlock().getState();
         getFirstEmptySlot(campfire).ifPresent(slot -> customCrafting.getRegistries().getRecipes().get(RecipeType.CAMPFIRE).stream()
                 .filter(recipe1 -> recipe1.getSource().check(event.getItem(), recipe1.isCheckNBT()).isPresent() && recipe1.checkConditions(Conditions.Data.of(campfire.getBlock())))


### PR DESCRIPTION
The new campfire interaction listener blocked all campfire interactions when the items didn't match a recipe.
This is now fixed. 
Water Bucket, Flint and Steel, Shovels, and the Fire Charge will no longer work inside of campfire recipes! They will always interact with the campfire in the way they were meant to.