### PR TITLE
Fix recipe priority for various recipe types

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/listeners/AnvilListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/AnvilListener.java
@@ -84,6 +84,7 @@ public class AnvilListener implements Listener {
         }
 
         customCrafting.getRegistries().getRecipes().get(RecipeType.ANVIL).stream()
+                .sorted()
                 .filter(customRecipeAnvil -> !customRecipeAnvil.isDisabled() && customRecipeAnvil.checkConditions(data))
                 .map(recipe -> {
                     Optional<CustomItem> finalInputLeft = Optional.empty();

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/smithing/SmithingListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/smithing/SmithingListener.java
@@ -89,7 +89,9 @@ public class SmithingListener implements Listener {
         var addition = inv.getItem(CustomRecipeSmithing.ADDITION_SLOT);
         preCraftedRecipes.put(player.getUniqueId(), null);
 
-        customCrafting.getRegistries().getRecipes().getAvailable(RecipeType.SMITHING).stream()
+        customCrafting.getRegistries().getRecipes().get(RecipeType.SMITHING).stream()
+                .sorted()
+                .filter(recipe -> !recipe.isDisabled())
                 .map(recipe -> recipe.check(player, event.getView(), template, base, addition))
                 .filter(Objects::nonNull)
                 .findFirst()

--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/FurnaceListener1_17Adapter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/FurnaceListener1_17Adapter.java
@@ -62,6 +62,8 @@ public class FurnaceListener1_17Adapter implements Listener {
                     case SMOKER -> RecipeType.SMOKER;
                     default -> RecipeType.FURNACE;
                 }).stream()
+                .sorted()
+                .filter(recipe -> !recipe.isDisabled())
                 .map(recipe1 -> manager.getAdapter().processRecipe(recipe1, event.getSource(), event.getBlock()).getKey())
                 .filter(Objects::nonNull)
                 .findFirst()


### PR DESCRIPTION
Due to recent changes in the underlying recipe system, the recipes were not sorted based on priority when checked. This PR sorts them again when checked so the priority works again. 