### PR TITLE
Add Exlude Option to Lore, Book & Banner Merge Adapter

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipebook_editor/ButtonSaveCategory.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipebook_editor/ButtonSaveCategory.java
@@ -22,7 +22,6 @@
 
 package me.wolfyscript.customcrafting.gui.recipebook_editor;
 
-import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.configs.recipebook.Category;
 import me.wolfyscript.customcrafting.configs.recipebook.CategoryFilter;
 import me.wolfyscript.customcrafting.configs.recipebook.CategorySettings;
@@ -32,7 +31,6 @@ import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Plac
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.gui.GuiMenuComponent;
 import me.wolfyscript.utilities.api.inventory.gui.button.CallbackButtonRender;
-import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ActionButton;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import org.bukkit.Material;
 import org.bukkit.util.StringUtil;
@@ -41,7 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-class ButtonSaveCategory extends ActionButton<CCCache> {
+class ButtonSaveCategory {
 
     public static void registerSave(GuiMenuComponent.ButtonBuilder<CCCache> buttonBuilder) {
         buttonBuilder.action(ClusterRecipeBookEditor.SAVE.getKey())
@@ -90,43 +88,6 @@ class ButtonSaveCategory extends ActionButton<CCCache> {
                         })
                 )
                 .register();
-    }
-
-
-    ButtonSaveCategory(boolean saveAs, CustomCrafting customCrafting) {
-        super(saveAs ? ClusterRecipeBookEditor.SAVE_AS.getKey() : ClusterRecipeBookEditor.SAVE.getKey(), Material.WRITABLE_BOOK, (cache, guiHandler, player, inventory, slot, event) -> {
-            var recipeBookEditor = cache.getRecipeBookEditorCache();
-            WolfyUtilities api = guiHandler.getApi();
-
-            if (saveAs) {
-                guiHandler.setChatTabComplete((guiHandler1, player1, args) -> {
-                    List<String> results = new ArrayList<>();
-                    if (args.length == 1) {
-                        StringUtil.copyPartialMatches(args[0], recipeBookEditor.getEditorConfigCopy().getCategories().keySet(), results);
-                    }
-                    Collections.sort(results);
-                    return results;
-                });
-                inventory.getWindow().openChat(guiHandler, inventory.getWindow().getCluster().translatedMsgKey("save.input"), (guiHandler1, player1, s, args) -> {
-                    if (s != null && !s.isEmpty() && recipeBookEditor.setCategoryID(s)) {
-                        if (saveCategorySetting(recipeBookEditor)) {
-                            guiHandler1.openPreviousWindow();
-                            return true;
-                        }
-                        api.getChat().sendKey(player1, ClusterRecipeBookEditor.KEY, "save.error");
-                    }
-                    return false;
-                });
-                return true;
-            } else if (recipeBookEditor.hasCategoryID()) {
-                if (saveCategorySetting(recipeBookEditor)) {
-                    guiHandler.openPreviousWindow();
-                } else {
-                    api.getChat().sendKey(player, ClusterRecipeBookEditor.KEY, "save.error");
-                }
-            }
-            return true;
-        });
     }
 
     private static boolean saveCategorySetting(RecipeBookEditorCache recipeBookEditorCache) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/BannerMergeAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/BannerMergeAdapter.java
