### PR TITLE
Fix Furnace Recipe Cache not taking the Z-Axis into account

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/utils/cooking/CookingManager.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/cooking/CookingManager.java
@@ -108,12 +108,12 @@ public class CookingManager {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             BlockPositionData that = (BlockPositionData) o;
-            return x == that.x && y == that.y && Objects.equals(world, that.world);
+            return x == that.x && y == that.y && z == that.z && Objects.equals(world, that.world);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(x, y, world);
+            return Objects.hash(x, y, z, world);
         }
     }
 


### PR DESCRIPTION
Adds missing Z-axis to BlockPosition#hashCode and #equals