### PR TITLE
Add Preserve Trim Option to Smithing Recipe

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCacheSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/recipe_creator/RecipeCacheSmithing.java
@@ -25,6 +25,8 @@ package me.wolfyscript.customcrafting.data.cache.recipe_creator;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.CustomRecipeSmithing;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
+import me.wolfyscript.utilities.util.version.MinecraftVersion;
+import me.wolfyscript.utilities.util.version.ServerVersion;
 
 public class RecipeCacheSmithing extends RecipeCache<CustomRecipeSmithing> {
 
@@ -34,12 +36,14 @@ public class RecipeCacheSmithing extends RecipeCache<CustomRecipeSmithing> {
 
     private boolean preserveEnchants;
     private boolean preserveDamage;
+    private boolean preserveTrim;
     private boolean onlyChangeMaterial;
 
     RecipeCacheSmithing(CustomCrafting customCrafting) {
         super(customCrafting);
         this.preserveEnchants = true;
         this.preserveDamage = true;
+        this.preserveTrim = ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 20, 0));
         this.onlyChangeMaterial = false;
     }
 
@@ -50,6 +54,7 @@ public class RecipeCacheSmithing extends RecipeCache<CustomRecipeSmithing> {
         this.addition = recipe.getAddition().clone();
         this.preserveEnchants = recipe.isPreserveEnchants();
         this.preserveDamage = recipe.isPreserveDamage();
+        this.preserveTrim = recipe.isPreserveTrim();
     }
 
     @Override
@@ -89,6 +94,7 @@ public class RecipeCacheSmithing extends RecipeCache<CustomRecipeSmithing> {
 
         recipeSmithing.setPreserveEnchants(preserveEnchants);
         recipeSmithing.setPreserveDamage(preserveDamage);
+        recipeSmithing.setPreserveTrim(preserveTrim);
         recipeSmithing.setOnlyChangeMaterial(onlyChangeMaterial);
         return recipeSmithing;
     }
