### PR TITLE
Fix Vanilla Cooking Recipe Placeholders using Result item as source

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     compileOnly("io.netty:netty-all:4.1.85.Final")
     compileOnly("me.clip:placeholderapi:2.10.4")
     compileOnly("com.github.oraxen:oraxen:1.156.0")
-    compileOnly("com.wolfyscript.wolfyutils.spigot:wolfyutils-spigot:4.16.15-beta.1-SNAPSHOT")
+    compileOnly("com.wolfyscript.wolfyutils.spigot:wolfyutils-spigot:4.16.15-beta.2")
 }
 
 group = "com.wolfyscript.customcrafting"

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
@@ -33,7 +33,6 @@ import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.BlastingRecipe;
-import org.bukkit.inventory.RecipeChoice;
 
 public class CustomRecipeBlasting extends CustomRecipeCooking<CustomRecipeBlasting, BlastingRecipe> {
 
@@ -65,9 +64,9 @@ public class CustomRecipeBlasting extends CustomRecipeCooking<CustomRecipeBlasti
     @Override
     public BlastingRecipe getVanillaRecipe() {
         if (!getSource().isEmpty()) {
-            BlastingRecipe placeholderRecipe = new BlastingRecipe(ICustomVanillaRecipe.toPlaceholder(getNamespacedKey()).bukkit(), getResult().getItemStack(), new RecipeChoice.MaterialChoice(getResult().getItemStack().getType()), getExp(), getCookingTime());
+            BlastingRecipe placeholderRecipe = new BlastingRecipe(ICustomVanillaRecipe.toPlaceholder(getNamespacedKey()).bukkit(), getResult().getItemStack(), getMaterialSourceChoice(), getExp(), getCookingTime());
             Bukkit.addRecipe(placeholderRecipe);
-            return new BlastingRecipe(ICustomVanillaRecipe.toDisplayKey(getNamespacedKey()).bukkit(), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            return new BlastingRecipe(ICustomVanillaRecipe.toDisplayKey(getNamespacedKey()).bukkit(), getResult().getItemStack(), getSourceChoice(), getExp(), getCookingTime());
         }
         return null;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
@@ -24,7 +24,6 @@ package me.wolfyscript.customcrafting.recipes;
 
 import com.google.common.base.Preconditions;
 
-import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
@@ -32,7 +31,6 @@ import me.wolfyscript.customcrafting.data.CCPlayerData;
 import me.wolfyscript.customcrafting.gui.recipebook.ButtonContainerIngredient;
 import me.wolfyscript.customcrafting.gui.recipebook.ClusterRecipeBook;
 import me.wolfyscript.customcrafting.recipes.conditions.Condition;
-import me.wolfyscript.customcrafting.recipes.conditions.Conditions;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
 import me.wolfyscript.customcrafting.recipes.items.Result;
 import com.wolfyscript.utilities.validator.Validator;
@@ -47,12 +45,9 @@ import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
 import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
-import com.wolfyscript.utilities.bukkit.nms.item.crafting.FunctionalRecipeBuilderCooking;
 import me.wolfyscript.utilities.api.nms.network.MCByteBuf;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.entity.Player;
 import org.bukkit.inventory.CookingRecipe;
 import org.bukkit.inventory.RecipeChoice;
 import org.jetbrains.annotations.NotNull;
@@ -147,22 +142,13 @@ public abstract class CustomRecipeCooking<C extends CustomRecipeCooking<C, T>, T
         this.exp = exp;
     }
 
-    protected RecipeChoice getRecipeChoice() {
+    protected RecipeChoice getSourceChoice() {
         return isCheckNBT() ? new RecipeChoice.ExactChoice(getSource().choices().stream().map(StackReference::referencedStack).toList()) :
                 new RecipeChoice.MaterialChoice(getSource().choices().stream().map(i -> i.referencedStack().getType()).toList());
     }
 
-    protected void registerRecipeIntoMinecraft(FunctionalRecipeBuilderCooking builder) {
-        builder.setGroup(group);
-        builder.setExperience(getExp());
-        builder.setCookingTime(getCookingTime());
-        builder.setRecipeMatcher((inventory, world) -> {
-            Location location = inventory.getLocation();
-            if (location != null && !checkConditions(Conditions.Data.of(null, location.getBlock(), null))) return false;
-            return getSource().test(inventory.getItem(0), isCheckNBT());
-        });
-        builder.setRecipeAssembler(inventory -> java.util.Optional.ofNullable(getResult().getItemStack()));
-        builder.createAndRegister();
+    protected RecipeChoice getMaterialSourceChoice() {
+        return new RecipeChoice.MaterialChoice(getSource().choices().stream().map(i -> i.referencedStack().getType()).toList());
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
@@ -33,7 +33,6 @@ import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.FurnaceRecipe;
-import org.bukkit.inventory.RecipeChoice;
 
 public class CustomRecipeFurnace extends CustomRecipeCooking<CustomRecipeFurnace, FurnaceRecipe> {
 
@@ -66,10 +65,10 @@ public class CustomRecipeFurnace extends CustomRecipeCooking<CustomRecipeFurnace
     @Override
     public FurnaceRecipe getVanillaRecipe() {
         if (!getSource().isEmpty()) {
-            FurnaceRecipe placeholderRecipe = new FurnaceRecipe(ICustomVanillaRecipe.toPlaceholder(getNamespacedKey()).bukkit(), getResult().getItemStack(), new RecipeChoice.MaterialChoice(getResult().getItemStack().getType()), getExp(), getCookingTime());
+            FurnaceRecipe placeholderRecipe = new FurnaceRecipe(ICustomVanillaRecipe.toPlaceholder(getNamespacedKey()).bukkit(), getResult().getItemStack(), getMaterialSourceChoice(), getExp(), getCookingTime());
             Bukkit.addRecipe(placeholderRecipe);
             //registerRecipeIntoMinecraft(new FunctionalRecipeBuilderSmelting(getNamespacedKey(), getResult().getItemStack(), getRecipeChoice()));
-            return new FurnaceRecipe(ICustomVanillaRecipe.toDisplayKey(getNamespacedKey()).bukkit(), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            return new FurnaceRecipe(ICustomVanillaRecipe.toDisplayKey(getNamespacedKey()).bukkit(), getResult().getItemStack(), getSourceChoice(), getExp(), getCookingTime());
         }
         return null;
     }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
@@ -32,7 +32,6 @@ import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.SmokingRecipe;
 
 public class CustomRecipeSmoking extends CustomRecipeCooking<CustomRecipeSmoking, SmokingRecipe> {
@@ -75,9 +74,9 @@ public class CustomRecipeSmoking extends CustomRecipeCooking<CustomRecipeSmoking
     @Override
     public SmokingRecipe getVanillaRecipe() {
         if (!getSource().isEmpty()) {
-            SmokingRecipe placeholderRecipe = new SmokingRecipe(ICustomVanillaRecipe.toPlaceholder(getNamespacedKey()).bukkit(), getResult().getItemStack(), new RecipeChoice.MaterialChoice(getResult().getItemStack().getType()), getExp(), getCookingTime());
+            SmokingRecipe placeholderRecipe = new SmokingRecipe(ICustomVanillaRecipe.toPlaceholder(getNamespacedKey()).bukkit(), getResult().getItemStack(), getMaterialSourceChoice(), getExp(), getCookingTime());
             Bukkit.addRecipe(placeholderRecipe);
-            return new SmokingRecipe(ICustomVanillaRecipe.toDisplayKey(getNamespacedKey()).bukkit(), getResult().getItemStack(), getRecipeChoice(), getExp(), getCookingTime());
+            return new SmokingRecipe(ICustomVanillaRecipe.toDisplayKey(getNamespacedKey()).bukkit(), getResult().getItemStack(), getSourceChoice(), getExp(), getCookingTime());
         }
         return null;
     }


### PR DESCRIPTION
The vanilla placeholder recipes used the result item as the source item, so they didn't work properly.