### PR TITLE
Add Data Directory Backup For Local Storage

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/SaveSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/SaveSubCommand.java
@@ -48,18 +48,25 @@ public class SaveSubCommand extends AbstractSubCommand {
     public boolean onCommand(@NotNull CommandSender sender, @NotNull String var3, @NotNull String[] args) {
         WolfyUtilities api = customCrafting.getApi();
         if (sender instanceof Player && ChatUtils.checkPerm(sender, "customcrafting.cmd.recipes_save")) {
+            sender.sendMessage("§eCreating backup of data directory...");
+
+            if (!customCrafting.getDataHandler().getActiveLoader().backup()) {
+                sender.sendMessage("§cFailed to create backup! Aborting re-save! Please check the errors in the logs!");
+                return true;
+            }
+
             api.getRegistries().getCustomItems().entrySet().forEach(entry -> {
                 api.getConsole().info("Saving item: " + entry.getKey().toString());
                 ItemLoader.saveItem(entry.getKey(), entry.getValue());
             });
+
             customCrafting.getRegistries().getRecipes().values().forEach(recipe -> {
                 api.getConsole().info("Saving recipe: " + recipe.getNamespacedKey());
                 recipe.save();
             });
-            sender.sendMessage("§eAll recipes are resaved! See the console log for errors.");
-            sender.sendMessage("§cNotice that some recipes must be recreated due incompatibility! These are: ");
-            sender.sendMessage("§c- recipes that caused errors when saving (their config is corrupted from now on)");
-            sender.sendMessage("§c- recipes that don't work when the server is restarted");
+
+            sender.sendMessage("§eAll recipes & items are re-saved! See the logs for errors");
+            sender.sendMessage("§cNotice that some recipes may fail due to incompatibility");
             sender.sendMessage("§eYou can get or ask for further information on the discord!");
         }
         return true;

--- a/src/main/java/me/wolfyscript/customcrafting/configs/BackupSettings.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/BackupSettings.java
@@ -1,0 +1,55 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.configs;
+
+import me.wolfyscript.utilities.util.Pair;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+public class BackupSettings {
+
+    private static final String ENABLED = "enabled";
+    private static final String KEEP_FOR = "keep_for";
+
+    private final ConfigurationSection section;
+
+    public BackupSettings(ConfigurationSection section) {
+        this.section = section;
+    }
+
+    public boolean enabled() {
+        return section.getBoolean(ENABLED, true);
+    }
+
+    public Duration keepFor() {
+        var unit = Objects.requireNonNullElse(TimeUnit.valueOf(section.getString(KEEP_FOR + ".unit", "SECONDS")), TimeUnit.SECONDS);
+        var value = section.getLong(KEEP_FOR + ".value");
+
+        return Duration.of(value, unit.toChronoUnit());
+    }
+
+}

--- a/src/main/java/me/wolfyscript/customcrafting/configs/LocalStorageSettings.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/LocalStorageSettings.java
@@ -37,17 +37,23 @@ public class LocalStorageSettings  implements ConfigurationSerializable {
     private final boolean load;
     private final boolean beforeDatabase;
     private final boolean override;
+    private final BackupSettings backupSettings;
 
     public LocalStorageSettings(Map<String, Object> values) {
         this.load = values.get(LOAD) instanceof Boolean bool && bool;
         this.beforeDatabase = values.get(BEFORE_DATABASE) instanceof Boolean bool && bool;
         this.override = values.get(OVERRIDE) instanceof Boolean bool && bool;
+        ConfigurationSection section = values.get("data") instanceof ConfigurationSection s ? s : null;
+        this.backupSettings = section != null ? new BackupSettings(section) : null;
     }
 
     public LocalStorageSettings(ConfigurationSection section) {
         this.load = section.getBoolean(LOAD);
         this.beforeDatabase = section.getBoolean(BEFORE_DATABASE);
         this.override = section.getBoolean(OVERRIDE);
+
+        ConfigurationSection backupSection = section.getConfigurationSection("backup");
+        this.backupSettings = backupSection != null ? new BackupSettings(backupSection) : null;
     }
 
     @Override
@@ -69,5 +75,9 @@ public class LocalStorageSettings  implements ConfigurationSerializable {
 
     public boolean isOverride() {
         return override;
+    }
+
+    public BackupSettings backupSettings() {
+        return backupSettings;
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/configs/MainConfig.java
+++ b/src/main/java/me/wolfyscript/customcrafting/configs/MainConfig.java
@@ -23,6 +23,7 @@
 package me.wolfyscript.customcrafting.configs;
 
 import java.util.*;
+import java.util.function.Function;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
@@ -166,24 +167,25 @@ public class MainConfig extends YamlConfiguration {
         return getBoolean("recipes.brewing");
     }
 
+    private <T> T getSetting(String key, Function<ConfigurationSection, T> creator) {
+        ConfigurationSection section = getConfigurationSection(key);
+        return section != null ? creator.apply(section) : null;
+    }
+
     public DataSettings getDataSettings() {
-        ConfigurationSection section = getConfigurationSection("data");
-        return section != null ? new DataSettings(section) : null;
+        return getSetting("data", DataSettings::new);
     }
 
     public LocalStorageSettings getLocalStorageSettings() {
-        ConfigurationSection section = getConfigurationSection("local_storage");
-        return section != null ? new LocalStorageSettings(section) : null;
+        return getSetting("local_storage", LocalStorageSettings::new);
     }
 
     public DatabaseSettings getDatabaseSettings() {
-        ConfigurationSection section = getConfigurationSection("database");
-        return section != null ? new DatabaseSettings(section) : null;
+        return getSetting("database", DatabaseSettings::new);
     }
 
     public CookingSettings getFurnacesSettings() {
-        ConfigurationSection section = getConfigurationSection("cooking");
-        return section != null ? new CookingSettings(section) : null;
+        return getSetting("cooking", CookingSettings::new);
     }
 
     public CauldronInteraction getCauldronInteraction() {

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
@@ -42,17 +42,21 @@ import org.apache.commons.lang3.time.StopWatch;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
+import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.logging.Level;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 public class LocalStorageLoader extends ResourceLoader {
 
     private static final String PREFIX = "[LOCAL] ";
+    private static final DateTimeFormatter BACKUP_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS");
+    public static final File DATA_BACKUP_DIR = new File(CustomCrafting.inst().getDataFolder() + File.separator + "data_backups");
     public static final File DATA_FOLDER = new File(CustomCrafting.inst().getDataFolder() + File.separator + "data");
     private static final String ITEMS_FOLDER = "items";
     private static final String RECIPES_FOLDER = "recipes";
@@ -92,6 +96,48 @@ public class LocalStorageLoader extends ResourceLoader {
         Validator<T> validator = (Validator<T>) CustomCrafting.inst().getRegistries().getValidators().get(recipe.getRecipeType().getNamespacedKey());
         if (validator == null) return Optional.empty();
         return Optional.of(validator.validate(recipe));
+    }
+
+    public static void pack(File sourceDirPath, File zipFilePath) throws IOException {
+        Path p = Files.createFile(zipFilePath.toPath());
+        try (ZipOutputStream zs = new ZipOutputStream(Files.newOutputStream(p))) {
+            Path pp = sourceDirPath.toPath();
+            Files.walk(pp)
+                    .filter(path -> !Files.isDirectory(path))
+                    .forEach(path -> {
+                        ZipEntry zipEntry = new ZipEntry(pp.relativize(path).toString());
+                        try {
+                            zs.putNextEntry(zipEntry);
+                            Files.copy(path, zs);
+                            zs.closeEntry();
+                        } catch (IOException e) {
+                            CustomCrafting.inst().getLogger().log(Level.SEVERE, e, () -> "Failed to create backup of data directory!");
+                        }
+                    });
+        } catch (IOException e) {
+            CustomCrafting.inst().getLogger().log(Level.SEVERE, e, () -> "Failed to create backup of data directory!");
+        }
+    }
+
+    @Override
+    public boolean backup() {
+        if (!DATA_BACKUP_DIR.exists()) {
+            if (!DATA_BACKUP_DIR.mkdirs()) {
+                customCrafting.getLogger().severe("Failed to create backup directory!");
+                return false;
+            }
+        }
+
+        LocalDateTime date = LocalDateTime.now();
+        String text = BACKUP_DATE_FORMAT.format(date);
+        try {
+            customCrafting.getLogger().info("Creating backup of data directory '" + text + ".zip'...");
+            pack(DATA_FOLDER, new File(DATA_BACKUP_DIR, text));
+            return true;
+        } catch (IOException e) {
+            customCrafting.getLogger().log(Level.SEVERE, e, () -> "Failed to create backup of data directory!");
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/ResourceLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/ResourceLoader.java
@@ -60,6 +60,10 @@ public abstract class ResourceLoader implements Comparable<ResourceLoader>, Keye
     public void load(boolean upgrade) {
         load();
         if (upgrade) {
+            if (!backup()) {
+                api.getConsole().warn("Aborting Items & Recipes config upgrade to the latest format!");
+                return;
+            }
             api.getConsole().info("Updating Items & Recipes to the latest format..");
             save();
             api.getConsole().info("Loading updated Items & Recipes...");
@@ -90,9 +94,12 @@ public abstract class ResourceLoader implements Comparable<ResourceLoader>, Keye
     }
 
     public void save() {
+        backup();
         api.getRegistries().getCustomItems().entrySet().forEach(entry -> ItemLoader.saveItem(this, entry.getKey(), entry.getValue()));
         customCrafting.getRegistries().getRecipes().values().forEach(recipe -> recipe.save(this, null));
     }
+
+    public boolean backup() { return true; }
 
     /**
      * Saves the specified recipe

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -41,6 +41,12 @@ local_storage:
   # this should always be true if you don't use a database or want to export your data to the database.
   # If you use a database you can still load local data, but configure how it loads them with the following settings below.
   load: true
+  backup:
+    enabled: true
+    keep_for:
+      value: 60
+      unit: DAYS
+
   # Specifies if the local storage should be loaded before or after the database.
   # This is useful if you have items/recipes that depend on items in the database or other way around.
   # Make sure that the dependencies of items and recipes are loaded in the correct order.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -41,8 +41,12 @@ local_storage:
   # this should always be true if you don't use a database or want to export your data to the database.
   # If you use a database you can still load local data, but configure how it loads them with the following settings below.
   load: true
+  # The settings for the backup, that is done before automatic and manual (/recipe save) recipe/item upgrades to the new config format
   backup:
+    # Backup can be disabled, but that is not recommended
     enabled: true
+    # Specify for how long a backup is kept
+    # Whenever a new backup is created, old backups that or older than specified here are deleted
     keep_for:
       value: 60
       unit: DAYS


### PR DESCRIPTION
When using the local storage loader (default) a backup is created before the recipe and item configs are upgrade to the new format.
This applies to both the automatic udgrade and manual upgrade using the `/recipes save`.

The backups are stored as zip files inside of the `CustomCrafting/data_backups` directory.
By default each backup is kept for 60 days. The old backups are only deleted after the spefied duration and only when a new backup was created.

The backup feature can be toggled and configured in the `config.yml` under `local_storage.backup`.

`keep_for` specifies the duration for which to keep the backups. The unit can be `MINUTES`, `HOURS`, `DAYS`