@@ -147,6 +153,14 @@ public class RecipeCacheSmithing extends RecipeCache<CustomRecipeSmithing> {
 
     public void setOnlyChangeMaterial(boolean onlyChangeMaterial) {
         this.onlyChangeMaterial = onlyChangeMaterial;
+    }
+
+    public void setPreserveTrim(boolean preserveTrim) {
+        this.preserveTrim = preserveTrim;
+    }
+
+    public boolean isPreserveTrim() {
+        return preserveTrim;
     }
 
     public boolean isOnlyChangeMaterial() {

--- a/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/recipe_creator/RecipeCreatorSmithing.java
@@ -26,15 +26,18 @@ import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
 import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
+import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import me.wolfyscript.utilities.util.version.MinecraftVersion;
 import me.wolfyscript.utilities.util.version.ServerVersion;
 import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
 
 public class RecipeCreatorSmithing extends RecipeCreator {
 
     private static final String CHANGE_MATERIAL = "change_material";
     private static final String PRESERVE_ENCHANTS = "preserve_enchants";
     private static final String PRESERVE_DAMAGE = "preserve_damage";
+    private static final String PRESERVE_TRIM = "preserve_trim";
 
     public RecipeCreatorSmithing(GuiCluster<CCCache> cluster, CustomCrafting customCrafting) {
         super(cluster, "smithing", 45, customCrafting);
@@ -62,13 +65,22 @@ public class RecipeCreatorSmithing extends RecipeCreator {
             cache.getRecipeCreatorCache().getSmithingCache().setPreserveEnchants(true);
             return true;
         })).register();
-        btnB.toggle(PRESERVE_DAMAGE).stateFunction((cache, handler, player, inv, i) -> cache.getRecipeCreatorCache().getSmithingCache().isPreserveDamage()).enabledState(s -> s.subKey("enabled").icon(Material.LIME_CONCRETE).action((cache, handler, player, inv, i, e) -> {
+        btnB.toggle(PRESERVE_DAMAGE).stateFunction((cache, handler, player, inv, i) -> cache.getRecipeCreatorCache().getSmithingCache().isPreserveDamage()).enabledState(s -> s.subKey("enabled").icon(new ItemBuilder(Material.IRON_SWORD).addUnsafeEnchantment(Enchantment.DURABILITY, 0).create()).action((cache, handler, player, inv, i, e) -> {
             cache.getRecipeCreatorCache().getSmithingCache().setPreserveDamage(false);
             return true;
-        })).disabledState(s -> s.subKey("disabled").icon(Material.RED_CONCRETE).action((cache, handler, player, inv, i, e) -> {
+        })).disabledState(s -> s.subKey("disabled").icon(Material.IRON_SWORD).action((cache, handler, player, inv, i, e) -> {
             cache.getRecipeCreatorCache().getSmithingCache().setPreserveDamage(true);
             return true;
         })).register();
+        if (ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 20, 0))) {
+            btnB.toggle(PRESERVE_TRIM).stateFunction((cache, handler, player, inv, i) -> cache.getRecipeCreatorCache().getSmithingCache().isPreserveTrim()).enabledState(s -> s.subKey("enabled").icon(new ItemBuilder(Material.VEX_ARMOR_TRIM_SMITHING_TEMPLATE).addUnsafeEnchantment(Enchantment.DURABILITY, 0).create()).action((cache, handler, player, inv, i, e) -> {
+                cache.getRecipeCreatorCache().getSmithingCache().setPreserveTrim(false);
+                return true;
+            })).disabledState(s -> s.subKey("disabled").icon(Material.VEX_ARMOR_TRIM_SMITHING_TEMPLATE).action((cache, handler, player, inv, i, e) -> {
+                cache.getRecipeCreatorCache().getSmithingCache().setPreserveTrim(true);
+                return true;
+            })).register();
+        }
     }
 
     @Override
@@ -92,6 +104,9 @@ public class RecipeCreatorSmithing extends RecipeCreator {
 
         event.setButton(37, PRESERVE_ENCHANTS);
         event.setButton(38, PRESERVE_DAMAGE);
+        if (ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 20, 0))) {
+            event.setButton(39, PRESERVE_TRIM);
+        }
         event.setButton(40, CHANGE_MATERIAL);
 
         event.setButton(42, ClusterRecipeCreator.GROUP);

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
@@ -39,6 +39,7 @@ import me.wolfyscript.customcrafting.recipes.data.SmithingData;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
 import me.wolfyscript.customcrafting.recipes.items.Result;
 import me.wolfyscript.customcrafting.recipes.items.target.MergeAdapter;
+import me.wolfyscript.customcrafting.recipes.items.target.adapters.ArmorTrimMergeAdapter;
 import me.wolfyscript.customcrafting.recipes.items.target.adapters.DamageMergeAdapter;
 import me.wolfyscript.customcrafting.recipes.items.target.adapters.EnchantMergeAdapter;
 import me.wolfyscript.customcrafting.utils.ItemLoader;
@@ -84,10 +85,11 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> imp
 
     private boolean preserveEnchants;
     private boolean preserveDamage;
+    private boolean preserveTrim;
     private boolean onlyChangeMaterial; //Only changes the material of the item. Useful to make vanilla style recipes.
 
     @JsonIgnore
-    private List<MergeAdapter> internalMergeAdapters = new ArrayList<>(2);
+    private List<MergeAdapter> internalMergeAdapters = new ArrayList<>(3);
 
     public CustomRecipeSmithing(NamespacedKey namespacedKey, JsonNode node) {
         super(namespacedKey, node);
@@ -108,6 +110,7 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> imp
         this.result = new Result();
         this.preserveEnchants = true;
         this.preserveDamage = true;
+        this.preserveTrim = ServerVersion.isAfterOrEq(MinecraftVersion.of(1, 20, 0));
         this.onlyChangeMaterial = false;
     }
 
@@ -123,6 +126,7 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> imp
         this.addition = customRecipeSmithing.getAddition();
         this.preserveEnchants = customRecipeSmithing.isPreserveEnchants();
         this.preserveDamage = customRecipeSmithing.isPreserveDamage();
+        this.preserveTrim = customRecipeSmithing.isPreserveTrim();
         this.onlyChangeMaterial = customRecipeSmithing.isOnlyChangeMaterial();
     }
 
