### PR TITLE
No Longer Display Note About Brewing Stand Recipes

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuMain.java
+++ b/src/main/java/me/wolfyscript/customcrafting/gui/main_gui/MenuMain.java
@@ -143,10 +143,14 @@ public class MenuMain extends CCWindow {
         event.setButton(23, CAMPFIRE);
         event.setButton(25, STONECUTTER);
 
-        offset = 0;
-        event.setButton(30, customCrafting.getConfigHandler().getConfig().isBrewingRecipes() ? BREWING_STAND : "brewing_stand_disabled");
+        offset = 1;
+        if (customCrafting.getConfigHandler().getConfig().isBrewingRecipes()) {
+            event.setButton(30, BREWING_STAND);
+            offset = 0;
+        }
+
         event.setButton(28 + offset, GRINDSTONE);
-        event.setButton(32 + offset, ELITE_CRAFTING);
+        event.setButton(32 - offset, ELITE_CRAFTING);
         event.setButton(34 - offset, SMITHING);
 
         if (customCrafting.getConfigHandler().getConfig().isGUIDrawBackground()) {


### PR DESCRIPTION
This removes the Brewing Stand Recipe Creator Button that notes that the brewing stand recipes can be enabled in the config.
Brewing Stands seem to be broken in 1.20+ and so far were not updated.