@@ -180,10 +180,14 @@ public class BannerMergeAdapter extends MergeAdapter {
 
         @Override
         public boolean isEqual(Pattern value, EvalContext evalContext) {
-            return value().map(provider -> {
-                PatternOption option = provider.getValue(evalContext);
-                return option.type == value.getPattern() && option.dyeColor == value.getColor();
-            }).orElse(true);
+            boolean exclude = exclude().map(shouldExclude -> shouldExclude.evaluate(evalContext)).orElse(false);
+            for (ValueProvider<PatternOption> valueProvider : values()) {
+                PatternOption option = valueProvider.getValue(evalContext);
+                if (option.type == value.getPattern() && option.dyeColor == value.getColor()) {
+                    return !exclude;
+                }
+            }
+            return exclude;
         }
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/ElementOptionComponentBukkit.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/ElementOptionComponentBukkit.java
@@ -22,6 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes.items.target.adapters;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntComparators;
+import it.unimi.dsi.fastutil.ints.IntList;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.lib.net.kyori.adventure.platform.bukkit.BukkitComponentSerializer;
 import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.MiniMessage;
@@ -30,19 +33,19 @@ import me.wolfyscript.utilities.util.eval.context.EvalContext;
 import me.wolfyscript.utilities.util.eval.value_providers.ValueProvider;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 public class ElementOptionComponentBukkit extends ElementOption<String, String> {
 
     public boolean isEqual(String value, EvalContext evalContext, MiniMessage miniMessage, TagResolver... tagResolvers) {
-        boolean exclude = exclude().map(shouldExclude -> shouldExclude.evaluate(evalContext)).orElse(false);
         for (ValueProvider<String> valueProvider : values()) {
             if (Objects.equals(miniMessage.deserialize(valueProvider.getValue(evalContext), tagResolvers), BukkitComponentSerializer.legacy().deserialize(value))) {
-                return !exclude;
+                return true;
             }
         }
-        return exclude;
+        return false;
     }
 
     @Override
@@ -53,29 +56,51 @@ public class ElementOptionComponentBukkit extends ElementOption<String, String> 
     public List<String> readFromSource(List<String> source, EvalContext evalContext, MiniMessage miniMessage, TagResolver... tagResolvers) {
         List<String> result = new ArrayList<>();
         if (condition().map(boolOperator -> boolOperator.evaluate(evalContext)).orElse(true)) {
-            index().ifPresentOrElse(indexProvider -> {
-                int index = indexProvider.getValue(evalContext);
-                if (index < 0) {
-                    index = source.size() + (index % source.size()); //Convert the negative index to a positive reverted index, that starts from the end.
-                }
-                index = index % source.size(); //Prevent out of bounds
-                if (source.size() > index) {
-                    String targetValue = source.get(index);
-                    if (isEqual(targetValue, evalContext, miniMessage, tagResolvers)) {
-                        result.add(targetValue);
+            boolean shouldExclude = exclude().map(boolOperator -> boolOperator.evaluate(evalContext)).orElse(false);
+            if (!indices().isEmpty()) {
+                IntList indicesUsed = new IntArrayList();
+                for (ValueProvider<Integer> indexProvider : indices()) {
+                    int index = indexProvider.getValue(evalContext);
+                    if (index < 0) {
+                        index = source.size() + (index % source.size()); //Convert the negative index to a positive reverted index, that starts from the end.
+                    }
+                    index = index % source.size(); //Prevent out of bounds
+                    if (source.size() > index) {
+                        String targetValue = source.get(index);
+                        if (isEqual(targetValue, evalContext, miniMessage, tagResolvers)) {
+                            indicesUsed.add(index);
+                        } else if (values().isEmpty() && shouldExclude) {
+                            indicesUsed.add(index);
+                        }
                     }
                 }
-            }, () -> {
-                if (values().isEmpty()) {
+                indicesUsed.sort(IntComparators.OPPOSITE_COMPARATOR);
+
+                if (shouldExclude) {
                     result.addAll(source);
-                    return;
                 }
+                for (int index : indicesUsed) {
+                    if (shouldExclude) {
+                        result.remove(index);
+                    } else {
+                        result.add(source.get(index));
+                    }
+                }
+                if (!shouldExclude) {
+                    Collections.reverse(result);
+                }
+                return result;
+            }
+
+            if (!values().isEmpty()) {
                 for (String targetValue : source) {
-                    if (isEqual(targetValue, evalContext, miniMessage, tagResolvers)) {
+                    if (isEqual(targetValue, evalContext, miniMessage, tagResolvers) && !shouldExclude) {
                         result.add(targetValue);
                     }
                 }
-            });
+                return result;
+            }
+            result.addAll(source);
         }
         return result;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/ElementOptionComponentBukkit.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/ElementOptionComponentBukkit.java
@@ -22,9 +22,6 @@
 
 package me.wolfyscript.customcrafting.recipes.items.target.adapters;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntComparators;
-import it.unimi.dsi.fastutil.ints.IntList;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.lib.net.kyori.adventure.platform.bukkit.BukkitComponentSerializer;
 import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.MiniMessage;
@@ -32,14 +29,17 @@ import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.TagR
 import me.wolfyscript.utilities.util.eval.context.EvalContext;
 import me.wolfyscript.utilities.util.eval.value_providers.ValueProvider;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 public class ElementOptionComponentBukkit extends ElementOption<String, String> {
 
+    @Deprecated(forRemoval = true)
     public boolean isEqual(String value, EvalContext evalContext, MiniMessage miniMessage, TagResolver... tagResolvers) {
+        return isComponentEqual(value, evalContext, miniMessage, tagResolvers);
+    }
+
+    public boolean isComponentEqual(String value, EvalContext evalContext, MiniMessage miniMessage, TagResolver... tagResolvers) {
         for (ValueProvider<String> valueProvider : values()) {
             if (Objects.equals(miniMessage.deserialize(valueProvider.getValue(evalContext), tagResolvers), BukkitComponentSerializer.legacy().deserialize(value))) {
                 return true;
@@ -50,58 +50,10 @@ public class ElementOptionComponentBukkit extends ElementOption<String, String> 
 
     @Override
     public boolean isEqual(String value, EvalContext evalContext) {
-        return isEqual(value, evalContext, CustomCrafting.inst().getApi().getChat().getMiniMessage(), TagResolver.empty());
+        return isComponentEqual(value, evalContext, CustomCrafting.inst().getApi().getChat().getMiniMessage(), TagResolver.empty());
     }
 
     public List<String> readFromSource(List<String> source, EvalContext evalContext, MiniMessage miniMessage, TagResolver... tagResolvers) {
-        List<String> result = new ArrayList<>();
-        if (condition().map(boolOperator -> boolOperator.evaluate(evalContext)).orElse(true)) {
-            boolean shouldExclude = exclude().map(boolOperator -> boolOperator.evaluate(evalContext)).orElse(false);
-            if (!indices().isEmpty()) {
-                IntList indicesUsed = new IntArrayList();
-                for (ValueProvider<Integer> indexProvider : indices()) {
-                    int index = indexProvider.getValue(evalContext);
-                    if (index < 0) {
-                        index = source.size() + (index % source.size()); //Convert the negative index to a positive reverted index, that starts from the end.
-                    }
-                    index = index % source.size(); //Prevent out of bounds
-                    if (source.size() > index) {
-                        String targetValue = source.get(index);
-                        if (isEqual(targetValue, evalContext, miniMessage, tagResolvers)) {
-                            indicesUsed.add(index);
-                        } else if (values().isEmpty() && shouldExclude) {
-                            indicesUsed.add(index);
-                        }
-                    }
-                }
-                indicesUsed.sort(IntComparators.OPPOSITE_COMPARATOR);
-
-                if (shouldExclude) {
-                    result.addAll(source);
-                }
-                for (int index : indicesUsed) {
-                    if (shouldExclude) {
-                        result.remove(index);
-                    } else {
-                        result.add(source.get(index));
-                    }
-                }
-                if (!shouldExclude) {
-                    Collections.reverse(result);
-                }
-                return result;
-            }
-
-            if (!values().isEmpty()) {
-                for (String targetValue : source) {
-                    if (isEqual(targetValue, evalContext, miniMessage, tagResolvers) && !shouldExclude) {
-                        result.add(targetValue);
-                    }
-                }
-                return result;
-            }
-            result.addAll(source);
-        }
-        return result;
+        return readFromSource(source, s -> isComponentEqual(s, evalContext, miniMessage, tagResolvers), evalContext);
     }
 }


### PR DESCRIPTION
This adds a few new features to the element options used by the lore, book, and banner merge adapter.
Additionally, the `value` property can have an array of values now to provide an easier way to include/exclude values.

## Examples

### Compact value inclusions
Something like this pre-update:
```hocon
{
  key: "customcrafting:display_lore",
  lines: [
    {
      value = "<grey>Special Enchant III</grey>"
    },
    {
      value = "<grey>Special Enchant IV</grey>"
    },
    {
      value = "<grey>Special Enchant V</grey>"
    }
  ]
}
```

Can be changed to this:
```hocon
{
  key: "customcrafting:display_lore",
  lines: [
    {
      value = [
        "<grey>Special Enchant III</grey>",
        "<grey>Special Enchant IV</grey>",
        "<grey>Special Enchant V</grey>"
      ]
    }
  ]
}
```

Same for indices:
```hocon
{
  key: "customcrafting:display_lore",
  lines: [
    {
      index = 1
    },
    {
      index = 2
    },
    {
      index = 3
    }
  ]
}
```

Can be changed to this:
```hocon
{
  key: "customcrafting:display_lore",
  lines: [
    {
      indices = [ 1, 2, 3 ]
    }
  ]
}
```

### Exclusion
Now it is possible to exclude specific values and indices from the ingredient lore/book/banner.

Excludes the first 3 lines/pages/patterns:
```hocon
{
  key: "customcrafting:display_lore", // or "customcrafting:book", "customcrafting:banner"
  lines: [
    {
      indices = [ 0, 1, 2 ]
      exclude = true
    }
  ]
}
```

Excludes the lines/pages/patterns matching any of the values:
```hocon
{
  key: "customcrafting:display_lore", // similar for "customcrafting:book", and "customcrafting:banner", just with other value options!
  lines: [
    {
      values = [
        "<grey>Special Enchant III</grey>",
        "<grey>Special Enchant IV</grey>",
        "<grey>Special Enchant V</grey>"
      ]
      exclude = true
    }
  ]
}
```

You may even combine both values and indices. Excludes the matching values in the first 3 lines/pages/patterns:
```hocon
{
  key: "customcrafting:display_lore", // similar for "customcrafting:book", and "customcrafting:banner", just with other value options!
  lines: [
    {
      indices = [ 0, 1, 2 ]
      values = [
        "<grey>Special Enchant III</grey>",
        "<grey>Special Enchant IV</grey>",
        "<grey>Special Enchant V</grey>"
      ]
      exclude = true
    }
  ]
}
```