@@ -214,6 +218,8 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> imp
         this.preserveEnchants = preserveEnchants;
         if (!onlyChangeMaterial && preserveEnchants) {
             internalMergeAdapters.add(new EnchantMergeAdapter());
+        } else if (!preserveEnchants) {
+            internalMergeAdapters.removeIf(mergeAdapter -> mergeAdapter.getClass().equals(EnchantMergeAdapter.class));
         }
     }
 
@@ -225,6 +231,21 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> imp
         this.preserveDamage = preserveDamage;
         if (!onlyChangeMaterial && preserveEnchants) {
             internalMergeAdapters.add(new DamageMergeAdapter());
+        } else if (!preserveDamage) {
+            internalMergeAdapters.removeIf(mergeAdapter -> mergeAdapter.getClass().equals(DamageMergeAdapter.class));
+        }
+    }
+
+    public boolean isPreserveTrim() {
+        return preserveTrim;
+    }
+
+    public void setPreserveTrim(boolean preserveTrim) {
+        this.preserveTrim = preserveTrim;
+        if (!onlyChangeMaterial && preserveTrim) {
+            internalMergeAdapters.add(new ArmorTrimMergeAdapter());
+        } else if (!preserveTrim) {
+            internalMergeAdapters.removeIf(mergeAdapter -> mergeAdapter.getClass().equals(ArmorTrimMergeAdapter.class));
         }
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/ArmorTrimMergeAdapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/target/adapters/ArmorTrimMergeAdapter.java
@@ -62,6 +62,8 @@ public class ArmorTrimMergeAdapter extends MergeAdapter {
 
     public ArmorTrimMergeAdapter() {
         super(KEY);
+        this.copyPattern = true;
+        this.copyMaterial = true;
     }
 
     public ArmorTrimMergeAdapter(ArmorTrimMergeAdapter adapter) {
@@ -123,7 +125,7 @@ public class ArmorTrimMergeAdapter extends MergeAdapter {
 
     @JsonGetter("defaultMaterial")
     private String getJsonDefaultMaterial() {
-        return defaultMaterial.getKey().toString();
+        return defaultMaterial == null ? null : defaultMaterial.getKey().toString();
     }
 
     @JsonSetter("defaultPattern")
@@ -135,7 +137,7 @@ public class ArmorTrimMergeAdapter extends MergeAdapter {
 
     @JsonGetter("defaultPattern")
     private String getJsonDefaultPattern() {
-        return defaultPattern.getKey().toString();
+        return defaultPattern == null ? null : defaultPattern.getKey().toString();
     }
 
     @JsonSetter("copyPattern")

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -2987,6 +2987,27 @@
                 "<dark_grey>[<green>Click</green>]</dark_grey> <yellow>Preserve Damage</yellow>"
               ]
             }
+          },
+          "preserve_trim": {
+            "enabled": {
+              "name": "<green>\u2714</green>  <gold><b>Preserve Trim</b></gold>",
+              "lore": [
+                "<yellow>Copies the trim from</yellow>",
+                "<yellow>the base to the result item.</yellow>",
+                "",
+                "<dark_grey>[<green>Click</green>]</dark_grey> <yellow>Discard Trim</yellow>"
+              ]
+            },
+            "disabled": {
+              "name": "<red>\u274C</red>  <gold><b>Discard Trim</b></gold>",
+              "lore": [
+                "<yellow>Leaves the trim of the</yellow>",
+                "<yellow>result as is and discards</yellow>",
+                "<yellow>the base ingredient trim.</yellow>",
+                "",
+                "<dark_grey>[<green>Click</green>]</dark_grey> <yellow>Preserve Trim</yellow>"
+              ]
+            }
           }
         }
       },


### PR DESCRIPTION
Adds the preserve trim option to the custom smithing recipes that copies the trim of the base ingredient to the result.
Internally it uses the ArmorTrimMergeAdapter. 