### PR TITLE
Fix Invalid Smithing Recipe Data Base Slot

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/recipes/data/SmithingData.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/data/SmithingData.java
@@ -43,7 +43,7 @@ public class SmithingData extends RecipeData<CustomRecipeSmithing> implements IS
     }
 
     public CustomItem getBase() {
-        return getBySlot(IS_1_20 ? 0 : 1).customItem();
+        return getBySlot(IS_1_20 ? 1 : 0).customItem();
     }
 
     public CustomItem getAddition() {


### PR DESCRIPTION
This fixes an invalid slot inside of the SmithingData#getBase, which was flipped in 1.20 and 1.19