### PR TITLE
Add Config Option to toggle vanilla cooking recipe fallback check

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/configs/CookingSettings.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/CookingSettings.java
@@ -1,0 +1,57 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.configs;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CookingSettings implements ConfigurationSerializable {
+
+    private static final String MATCH_VANILLA_RECIPES = "match_vanilla_recipes";
+
+    private final boolean matchVanillaRecipes;
+
+    public CookingSettings(Map<String, Object> values) {
+        this.matchVanillaRecipes = values.get(MATCH_VANILLA_RECIPES) instanceof Boolean bool && bool;
+    }
+
+    public CookingSettings(ConfigurationSection section) {
+        this.matchVanillaRecipes = section.getBoolean(MATCH_VANILLA_RECIPES, true);
+    }
+
+    @Override
+    public @NotNull Map<String, Object> serialize() {
+        Map<String, Object> result = new HashMap<>();
+        result.put(MATCH_VANILLA_RECIPES, matchVanillaRecipes);
+        return result;
+    }
+
+    public boolean isMatchVanillaRecipes() {
+        return matchVanillaRecipes;
+    }
+
+}

--- a/src/main/java/me/wolfyscript/customcrafting/configs/MainConfig.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/MainConfig.java
@@ -32,7 +32,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.event.player.PlayerInteractEvent;
 
 public class MainConfig extends YamlConfiguration {
 
@@ -174,6 +173,11 @@ public class MainConfig extends YamlConfiguration {
     public DatabaseSettings getDatabaseSettings() {
         ConfigurationSection section = getConfigurationSection("database");
         return section != null ? new DatabaseSettings(section) : null;
+    }
+
+    public CookingSettings getFurnacesSettings() {
+        ConfigurationSection section = getConfigurationSection("cooking");
+        return section != null ? new CookingSettings(section) : null;
     }
 
     public CauldronInteraction getCauldronInteraction() {

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/FurnaceListener1_17Adapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/FurnaceListener1_17Adapter.java
@@ -79,7 +79,7 @@ public class FurnaceListener1_17Adapter implements Listener {
                     if (customCrafting.getConfigHandler().getConfig().getFurnacesSettings().isMatchVanillaRecipes()) {
                         // Try to find other vanilla/custom recipe that matches the ingredient used. This may conflict with other plugins.
                         // For that case there is the config option to simply bypass this match & block placeholder/display recipes.
-                        if (!ICustomVanillaRecipe.isPlaceholderOrDisplayRecipe(event.getRecipe().getKey())) return;
+                        if (!ICustomVanillaRecipe.isPlaceholderOrDisplayRecipe(event.getRecipe().getKey())) return; // if for some reason it isn't a custom recipe, lets just move on
                         Iterator<Recipe> recipeIterator = customCrafting.getApi().getNmsUtil().getRecipeUtil().recipeIterator(switch (event.getBlock().getType()) {
                             case BLAST_FURNACE -> me.wolfyscript.utilities.api.nms.inventory.RecipeType.BLASTING;
                             case SMOKER -> me.wolfyscript.utilities.api.nms.inventory.RecipeType.SMOKING;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -80,6 +80,9 @@ crafting_table:
   # If the crafting table item should be reset on each server start. This means the config is replaced with a new version.
   reset: true
 
+cooking:
+  match_vanilla_recipes: true
+
 recipe_book:
   # If the recipe book item should be reset on each server start. This means the config is replaced with a new version.
   reset: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -81,6 +81,8 @@ crafting_table:
   reset: true
 
 cooking:
+  # Toggles the vanilla recipe fallback matching, that occurs when the custom recipe check fails
+  # Note: If a custom recipe is using an item used in a vanilla recipe, the vanilla recipe will be overridden.
   match_vanilla_recipes: true
 
 recipe_book:


### PR DESCRIPTION
By default, CC tries to match a vanilla cooking recipe if the custom recipe check fails. This is done, so the recipes do not override vanilla recipes, but it may cause conflicts with other plugins.
This PR adds a config option to toggle that feature. If disabled, it only blocks CCs placeholder/display recipes, but does not check for any other recipes.
Note: If a custom recipe is using an item used in a vanilla recipe, that recipe will be overridden.
