### PR TITLE
Fix Duplicate Bukkit Recipes

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/registry/RegistryRecipes.java
+++ b/src/main/java/me/wolfyscript/customcrafting/registry/RegistryRecipes.java
@@ -507,6 +507,7 @@ public final class RegistryRecipes extends RegistrySimple<CustomRecipe<?>> {
     }
 
     private void removeBukkitRecipe(NamespacedKey namespacedKey) {
-        Bukkit.removeRecipe(new org.bukkit.NamespacedKey(namespacedKey.getNamespace(), namespacedKey.getKey()));
+        Bukkit.removeRecipe(ICustomVanillaRecipe.toPlaceholder(namespacedKey).bukkit());
+        Bukkit.removeRecipe(ICustomVanillaRecipe.toDisplayKey(namespacedKey).bukkit());
     }
 }


### PR DESCRIPTION
Placeholder and Display recipes registered via Bukkit were not removed when the custom recipe is unregistered, or updated.