### PR TITLE
Fix Duplicate Disable Button In Recipe List

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
@@ -37,6 +37,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.inventory.Recipe;
 
 import java.io.File;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -162,9 +163,9 @@ public class DataHandler implements Listener {
 
     public List<NamespacedKey> getMinecraftRecipes() {
         if (minecraftRecipes.isEmpty()) {
-            minecraftRecipes = Streams.stream(Bukkit.recipeIterator())
-                    .map(recipe -> recipe instanceof Keyed keyed ? NamespacedKey.fromBukkit(keyed.getKey()) : null)
-                    .filter(recipe -> recipe != null && recipe.getNamespace().equals("minecraft"))
+            return Streams.stream(Bukkit.recipeIterator())
+                    .filter(recipe -> recipe instanceof Keyed keyed && keyed.getKey().getNamespace().equals("minecraft"))
+                    .map(recipe -> NamespacedKey.fromBukkit(((Keyed) recipe).getKey()))
                     .sorted()
                     .toList();
         }

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/DisableRecipesHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/DisableRecipesHandler.java
@@ -32,12 +32,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Recipe;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 public class DisableRecipesHandler {
 
@@ -45,7 +40,7 @@ public class DisableRecipesHandler {
     private final MainConfig config;
 
     private final Set<NamespacedKey> recipes = new HashSet<>();
-    private final Map<org.bukkit.NamespacedKey, Recipe> cachedRecipes = new HashMap<>();
+    private final Map<org.bukkit.NamespacedKey, Recipe> cachedRecipes = new WeakHashMap<>();
 
     public DisableRecipesHandler(CustomCrafting customCrafting) {
         this.customCrafting = customCrafting;


### PR DESCRIPTION
The recipe list of vanilla recipes displayed disabled recipes twice. This is now fixed.