### PR TITLE
Fix Invalid Cooking Recipe Result

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/CookingManager.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/CookingManager.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class CookingManager {
 
     private final CustomCrafting plugin;
-    final Map<BlockPositionData, Pair<CookingRecipeData<?>, Boolean>> cachedRecipeData = new ConcurrentHashMap<>();
+    private final Map<BlockPositionData, Pair<CookingRecipeData<?>, Boolean>> cachedRecipeData = new ConcurrentHashMap<>();
     private final SmeltAPIAdapter smeltAdapter;
 
     public CookingManager(CustomCrafting plugin) {

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/SmeltAPIAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/SmeltAPIAdapter.java
@@ -93,12 +93,12 @@ public abstract class SmeltAPIAdapter {
      */
     public void applyResult(FurnaceSmeltEvent event) {
         var block = event.getBlock();
-        if (manager.cachedRecipeData.get(block) != null) {
+        manager.getCustomRecipeCache(block).ifPresent(cachedData -> {
             FurnaceInventory inventory = ((Furnace) event.getBlock().getState()).getInventory();
             ItemStack smelting = inventory.getSmelting();
             if (ItemUtils.isAirOrNull(smelting)) return;
 
-            var data = manager.cachedRecipeData.get(block).getKey();
+            var data = cachedData.getKey();
             Bukkit.getScheduler().runTaskLater(customCrafting, () -> manager.clearCache(block), 1); //Clearing the cached data after 1 tick (event should be done).
             if (data == null) return;
             var result = data.getResult();
@@ -124,7 +124,7 @@ public abstract class SmeltAPIAdapter {
             result.executeExtensions(block.getLocation(), true, null);
             result.removeCachedItem(block);
             block.getState().update(); // Update the state of the block. Just in case!
-        }
+        });
     }
 
 }


### PR DESCRIPTION
When smelting a vanilla recipe and a custom recipe, that uses the same ingredient item type, right after, causes it to produce the vanilla result instead.
Fixed by properly reading the cached custom cooking recipe when applying the result.