### PR TITLE
Fix ItemCreator not properly applying changes to CustomItems

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/data/cache/items/Items.java
+++ b/src/main/java/me/wolfyscript/customcrafting/data/cache/items/Items.java
@@ -28,6 +28,7 @@ import com.wolfyscript.utilities.bukkit.world.items.reference.WolfyUtilsStackIde
 import me.wolfyscript.customcrafting.gui.item_creator.tabs.ItemCreatorTab;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import org.bukkit.Material;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.inventory.EquipmentSlot;
@@ -36,6 +37,7 @@ import org.bukkit.inventory.ItemStack;
 import java.io.Serializable;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 public class Items implements Serializable {
 
@@ -107,6 +109,14 @@ public class Items implements Serializable {
             }
             return null;
         });
+    }
+
+    public void modifyOriginalStack(Consumer<ItemStack> stackConsumer) {
+        if (item.stackReference().identifier().map(stackIdentifier -> stackIdentifier instanceof BukkitStackIdentifier).orElse(false)) {
+            if (ItemUtils.isAirOrNull(item.stackReference().originalStack())) return;
+            stackConsumer.accept(item.stackReference().originalStack());
+            item.stackReference().swapParser(item.stackReference().parser());
+        }
     }
 
     public Optional<WolfyUtilsStackIdentifier> asWolfyUtilsIdentifier() {

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/ButtonItemFlagsToggle.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/ButtonItemFlagsToggle.java
@@ -36,10 +36,10 @@ public class ButtonItemFlagsToggle extends ToggleButton<CCCache> {
         super("flags." + flagId, (cache, guiHandler, player, guiInventory, i) -> {
             return cache.getItems().asBukkitIdentifier().map(identifier -> !ItemUtils.isAirOrNull(identifier.stack()) && identifier.stack().getItemMeta().hasItemFlag(itemFlag)).orElse(false);
         }, new ButtonState<>("flags." + flagId + ".enabled", material, (cache, guiHandler, player, inventory, slot, event) -> {
-            guiHandler.getCustomCache().getItems().asBukkitIdentifier().ifPresent(identifier -> identifier.stack().removeItemFlags(itemFlag));
+            guiHandler.getCustomCache().getItems().modifyOriginalStack(stack -> stack.removeItemFlags(itemFlag));
             return true;
         }), new ButtonState<>("flags." + flagId + ".disabled", material, (cache, guiHandler, player, inventory, slot, event) -> {
-            guiHandler.getCustomCache().getItems().asBukkitIdentifier().ifPresent(identifier -> identifier.stack().addItemFlags(itemFlag));
+            guiHandler.getCustomCache().getItems().modifyOriginalStack(stack -> stack.addItemFlags(itemFlag));
             return true;
         }));
     }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabAttributes.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabAttributes.java
@@ -130,10 +130,10 @@ public class TabAttributes extends ItemCreatorTabVanilla {
             return false;
         }));
         creator.registerButton(new ActionButton<>("attribute.save", Material.GREEN_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-            items.asBukkitIdentifier().ifPresent(identifier -> {
-                var itemMeta = identifier.stack().getItemMeta();
+            items.modifyOriginalStack(stack -> {
+                var itemMeta = stack.getItemMeta();
                 itemMeta.addAttributeModifier(Attribute.valueOf(cache.getSubSetting().split("\\.")[1].toUpperCase(Locale.ROOT)), items.getAttributeModifier());
-                identifier.stack().setItemMeta(itemMeta);
+                stack.setItemMeta(itemMeta);
             });
             return true;
         }));

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabCustomModelData.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabCustomModelData.java
@@ -58,14 +58,13 @@ public class TabCustomModelData extends ItemCreatorTabVanilla {
         }, (guiHandler, player, s, strings) -> {
             BukkitStackIdentifier identifier = guiHandler.getCustomCache().getItems().asBukkitIdentifier().orElse(null);
             if (identifier != null) {
-                var itemMeta = identifier.stack().getItemMeta();
-                if (!(itemMeta instanceof Repairable)) {
-                    return true;
-                }
                 try {
                     int value = Integer.parseInt(s);
-                    itemMeta.setCustomModelData(value);
-                    identifier.stack().setItemMeta(itemMeta);
+                    guiHandler.getCustomCache().getItems().modifyOriginalStack(stack -> {
+                        var itemMeta = stack.getItemMeta();
+                        itemMeta.setCustomModelData(value);
+                        stack.setItemMeta(itemMeta);
+                    });
                     creator.sendMessage(player, "custom_model_data.success", new Pair<>("%VALUE%", String.valueOf(value)));
                 } catch (NumberFormatException e) {
                     creator.sendMessage(player, "custom_model_data.invalid_value", new Pair<>("%VALUE%", s));
@@ -75,10 +74,10 @@ public class TabCustomModelData extends ItemCreatorTabVanilla {
             return false;
         }));
         creator.registerButton(new ActionButton<>("custom_model_data.reset", Material.RED_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-            guiHandler.getCustomCache().getItems().asBukkitIdentifier().ifPresent(identifier -> {
-                var itemMeta = identifier.stack().getItemMeta();
+            guiHandler.getCustomCache().getItems().modifyOriginalStack(stack -> {
+                var itemMeta = stack.getItemMeta();
                 itemMeta.setCustomModelData(null);
-                identifier.stack().setItemMeta(itemMeta);
+                stack.setItemMeta(itemMeta);
             });
             return true;
         }));

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabDamage.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabDamage.java
@@ -54,14 +54,16 @@ public class TabDamage extends ItemCreatorTab {
         creator.registerButton(new ChatInputButton<>("damage.set", Material.GREEN_CONCRETE, (guiHandler, player, s, strings) -> {
             BukkitStackIdentifier identifier = guiHandler.getCustomCache().getItems().asBukkitIdentifier().orElse(null);
             if (identifier != null) {
-                var itemMeta = identifier.stack().getItemMeta();
-                if (!(itemMeta instanceof Damageable)) {
+                if (!(identifier.stack().getItemMeta() instanceof Damageable)) {
                     return true;
                 }
                 try {
                     int value = Integer.parseInt(s);
-                    ((Damageable) itemMeta).setDamage(value);
-                    identifier.stack().setItemMeta(itemMeta);
+                    guiHandler.getCustomCache().getItems().modifyOriginalStack(stack -> {
+                        var itemMeta = stack.getItemMeta();
+                        ((Damageable) itemMeta).setDamage(value);
+                        stack.setItemMeta(itemMeta);
+                    });
                     creator.sendMessage(player, "damage.value_success", new Pair<>("%VALUE%", String.valueOf(value)));
                 } catch (NumberFormatException e) {
                     creator.sendMessage(player, "damage.invalid_value", new Pair<>("%VALUE%", s));
@@ -71,12 +73,12 @@ public class TabDamage extends ItemCreatorTab {
             return false;
         }));
         creator.registerButton(new ActionButton<>("damage.reset", Material.RED_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-            items.asBukkitIdentifier().ifPresent(identifier -> {
-                var itemMeta = identifier.stack().getItemMeta();
+            items.modifyOriginalStack(stack -> {
+                var itemMeta = stack.getItemMeta();
                 if (itemMeta instanceof Damageable) {
                     ((Damageable) itemMeta).setDamage(0);
                 }
-                identifier.stack().setItemMeta(itemMeta);
+                stack.setItemMeta(itemMeta);
             });
             return true;
         }));

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabDisplayName.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabDisplayName.java
@@ -55,15 +55,15 @@ public class TabDisplayName extends ItemCreatorTabVanilla {
         creator.registerButton(new ButtonOption(Material.NAME_TAG, this));
         new ChatInputButton.Builder<>(creator, KEY + ".set")
                 .inputAction((guiHandler, player, s, strings) -> {
-                    guiHandler.getCustomCache().getItems().asBukkitIdentifier().ifPresent(identifier -> {
-                        ItemMeta itemMeta = identifier.stack().getItemMeta();
+                    guiHandler.getCustomCache().getItems().modifyOriginalStack(itemStack -> {
+                        ItemMeta itemMeta = itemStack.getItemMeta();
                         if (creator.getCustomCrafting().isPaper()) {
                             // TODO: Need to use the non-relocated MiniMessage! (v5) No longer shade & relocate Adventure
                             itemMeta.displayName(MiniMessage.miniMessage().deserialize(s));
                         } else {
                             itemMeta.setDisplayName(BukkitComponentSerializer.legacy().serialize(api.getChat().getMiniMessage().deserialize(s)));
                         }
-                        identifier.stack().setItemMeta(itemMeta);
+                        itemStack.setItemMeta(itemMeta);
                     });
                     return false;
                 }).state(state -> state.icon(Material.GREEN_CONCRETE).action((cache, guiHandler, player, guiInventory, i, event) -> {

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabEnchants.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabEnchants.java
@@ -85,7 +85,7 @@ public class TabEnchants extends ItemCreatorTabVanilla {
                         }
                         var enchantment = Enchantment.getByKey(org.bukkit.NamespacedKey.fromString(args[0]));
                         if (enchantment != null) {
-                            guiHandler.getCustomCache().getItems().asBukkitIdentifier().ifPresent(identifier -> identifier.stack().addUnsafeEnchantment(enchantment, level));
+                            guiHandler.getCustomCache().getItems().modifyOriginalStack(stack -> stack.addUnsafeEnchantment(enchantment, level));
                         } else {
                             creator.sendMessage(guiHandler, creator.translatedMsgKey("enchant.invalid_enchant", Placeholder.unparsed("enchant", args[0])));
                             return true;
@@ -112,7 +112,7 @@ public class TabEnchants extends ItemCreatorTabVanilla {
                 .inputAction((guiHandler, player, s, args) -> {
                     var enchantment = Enchantment.getByKey(org.bukkit.NamespacedKey.fromString(args[0]));
                     if (enchantment != null) {
-                        guiHandler.getCustomCache().getItems().asBukkitIdentifier().ifPresent(identifier -> identifier.stack().removeEnchantment(enchantment));
+                        guiHandler.getCustomCache().getItems().modifyOriginalStack(stack -> stack.removeEnchantment(enchantment));
                     } else {
                         creator.sendMessage(guiHandler, creator.translatedMsgKey("enchant.invalid_enchant", Placeholder.unparsed("enchant", args[0])));
                         return true;

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabLore.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabLore.java
@@ -62,11 +62,11 @@ public class TabLore extends ItemCreatorTabVanilla {
 
         creator.registerButton(new ButtonOption(Material.WRITABLE_BOOK, this));
         creator.registerButton(new ChatInputButton<>(KEY + ".add", Material.WRITABLE_BOOK, (guiHandler, player, s, strings) -> {
-            guiHandler.getCustomCache().getItems().asBukkitIdentifier().ifPresent(identifier -> {
-                List<String> lore = identifier.stack().getLore();
+            guiHandler.getCustomCache().getItems().modifyOriginalStack(stack -> {
+                List<String> lore = stack.getLore();
                 if (lore != null) {
                     lore.add(BukkitComponentSerializer.legacy().serialize(api.getChat().getMiniMessage().deserialize(s, Placeholder.component("emtpy", Component.empty()))));
-                    identifier.stack().setLore(lore);
+                    stack.setLore(lore);
                 }
             });
             return false;

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabPlayerHead.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabPlayerHead.java
@@ -64,8 +64,8 @@ public class TabPlayerHead extends ItemCreatorTabVanilla {
         }));
         creator.registerButton(new ActionButton<>("player_head.texture.apply", Material.GREEN_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
             if (inventory.getItem(38) != null && inventory.getItem(38).getType().equals(Material.PLAYER_HEAD)) {
-                guiHandler.getCustomCache().getItems().asBukkitIdentifier().ifPresent(identifier -> {
-                    ItemBuilder builder = new ItemBuilder(identifier.stack());
+                guiHandler.getCustomCache().getItems().modifyOriginalStack(stack -> {
+                    ItemBuilder builder = new ItemBuilder(stack);
                     builder.setPlayerHeadValue(new ItemBuilder(inventory.getItem(30)).getPlayerHeadValue());
                 });
             }
@@ -74,14 +74,16 @@ public class TabPlayerHead extends ItemCreatorTabVanilla {
         creator.registerButton(new ChatInputButton<>("player_head.owner", Material.NAME_TAG, (guiHandler, player, s, args) -> {
             BukkitStackIdentifier identifier = guiHandler.getCustomCache().getItems().asBukkitIdentifier().orElse(null);
             if (identifier == null) return false;
-            var itemMeta = identifier.stack().getItemMeta();
-            if (!(itemMeta instanceof SkullMeta)) {
+            if (!(identifier.stack().getItemMeta() instanceof SkullMeta)) {
                 return true;
             }
             try {
-                var uuid = UUID.fromString(args[0]);
-                ((SkullMeta) itemMeta).setOwningPlayer(Bukkit.getOfflinePlayer(uuid));
-                identifier.stack().setItemMeta(itemMeta);
+                guiHandler.getCustomCache().getItems().modifyOriginalStack(stack -> {
+                    var itemMeta = stack.getItemMeta();
+                    var uuid = UUID.fromString(args[0]);
+                    ((SkullMeta) itemMeta).setOwningPlayer(Bukkit.getOfflinePlayer(uuid));
+                    stack.setItemMeta(itemMeta);
+                });
             } catch (IllegalArgumentException e) {
                 return true;
             }

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabRepairCost.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabRepairCost.java
@@ -22,7 +22,6 @@
 
 package me.wolfyscript.customcrafting.gui.item_creator.tabs;
 
-import com.wolfyscript.utilities.bukkit.world.items.reference.BukkitStackIdentifier;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.data.cache.items.Items;
 import me.wolfyscript.customcrafting.data.cache.items.ItemsButtonAction;
@@ -52,28 +51,27 @@ public class TabRepairCost extends ItemCreatorTabVanilla {
     public void register(MenuItemCreator creator, WolfyUtilities api) {
         creator.registerButton(new ButtonOption(Material.EXPERIENCE_BOTTLE, this));
         creator.registerButton(new ChatInputButton<>("repair_cost.set", Material.GREEN_CONCRETE, (guiHandler, player, s, strings) -> {
-            BukkitStackIdentifier identifier = guiHandler.getCustomCache().getItems().asBukkitIdentifier().orElse(null);
-            if (identifier != null) {
-                var itemMeta = identifier.stack().getItemMeta();
-                try {
-                    int value = Integer.parseInt(s);
+            try {
+                int value = Integer.parseInt(s);
+                guiHandler.getCustomCache().getItems().modifyOriginalStack(stack -> {
+                    var itemMeta = stack.getItemMeta();
                     ((Repairable) itemMeta).setRepairCost(value);
-                    identifier.stack().setItemMeta(itemMeta);
-                    creator.sendMessage(player, "repair.value_success", new Pair<>("%VALUE%", String.valueOf(value)));
-                } catch (NumberFormatException e) {
-                    creator.sendMessage(player, "repair.invalid_value", new Pair<>("%VALUE%", s));
-                    return true;
-                }
+                    stack.setItemMeta(itemMeta);
+                });
+                creator.sendMessage(player, "repair.value_success", new Pair<>("%VALUE%", String.valueOf(value)));
+            } catch (NumberFormatException e) {
+                creator.sendMessage(player, "repair.invalid_value", new Pair<>("%VALUE%", s));
+                return true;
             }
             return false;
         }));
         creator.registerButton(new ActionButton<>("repair_cost.reset", Material.RED_CONCRETE, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-            items.asBukkitIdentifier().ifPresent(identifier -> {
-                var itemMeta = identifier.stack().getItemMeta();
+            items.modifyOriginalStack(stack -> {
+                var itemMeta = stack.getItemMeta();
                 if (itemMeta instanceof Repairable) {
                     ((Repairable) itemMeta).setRepairCost(0);
                 }
-                identifier.stack().setItemMeta(itemMeta);
+                stack.setItemMeta(itemMeta);
             });
             return true;
         }));

--- a/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabUnbreakable.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/item_creator/tabs/TabUnbreakable.java
@@ -50,17 +50,17 @@ public class TabUnbreakable extends ItemCreatorTabVanilla {
         creator.registerButton(new ToggleButton<>(KEY, (cache, guiHandler, player, guiInventory, i) -> {
             return cache.getItems().asBukkitIdentifier().map(identifier -> !ItemUtils.isAirOrNull(identifier.stack()) && identifier.stack().getItemMeta().isUnbreakable()).orElse(false);
         }, new ButtonState<>(KEY + ".enabled", Material.BEDROCK, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-            cache.getItems().asBukkitIdentifier().ifPresent(identifier -> {
-                var itemMeta = identifier.stack().getItemMeta();
+            cache.getItems().modifyOriginalStack(stack -> {
+                var itemMeta = stack.getItemMeta();
                 itemMeta.setUnbreakable(false);
-                identifier.stack().setItemMeta(itemMeta);
+                stack.setItemMeta(itemMeta);
             });
             return true;
         }), new ButtonState<>(KEY + ".disabled", Material.GLASS, (ItemsButtonAction) (cache, items, guiHandler, player, inventory, i, event) -> {
-            cache.getItems().asBukkitIdentifier().ifPresent(identifier -> {
-                var itemMeta = identifier.stack().getItemMeta();
+            cache.getItems().modifyOriginalStack(stack -> {
+                var itemMeta = stack.getItemMeta();
                 itemMeta.setUnbreakable(true);
-                identifier.stack().setItemMeta(itemMeta);
+                stack.setItemMeta(itemMeta);
             });
             return true;
         })));

--- a/src/main/java/me/wolfyscript/customcrafting/utils/ChatUtils.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/ChatUtils.java
@@ -152,8 +152,8 @@ public class ChatUtils {
                 },
                 (guiHandler, player, cache, line) -> BukkitComponentSerializer.legacy().deserialize(line),
                 (guiHandler, player, cache, msg, args) -> BukkitComponentSerializer.legacy().serialize(miniM.deserialize(msg))
-        ).onAdd((guiHandler, player, cache, index, entry) -> cache.getItems().asBukkitIdentifier().ifPresent(identifier -> {
-            var itemMeta = identifier.stack().getItemMeta();
+        ).onAdd((guiHandler, player, cache, index, entry) -> cache.getItems().modifyOriginalStack(stack -> {
+            var itemMeta = stack.getItemMeta();
             List<String> lore = itemMeta.getLore();
             if (lore == null) {
                 lore = new ArrayList<>();
@@ -164,17 +164,17 @@ public class ChatUtils {
                 lore.add(entry);
             }
             itemMeta.setLore(lore);
-            identifier.stack().setItemMeta(itemMeta);
-        })).onRemove((guiHandler, player, cache, index, entry) -> cache.getItems().asBukkitIdentifier().ifPresent(identifier -> {
-            var itemMeta = identifier.stack().getItemMeta();
+            stack.setItemMeta(itemMeta);
+        })).onRemove((guiHandler, player, cache, index, entry) -> cache.getItems().modifyOriginalStack(stack -> {
+            var itemMeta = stack.getItemMeta();
             List<String> lore = itemMeta.getLore();
             if (lore != null) {
                 lore.remove(index);
                 itemMeta.setLore(lore);
             }
-            identifier.stack().setItemMeta(itemMeta);
-        })).onMove((guiHandler, player, cache, fromIndex, toIndex) -> cache.getItems().asBukkitIdentifier().ifPresent(identifier -> {
-            var itemMeta = identifier.stack().getItemMeta();
+            stack.setItemMeta(itemMeta);
+        })).onMove((guiHandler, player, cache, fromIndex, toIndex) -> cache.getItems().modifyOriginalStack(stack -> {
+            var itemMeta = stack.getItemMeta();
             List<String> lore = itemMeta.getLore();
             if (lore != null) {
                 String toPrevEntry = lore.get(toIndex);
@@ -182,15 +182,15 @@ public class ChatUtils {
                 lore.set(fromIndex, toPrevEntry);
                 itemMeta.setLore(lore);
             }
-            identifier.stack().setItemMeta(itemMeta);
-        })).onEdit((guiHandler, player, cache, index, previousEntry, newEntry) -> cache.getItems().asBukkitIdentifier().ifPresent(identifier -> {
-            var itemMeta = identifier.stack().getItemMeta();
+            stack.setItemMeta(itemMeta);
+        })).onEdit((guiHandler, player, cache, index, previousEntry, newEntry) -> cache.getItems().modifyOriginalStack(stack -> {
+            var itemMeta = stack.getItemMeta();
             List<String> lore = itemMeta.getLore();
             if (lore != null) {
                 lore.set(index, newEntry);
                 itemMeta.setLore(lore);
             }
-            identifier.stack().setItemMeta(itemMeta);
+            stack.setItemMeta(itemMeta);
         })).setSendInputInfoMessages((guiHandler, player, cache) -> {
             var chat = invAPI.getWolfyUtilities().getChat();
             chat.sendMessage(player, chat.translated("msg.input.wui_command"));
@@ -208,8 +208,8 @@ public class ChatUtils {
                 // TODO: This is quite inefficient! We need to convert to the non-shaded version of Adventure! (v5)
                 (guiHandler, player, cache, line) -> miniM.deserialize(paperMiniMsg.serialize(line)),
                 (guiHandler, player, cache, msg, args) -> paperMiniMsg.deserialize(msg)
-        ).onAdd((guiHandler, player, cache, index, entry) -> cache.getItems().asBukkitIdentifier().ifPresent(identifier -> {
-            var itemMeta = identifier.stack().getItemMeta();
+        ).onAdd((guiHandler, player, cache, index, entry) -> cache.getItems().modifyOriginalStack(stack -> {
+            var itemMeta = stack.getItemMeta();
             List<Component> lore = itemMeta.lore();
             if (lore == null) {
                 lore = new ArrayList<>();
@@ -220,17 +220,17 @@ public class ChatUtils {
                 lore.add(entry);
             }
             itemMeta.lore(lore);
-            identifier.stack().setItemMeta(itemMeta);
-        })).onRemove((guiHandler, player, cache, index, entry) -> cache.getItems().asBukkitIdentifier().ifPresent(identifier -> {
-            var itemMeta = identifier.stack().getItemMeta();
+            stack.setItemMeta(itemMeta);
+        })).onRemove((guiHandler, player, cache, index, entry) -> cache.getItems().modifyOriginalStack(stack -> {
+            var itemMeta = stack.getItemMeta();
             List<Component> lore = itemMeta.lore();
             if (lore != null) {
                 lore.remove(index);
                 itemMeta.lore(lore);
             }
-            identifier.stack().setItemMeta(itemMeta);
-        })).onMove((guiHandler, player, cache, fromIndex, toIndex) -> cache.getItems().asBukkitIdentifier().ifPresent(identifier -> {
-            var itemMeta = identifier.stack().getItemMeta();
+            stack.setItemMeta(itemMeta);
+        })).onMove((guiHandler, player, cache, fromIndex, toIndex) -> cache.getItems().modifyOriginalStack(stack -> {
+            var itemMeta = stack.getItemMeta();
             List<Component> lore = itemMeta.lore();
             if (lore != null) {
                 Component toPrevEntry = lore.get(toIndex);
@@ -238,15 +238,15 @@ public class ChatUtils {
                 lore.set(fromIndex, toPrevEntry);
                 itemMeta.lore(lore);
             }
-            identifier.stack().setItemMeta(itemMeta);
-        })).onEdit((guiHandler, player, cache, index, previousEntry, newEntry) -> cache.getItems().asBukkitIdentifier().ifPresent(identifier -> {
-            var itemMeta = identifier.stack().getItemMeta();
+            stack.setItemMeta(itemMeta);
+        })).onEdit((guiHandler, player, cache, index, previousEntry, newEntry) -> cache.getItems().modifyOriginalStack(stack -> {
+            var itemMeta = stack.getItemMeta();
             List<Component> lore = itemMeta.lore();
             if (lore != null) {
                 lore.set(index, newEntry);
                 itemMeta.lore(lore);
             }
-            identifier.stack().setItemMeta(itemMeta);
+            stack.setItemMeta(itemMeta);
         })).setSendInputInfoMessages((guiHandler, player, cache) -> {
             var chat = invAPI.getWolfyUtilities().getChat();
             chat.sendMessage(player, chat.translated("msg.input.wui_command"));
@@ -257,8 +257,8 @@ public class ChatUtils {
     public static void sendAttributeModifierManager(Player player) {
         CCCache cache = ((CCCache) api.getInventoryAPI().getGuiHandler(player).getCustomCache());
         var items = cache.getItems();
-        items.asBukkitIdentifier().ifPresent(identifier -> {
-            var itemMeta = identifier.stack().getItemMeta();
+        items.modifyOriginalStack(stack -> {
+            var itemMeta = stack.getItemMeta();
             for (int i = 0; i < 15; i++) {
                 player.sendMessage("");
             }
@@ -274,7 +274,7 @@ public class ChatUtils {
                                 new ClickData("§7[§c-§7] ", (wolfyUtilities, player1) -> {
                                     CCCache cache1 = (CCCache) api.getInventoryAPI().getGuiHandler(player).getCustomCache();
                                     itemMeta.removeAttributeModifier(Attribute.valueOf(cache1.getSubSetting().substring("attribute.".length()).toUpperCase(Locale.ROOT)), modifier);
-                                    cache1.getItems().asBukkitIdentifier().ifPresent(identifier1 -> identifier1.stack().setItemMeta(itemMeta));
+                                    stack.setItemMeta(itemMeta);
                                     sendAttributeModifierManager(player1);
                                 }, new HoverEvent(net.md_5.bungee.api.chat.HoverEvent.Action.SHOW_TEXT, "§c" + modifier.getName())),
                                 new ClickData("§e" + modifier.getName() + "  §b" + modifier.getAmount() + "  §6" + (modifier.getSlot() == null ? "ANY" : modifier.getSlot()) + "  §3" + modifier.getOperation(), null),


### PR DESCRIPTION
This fixes an issue, where the ItemCreator only edited the CustomItems referenced copy of the actual ItemStack, instead of the original ItemStack. Therefor changes were not saved and lost on reload/restart.