### PR TITLE
Implement the WolfyUtils Dependency system

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
 group = "com.wolfyscript.customcrafting"
 version = "4.17-SNAPSHOT"
 description = "customcrafting-spigot"
-java.sourceCompatibility = JavaVersion.VERSION_16
+java.sourceCompatibility = JavaVersion.VERSION_17
 
 tasks.named<ProcessResources>("processResources") {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     compileOnly("io.netty:netty-all:4.1.85.Final")
     compileOnly("me.clip:placeholderapi:2.10.4")
     compileOnly("io.th0rgal:oraxen:1.170.0")
-    compileOnly("com.wolfyscript.wolfyutils.spigot:wolfyutils-spigot:4.17-SNAPSHOT")
+    compileOnly("com.wolfyscript.wolfyutils.spigot:wolfyutils-spigot:4.17-beta.2-SNAPSHOT")
 }
 
 group = "com.wolfyscript.customcrafting"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,6 +127,14 @@ minecraftServers {
             extraEnv.put("BUILD_FROM_SOURCE", "true")
             ports.set(setOf(debugPortMapping, "25568:25565"))
         }
+        register("spigot_1_20_6") {
+            version.set("1.20.6")
+            type.set("SPIGOT")
+            imageVersion.set("java21-graalvm")
+
+            extraEnv.put("BUILD_FROM_SOURCE", "true")
+            ports.set(setOf(debugPortMapping, "25569:25565"))
+        }
         // Paper test servers
         register("paper_1_20") {
             version.set("1.20.4")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,8 @@ plugins {
 
 repositories {
     mavenLocal()
+    maven (url = "https://repo.codemc.io/repository/maven-public/")
+    maven(url = "https://repo.papermc.io/repository/maven-public/")
     maven(url = "https://artifacts.wolfyscript.com/artifactory/gradle-dev")
     maven(url = "https://repo.dmulloy2.net/repository/public/")
     maven(url = "https://repo.maven.apache.org/maven2/")
@@ -43,7 +45,7 @@ dependencies {
     api("com.comphenix.protocol:ProtocolLib:5.0.0-SNAPSHOT")
     api("org.bstats:bstats-bukkit:3.0.0")
     compileOnly("io.lumine:Mythic-Dist:5.3.5")
-    compileOnly("io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("com.mojang:authlib:3.11.50")
     compileOnly("org.jetbrains:annotations:23.0.0")
     compileOnly("io.netty:netty-all:4.1.85.Final")

--- a/src/main/java/me/wolfyscript/customcrafting/commands/CommandRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/CommandRecipe.java
@@ -23,11 +23,7 @@
 package me.wolfyscript.customcrafting.commands;
 
 import me.wolfyscript.customcrafting.CustomCrafting;
-import me.wolfyscript.customcrafting.commands.recipes.DeleteSubCommand;
-import me.wolfyscript.customcrafting.commands.recipes.EditSubCommand;
-import me.wolfyscript.customcrafting.commands.recipes.RecipeLookupCommand;
-import me.wolfyscript.customcrafting.commands.recipes.SaveSubCommand;
-import me.wolfyscript.customcrafting.commands.recipes.ToggleSubCommand;
+import me.wolfyscript.customcrafting.commands.recipes.*;
 import me.wolfyscript.customcrafting.utils.ChatUtils;
 import me.wolfyscript.customcrafting.utils.PlayerUtil;
 import org.bukkit.command.CommandSender;
@@ -45,6 +41,7 @@ public class CommandRecipe extends IndexCommand {
         registerSubCommand(new ToggleSubCommand(customCrafting));
         registerSubCommand(new SaveSubCommand(customCrafting));
         registerSubCommand(new RecipeLookupCommand(customCrafting));
+        registerSubCommand(new InfoSubCommand(customCrafting));
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/customcrafting/commands/recipes/InfoSubCommand.java
+++ b/src/main/java/me/wolfyscript/customcrafting/commands/recipes/InfoSubCommand.java
@@ -1,0 +1,272 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.commands.recipes;
+
+import com.wolfyscript.utilities.dependency.Dependency;
+import com.wolfyscript.utilities.dependency.DependencyResolver;
+import com.wolfyscript.utilities.verification.VerifierContainer;
+import me.wolfyscript.customcrafting.CustomCrafting;
+import me.wolfyscript.customcrafting.commands.AbstractSubCommand;
+import me.wolfyscript.customcrafting.handlers.ResourceLoader;
+import me.wolfyscript.customcrafting.recipes.CustomRecipe;
+import me.wolfyscript.customcrafting.utils.ChatUtils;
+import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
+import me.wolfyscript.customcrafting.utils.chat.CollectionView;
+import me.wolfyscript.lib.net.kyori.adventure.text.Component;
+import me.wolfyscript.lib.net.kyori.adventure.text.event.ClickEvent;
+import me.wolfyscript.lib.net.kyori.adventure.text.event.HoverEventSource;
+import me.wolfyscript.lib.net.kyori.adventure.text.format.NamedTextColor;
+import me.wolfyscript.lib.net.kyori.adventure.text.format.TextDecoration;
+import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import me.wolfyscript.utilities.api.chat.Chat;
+import me.wolfyscript.utilities.util.NamespacedKey;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class InfoSubCommand extends AbstractSubCommand {
+
+    private ResourceLoader resourceLoader;
+
+    private final String PENDING = "<yellow>⌚ Pending";
+    private final String FAILED = "<#e2332e> ❌  Failed";
+    private final String REGISTERED = "<#0bb134>✔ Registered";
+    private final String INVALID = "<gold>⚠ Invalid";
+    private final String NAMESPACE = "<#becfca>🪣</#becfca><white> Namespace";
+    private final String DIRECTORY = "<b><#4eb1e3>🗀</#4eb1e3></b><white> Directory";
+    private final String NAME = "<#4eb1e3>🪧</#4eb1e3><white> Name";
+
+    public InfoSubCommand(CustomCrafting customCrafting) {
+        super("info", new ArrayList<>(), customCrafting);
+        this.resourceLoader = customCrafting.getDataHandler().getActiveLoader();
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull String var3, @NotNull String[] args) {
+        if (sender instanceof Player player && ChatUtils.checkPerm(player, "customcrafting.cmd.recipes_delete")) {
+            var chat = api.getChat();
+            if (args.length == 0) {
+                sendList(player, resourceLoader, chat);
+                return true;
+            }
+
+            try {
+                NamespacedKey key = NamespacedKey.of(args[0]);
+                if (key != null) {
+                    CustomRecipe<?> customRecipe = customCrafting.getRegistries().getRecipes().get(key);
+
+                    chat.sendMessage(player, Component.text("----------------------------"));
+
+                    Optional<VerifierContainer<? extends CustomRecipe<?>>> invalidState = resourceLoader.getInvalidRecipes()
+                            .stream()
+                            .filter(verifierContainer -> verifierContainer.value().map(recipe -> recipe.getNamespacedKey().equals(key)).orElse(false))
+                            .findFirst();
+
+                    final String state;
+                    if (resourceLoader.getFailedRecipes().contains(key)) {
+                        state = FAILED;
+                    } else if (resourceLoader.getPendingRecipes().stream().anyMatch(recipe -> recipe.getNamespacedKey().equals(key))) {
+                        state = PENDING;
+                    } else if (invalidState.isPresent()) {
+                        state = INVALID;
+                    } else if (customRecipe != null) {
+                        state = REGISTERED;
+                    } else {
+                        state = "Unknown";
+                    }
+
+                    chat.sendMessage(player, chat.getMiniMessage().deserialize("<b>" + state + "</b>"));
+                    chat.sendMessage(player, Component.empty());
+                    chat.sendMessage(player, chat.getMiniMessage().deserialize(NAMESPACE + ": <yellow><namespace>", Placeholder.unparsed("namespace", key.getNamespace())));
+                    chat.sendMessage(player, chat.getMiniMessage().deserialize(DIRECTORY + ": <yellow><dir>", Placeholder.unparsed("dir", key.getKeyComponent().getFolder())));
+                    chat.sendMessage(player, chat.getMiniMessage().deserialize(NAME + ": <yellow><name>", Placeholder.unparsed("name", key.getKeyComponent().getObject())));
+                    chat.sendMessage(player, Component.empty());
+
+                    if (invalidState.isPresent() && customRecipe == null) {
+                        customRecipe = invalidState.get().value().orElse(null);
+                    }
+
+                    if (customRecipe != null) {
+                        // Recipe is either registered or invalid
+                        Set<Dependency> dependencies = DependencyResolver.resolveDependenciesFor(customRecipe, customRecipe.getClass());
+                        if (!dependencies.isEmpty()) {
+                            chat.sendMessage(player, chat.getMiniMessage().deserialize("<dark_aqua>🧪</dark_aqua> <white><u>Dependencies"));
+                            chat.sendMessage(player, Component.text("   " + dependencies.stream().map(Dependency::toString).collect(Collectors.joining(" - "))));
+                            chat.sendMessage(player, Component.empty());
+                        }
+
+                        if (invalidState.isPresent()) {
+                            chat.sendMessage(player, chat.getMiniMessage().deserialize("<red>⚑</red> <white><u>Detected Issues"));
+                            invalidState.ifPresent(verifierContainer -> {
+
+                                verifierContainer.printToOut(0,  false, "   ", string -> {
+                                    string = string.replace("\n", "");
+                                    if (string.stripLeading().startsWith("!")) {
+                                        chat.sendMessage(player, Component.text(string, NamedTextColor.DARK_RED));
+                                    } else {
+                                        chat.sendMessage(player, Component.text(string, NamedTextColor.RED));
+                                    }
+                                });
+                            });
+                        }
+                    }
+
+                }
+            } catch (IllegalArgumentException ex) {
+                chat.sendMessage(player, chat.translated("commands.recipes.invalid_recipe", Placeholder.unparsed("recipe", args[0])));
+            }
+        }
+        return true;
+    }
+
+    private List<Component> getCategoriesFor(Player player, int currentIndex, ResourceLoader resourceLoader, Chat chat) {
+        final int lengthLimit = 49;
+        return List.of(
+                chat.getMiniMessage().deserialize(REGISTERED + ": <b><loaded>", Placeholder.unparsed("loaded", String.valueOf(customCrafting.getRegistries().getRecipes().size())))
+                        .clickEvent(chat.executable(player, true, (wolfyUtilities, player1) -> {
+                            sendExpandedList(player,
+                                    currentIndex,
+                                    0,
+                                    resourceLoader,
+                                    (player2) -> customCrafting.getRegistries().getRecipes().keySet(),
+                                    (player2, element) -> {
+                                        String value = element.toString();
+                                        if (value.length() > lengthLimit) {
+                                            value = value.substring(0, lengthLimit) + "...";
+                                        }
+                                        return Component.text(value).hoverEvent(Component.text(element.toString())).clickEvent(ClickEvent.runCommand("/recipes info " + element));
+                                    },
+                                    chat
+                            ).send(player);
+                        })),
+                chat.getMiniMessage().deserialize(PENDING + ": <b><pending>", Placeholder.unparsed("pending", String.valueOf(resourceLoader.getPendingRecipes().size())))
+                        .clickEvent(chat.executable(player, true, (wolfyUtilities, player1) -> {
+                            sendExpandedList(player,
+                                    currentIndex,
+                                    1,
+                                    resourceLoader,
+                                    (player2) -> resourceLoader.getPendingRecipes(),
+                                    (player2, element) -> {
+                                        String value = element.getNamespacedKey().toString();
+                                        if (value.length() > lengthLimit) {
+                                            value = value.substring(0, lengthLimit) + "...";
+                                        }
+                                        return Component.text(value).hoverEvent(Component.text(element.getNamespacedKey().toString())).clickEvent(ClickEvent.runCommand("/recipes info " + element.getNamespacedKey().toString()));
+                                    },
+                                    chat
+                            ).send(player);
+                        })),
+                chat.getMiniMessage().deserialize(INVALID + ": <b><invalid>", Placeholder.unparsed("invalid", String.valueOf(resourceLoader.getInvalidRecipes().size())))
+                        .clickEvent(chat.executable(player, true, (wolfyUtilities, player1) -> sendExpandedList(player,
+                                currentIndex,
+                                2,
+                                resourceLoader,
+                                (player2) -> resourceLoader.getInvalidRecipes(),
+                                (player2, element) -> {
+                                    String value = element.value().map(recipe -> recipe.getNamespacedKey().toString()).orElse("missing key");
+                                    String stripped = value;
+                                    if (value.length() > lengthLimit) {
+                                        stripped = value.substring(0, lengthLimit) + "...";
+                                    }
+                                    return Component.text(stripped).hoverEvent(Component.text(value)).clickEvent(ClickEvent.runCommand("/recipes info " + value));
+                                },
+                                chat
+                        ).send(player))),
+                chat.getMiniMessage().deserialize(FAILED + ": <b><failed>", Placeholder.unparsed("failed", String.valueOf(resourceLoader.getFailedRecipes().size())))
+                        .clickEvent(chat.executable(player, true, (wolfyUtilities, player1) -> sendExpandedList(player,
+                                currentIndex,
+                                3,
+                                resourceLoader,
+                                (player2) -> resourceLoader.getFailedRecipes(),
+                                (player2, element) -> {
+                                    String value = element.toString();
+                                    if (value.length() > lengthLimit) {
+                                        value = value.substring(0, lengthLimit) + "...";
+                                    }
+                                    return Component.text(value).hoverEvent(Component.text(element.toString())).clickEvent(ClickEvent.runCommand("/recipes info " + element));
+                                },
+                                chat
+                        ).send(player)))
+        );
+    }
+
+    private void sendList(Player player, ResourceLoader resourceLoader, Chat chat) {
+        sendExpandedList(player, 0, -1, resourceLoader, null, null, chat).send(player);
+    }
+
+    private <T> CollectionView<T> sendExpandedList(Player player, int previousIndex, int clickedIndex, ResourceLoader resourceLoader, CollectionView.SupplyEntryCollection<T> supplyCollection, CollectionView.ParseEntryToComponent<T> parseEntryToComponent, Chat chat) {
+        boolean collapse = previousIndex == clickedIndex;
+
+        var components = getCategoriesFor(player, collapse ? -1 : clickedIndex, resourceLoader, chat);
+        var list = new CollectionView<>(chat, collapse ? null : supplyCollection, collapse ? null : parseEntryToComponent);
+        list.setEntriesPerPage(8);
+        list.prefix(true);
+
+        if (clickedIndex >= components.size() || clickedIndex < -1) {
+            throw new IllegalArgumentException("expandIndex out of bounds");
+        }
+
+        if (collapse || clickedIndex < 0) {
+            list.header((chat1, player1) -> {
+                chat.sendMessage(player, true, Component.text("------------------------"));
+            });
+        } else {
+            list.header((chat1, player1) -> {
+                chat.sendMessage(player, true, Component.text("------------------------"));
+                for (int i = 0; i < clickedIndex; i++) {
+                    chat1.sendMessage(player, true, Component.text("⏵ ").append(components.get(i)));
+                }
+                chat1.sendMessage(player, true, Component.text("⏷ ").append(components.get(clickedIndex)));
+            });
+        }
+        final int offset = collapse ? 0 : clickedIndex + 1;
+        if (offset < components.size()) {
+            list.footer((chat1, player1) -> {
+                if (offset != 0) {
+                    chat1.sendMessage(player, true, Component.text(" "));
+                }
+                for (int i = offset; i < components.size(); i++) {
+                    chat1.sendMessage(player, true, Component.text("⏵ ").append(components.get(i)));
+                }
+            });
+        }
+
+        return list;
+    }
+
+    @Override
+    protected @Nullable
+    List<String> onTabComplete(@NotNull CommandSender var1, @NotNull String var3, @NotNull String[] args) {
+        List<NamespacedKey> list = new ArrayList<>();
+        list.addAll(customCrafting.getRegistries().getRecipes().keySet());
+        list.addAll(resourceLoader.getFailedRecipes());
+        list.addAll(resourceLoader.getPendingRecipes().stream().map(CustomRecipe::getNamespacedKey).toList());
+        list.addAll(resourceLoader.getInvalidRecipes().stream().map(verifierContainer -> verifierContainer.value().map(CustomRecipe::getNamespacedKey).orElse(null)).toList());
+
+        return NamespacedKeyUtils.getPartialMatches(args[args.length - 1], list).stream().map(NamespacedKey::toString).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
@@ -147,7 +147,7 @@ public class DataHandler implements Listener {
     private void integrationEnable(PluginIntegrationEnableEvent event) {
         int validatedTotal = 0;
         for (ResourceLoader loader : loaders) {
-            validatedTotal += loader.validatePending();
+            validatedTotal += loader.validatePending(event.getIntegration());
         }
         if (validatedTotal > 0) {
             configHandler.getRecipeBookConfig().index(customCrafting);

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/ExtensionPackLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/ExtensionPackLoader.java
@@ -25,6 +25,7 @@ package me.wolfyscript.customcrafting.handlers;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
+import me.wolfyscript.utilities.compatibility.PluginIntegration;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
 public class ExtensionPackLoader extends ResourceLoader {
@@ -39,7 +40,7 @@ public class ExtensionPackLoader extends ResourceLoader {
     }
 
     @Override
-    public int validatePending() {
+    public int validatePending(PluginIntegration pluginIntegration) {
         return 0;
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
@@ -76,34 +76,10 @@ public class LocalStorageLoader extends ResourceLoader {
 
     private DataSettings dataSettings;
     private ExecutorService executor;
-    private final List<NamespacedKey> failedRecipes;
-
-    private final Multimap<CustomRecipe<?>, Dependency> recipeDependencies = Multimaps.newSetMultimap(new HashMap<>(), HashSet::new);
-    private final List<VerifierContainer<? extends CustomRecipe<?>>> invalidRecipes;
 
     protected LocalStorageLoader(CustomCrafting customCrafting) {
         super(customCrafting, new NamespacedKey(customCrafting, "local_loader"));
-        this.failedRecipes = new ArrayList<>();
-        this.invalidRecipes = new ArrayList<>();
         this.dataSettings = customCrafting.getConfigHandler().getConfig().getDataSettings();
-    }
-
-    protected void markInvalid(VerifierContainer<? extends CustomRecipe<?>> recipe) {
-        synchronized (invalidRecipes) {
-            invalidRecipes.add(recipe);
-        }
-    }
-
-    protected void markFailed(NamespacedKey recipe) {
-        synchronized (failedRecipes) {
-            failedRecipes.add(recipe);
-        }
-    }
-
-    private static <T extends CustomRecipe<?>> Optional<VerifierContainer<T>> validateRecipe(T recipe) {
-        var validator = (Verifier<T>) CustomCrafting.inst().getRegistries().getVerifiers().get(recipe.getRecipeType().getNamespacedKey());
-        if (validator == null) return Optional.empty();
-        return Optional.of(validator.validate(recipe));
     }
 
     public static void pack(File sourceDirPath, File zipFilePath) throws IOException {

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/ResourceLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/ResourceLoader.java
@@ -24,6 +24,12 @@ package me.wolfyscript.customcrafting.handlers;
 
 import java.io.File;
 import java.io.IOException;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.wolfyscript.utilities.dependency.Dependency;
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierContainer;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.configs.MainConfig;
 import me.wolfyscript.customcrafting.recipes.CustomRecipe;
@@ -36,7 +42,7 @@ import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Objects;
+import java.util.*;
 
 public abstract class ResourceLoader implements Comparable<ResourceLoader>, Keyed {
 
@@ -47,6 +53,10 @@ public abstract class ResourceLoader implements Comparable<ResourceLoader>, Keye
     protected final ObjectMapper objectMapper;
     private int priority = 0;
     private boolean replaceData = false;
+
+    protected final Multimap<CustomRecipe<?>, Dependency> recipeDependencies = Multimaps.newSetMultimap(new HashMap<>(), HashSet::new);
+    protected final List<VerifierContainer<? extends CustomRecipe<?>>> invalidRecipes = new ArrayList<>();
+    protected final List<NamespacedKey> failedRecipes = new ArrayList<>();
 
     protected ResourceLoader(CustomCrafting customCrafting, NamespacedKey key) {
         this.key = key;
@@ -73,6 +83,36 @@ public abstract class ResourceLoader implements Comparable<ResourceLoader>, Keye
     }
 
     public abstract int validatePending(PluginIntegration pluginIntegration);
+
+    protected static <T extends CustomRecipe<?>> Optional<VerifierContainer<T>> validateRecipe(T recipe) {
+        var validator = (Verifier<T>) CustomCrafting.inst().getRegistries().getVerifiers().get(recipe.getRecipeType().getNamespacedKey());
+        if (validator == null) return Optional.empty();
+        return Optional.of(validator.validate(recipe));
+    }
+
+    protected void markInvalid(VerifierContainer<? extends CustomRecipe<?>> recipe) {
+        synchronized (invalidRecipes) {
+            invalidRecipes.add(recipe);
+        }
+    }
+
+    protected void markFailed(NamespacedKey recipe) {
+        synchronized (failedRecipes) {
+            failedRecipes.add(recipe);
+        }
+    }
+
+    public Set<CustomRecipe<?>> getPendingRecipes() {
+        return Collections.unmodifiableSet(recipeDependencies.keySet());
+    }
+
+    public List<VerifierContainer<? extends CustomRecipe<?>>> getInvalidRecipes() {
+        return Collections.unmodifiableList(invalidRecipes);
+    }
+
+    public List<NamespacedKey> getFailedRecipes() {
+        return Collections.unmodifiableList(failedRecipes);
+    }
 
     /**
      * Sets the new value for the "replace data" option.<br>

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/ResourceLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/ResourceLoader.java
@@ -31,6 +31,7 @@ import me.wolfyscript.customcrafting.utils.ItemLoader;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.ObjectMapper;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
+import me.wolfyscript.utilities.compatibility.PluginIntegration;
 import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
@@ -71,7 +72,7 @@ public abstract class ResourceLoader implements Comparable<ResourceLoader>, Keye
         }
     }
 
-    public abstract int validatePending();
+    public abstract int validatePending(PluginIntegration pluginIntegration);
 
     /**
      * Sets the new value for the "replace data" option.<br>

--- a/src/main/java/me/wolfyscript/customcrafting/handlers/SQLDatabaseLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/handlers/SQLDatabaseLoader.java
@@ -33,6 +33,7 @@ import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonProcessingException;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.InjectableValues;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.network.database.sql.SQLDataBase;
+import me.wolfyscript.utilities.compatibility.PluginIntegration;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
 import java.io.IOException;
@@ -87,7 +88,7 @@ public class SQLDatabaseLoader extends DatabaseLoader {
     }
 
     @Override
-    public int validatePending() {
+    public int validatePending(PluginIntegration pluginIntegration) {
         return 0;
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShaped.java
@@ -25,8 +25,8 @@ package me.wolfyscript.customcrafting.recipes;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Streams;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.recipebook.ButtonContainerIngredient;
@@ -45,7 +45,6 @@ import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonSetter;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
-import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.api.nms.network.MCByteBuf;
@@ -70,10 +69,13 @@ public abstract class AbstractRecipeShaped<C extends AbstractRecipeShaped<C, S>,
     private static final String VERTICAL_KEY = "vertical";
     private static final String ROTATION_KEY = "rotation";
 
-    protected static <RT extends AbstractRecipeShaped<?, ?>> Validator<RT> validator() {
-        return ValidatorBuilder.<RT>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "abstract_shaped_crafting")).def()
-                .object(recipe -> recipe.result, resultInitStep -> resultInitStep.use(Result.VALIDATOR))
-                .collection(recipe -> recipe.mappedIngredients.entrySet(), init -> init.def().name(c -> "Ingredients").forEach(initEntry -> initEntry.use(Ingredient.ENTRY_VALIDATOR)))
+    protected static <RT extends AbstractRecipeShaped<?, ?>> Verifier<RT> validator() {
+        return VerifierBuilder.<RT>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "abstract_shaped_crafting"))
+                .object(recipe -> recipe.result, Result.VERIFIER)
+                .collection(recipe -> recipe.mappedIngredients.entrySet(), builder -> builder
+                        .name(c -> "Ingredients")
+                        .forEach(Ingredient.ENTRY_VERIFIER)
+                )
                 .build();
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/AbstractRecipeShapeless.java
@@ -24,8 +24,9 @@ package me.wolfyscript.customcrafting.recipes;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Streams;
-import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.io.IOException;
@@ -40,8 +41,6 @@ import me.wolfyscript.customcrafting.recipes.data.IngredientData;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
 import me.wolfyscript.customcrafting.recipes.items.Result;
 import me.wolfyscript.customcrafting.recipes.settings.CraftingRecipeSettings;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
 import me.wolfyscript.customcrafting.utils.CraftManager;
 import me.wolfyscript.customcrafting.utils.ItemLoader;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
@@ -51,7 +50,6 @@ import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonSetter;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
-import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.nms.network.MCByteBuf;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
@@ -67,10 +65,10 @@ public abstract class AbstractRecipeShapeless<C extends AbstractRecipeShapeless<
     @JsonIgnore
     private boolean hasAllowedEmptyIngredient;
 
-    protected static <RT extends AbstractRecipeShapeless<?,?>> Validator<RT> validator() {
-        return ValidatorBuilder.<RT>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "abstract_shapeless_crafting")).def()
-                .object(recipe -> recipe.result, resultInitStep -> resultInitStep.use(Result.VALIDATOR))
-                .collection(recipe -> recipe.ingredients, init -> init.def().forEach(initEntry -> initEntry.use(Ingredient.VALIDATOR)))
+    protected static <RT extends AbstractRecipeShapeless<?,?>> Verifier<RT> validator() {
+        return VerifierBuilder.<RT>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "abstract_shapeless_crafting"))
+                .object(recipe -> recipe.result, Result.VERIFIER)
+                .collection(recipe -> recipe.ingredients, builder -> builder.forEach(Ingredient.VERIFIER))
                 .build();
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
@@ -22,41 +22,30 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
-import com.wolfyscript.utilities.bukkit.nms.item.crafting.FunctionalRecipeBuilderCrafting;
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Optional;
 
-import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
+import com.wolfyscript.utilities.dependency.DependencySource;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
 import me.wolfyscript.customcrafting.gui.recipebook.ButtonContainerIngredient;
 import me.wolfyscript.customcrafting.gui.recipebook.ClusterRecipeBook;
-import me.wolfyscript.customcrafting.listeners.customevents.CustomPreCraftEvent;
 import me.wolfyscript.customcrafting.recipes.conditions.AdvancedWorkbenchCondition;
 import me.wolfyscript.customcrafting.recipes.conditions.Condition;
-import me.wolfyscript.customcrafting.recipes.conditions.Conditions;
 import me.wolfyscript.customcrafting.recipes.data.CraftingData;
-import me.wolfyscript.customcrafting.recipes.data.IngredientData;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
-import me.wolfyscript.customcrafting.recipes.items.Result;
 import me.wolfyscript.customcrafting.recipes.settings.CraftingRecipeSettings;
 import me.wolfyscript.customcrafting.utils.CraftManager;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
-import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
 import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
 import me.wolfyscript.utilities.api.nms.network.MCByteBuf;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -73,6 +62,7 @@ public abstract class CraftingRecipe<C extends CraftingRecipe<C, S>, S extends C
 
     protected static final String INGREDIENTS_KEY = "ingredients";
 
+    @DependencySource
     protected List<Ingredient> ingredients;
 
     protected final int maxGridDimension;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShaped.java
@@ -22,10 +22,10 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.settings.EliteRecipeSettings;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,10 +35,10 @@ import me.wolfyscript.utilities.util.NamespacedKey;
 public class CraftingRecipeEliteShaped extends AbstractRecipeShaped<CraftingRecipeEliteShaped, EliteRecipeSettings> {
 
     static {
-        final Validator<CraftingRecipeEliteShaped> VALIDATOR = ValidatorBuilder.<CraftingRecipeEliteShaped>object(RecipeType.ELITE_CRAFTING_SHAPED.getNamespacedKey()).use(AbstractRecipeShaped.validator())
+        final Verifier<CraftingRecipeEliteShaped> VERIFIER = VerifierBuilder.<CraftingRecipeEliteShaped>object(RecipeType.ELITE_CRAFTING_SHAPED.getNamespacedKey(), AbstractRecipeShaped.validator())
                 .name(container -> "Shaped Elite Crafting Recipe" + container.value().map(customRecipeSmithing -> " [" + customRecipeSmithing.getNamespacedKey() + "]").orElse(""))
                 .build();
-        CustomCrafting.inst().getRegistries().getValidators().register(VALIDATOR);
+        CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
     public CraftingRecipeEliteShaped(NamespacedKey namespacedKey, JsonNode node) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeEliteShapeless.java
@@ -22,10 +22,10 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.settings.EliteRecipeSettings;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
@@ -35,10 +35,10 @@ import me.wolfyscript.utilities.util.NamespacedKey;
 public class CraftingRecipeEliteShapeless extends AbstractRecipeShapeless<CraftingRecipeEliteShapeless, EliteRecipeSettings> {
 
     static {
-        final Validator<CraftingRecipeEliteShapeless> VALIDATOR = ValidatorBuilder.<CraftingRecipeEliteShapeless>object(RecipeType.ELITE_CRAFTING_SHAPELESS.getNamespacedKey()).use(AbstractRecipeShapeless.validator())
+        final Verifier<CraftingRecipeEliteShapeless> VERIFIER = VerifierBuilder.<CraftingRecipeEliteShapeless>object(RecipeType.ELITE_CRAFTING_SHAPELESS.getNamespacedKey(), AbstractRecipeShapeless.validator())
                 .name(container -> "Shapeless Elite Crafting Recipe" + container.value().map(customRecipeSmithing -> " [" + customRecipeSmithing.getNamespacedKey() + "]").orElse(""))
                 .build();
-        CustomCrafting.inst().getRegistries().getValidators().register(VALIDATOR);
+        CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
     public CraftingRecipeEliteShapeless(NamespacedKey namespacedKey, JsonNode node) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShaped.java
@@ -25,13 +25,12 @@ package me.wolfyscript.customcrafting.recipes;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
 import me.wolfyscript.customcrafting.recipes.settings.AdvancedRecipeSettings;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
@@ -45,10 +44,10 @@ import org.bukkit.inventory.RecipeChoice;
 public class CraftingRecipeShaped extends AbstractRecipeShaped<CraftingRecipeShaped, AdvancedRecipeSettings> implements ICustomVanillaRecipe<org.bukkit.inventory.ShapedRecipe> {
 
     static {
-        final Validator<CraftingRecipeShaped> VALIDATOR = ValidatorBuilder.<CraftingRecipeShaped>object(RecipeType.CRAFTING_SHAPED.getNamespacedKey()).use(AbstractRecipeShaped.validator())
+        final Verifier<CraftingRecipeShaped> VERIFIER = VerifierBuilder.<CraftingRecipeShaped>object(RecipeType.CRAFTING_SHAPED.getNamespacedKey(), AbstractRecipeShaped.validator())
                 .name(container -> "Shaped Crafting Recipe" + container.value().map(customRecipeSmithing -> " [" + customRecipeSmithing.getNamespacedKey() + "]").orElse(""))
                 .build();
-        CustomCrafting.inst().getRegistries().getValidators().register(VALIDATOR);
+        CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
     @Deprecated

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipeShapeless.java
@@ -25,18 +25,16 @@ package me.wolfyscript.customcrafting.recipes;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
 import me.wolfyscript.customcrafting.recipes.settings.AdvancedRecipeSettings;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
-import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -46,10 +44,10 @@ import org.bukkit.inventory.RecipeChoice;
 public class CraftingRecipeShapeless extends AbstractRecipeShapeless<CraftingRecipeShapeless, AdvancedRecipeSettings> implements ICustomVanillaRecipe<org.bukkit.inventory.ShapelessRecipe> {
 
     static {
-        final Validator<CraftingRecipeShapeless> VALIDATOR = ValidatorBuilder.<CraftingRecipeShapeless>object(RecipeType.CRAFTING_SHAPELESS.getNamespacedKey()).use(AbstractRecipeShapeless.validator())
+        final Verifier<CraftingRecipeShapeless> VERIFIER = VerifierBuilder.<CraftingRecipeShapeless>object(RecipeType.CRAFTING_SHAPELESS.getNamespacedKey(), AbstractRecipeShapeless.validator())
                 .name(container -> "Shapeless Crafting Recipe" + container.value().map(customRecipeSmithing -> " [" + customRecipeSmithing.getNamespacedKey() + "]").orElse(""))
                 .build();
-        CustomCrafting.inst().getRegistries().getValidators().register(VALIDATOR);
+        CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
     public CraftingRecipeShapeless(NamespacedKey namespacedKey, JsonNode node) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipe.java
@@ -23,8 +23,8 @@
 package me.wolfyscript.customcrafting.recipes;
 
 import com.google.common.base.Preconditions;
-import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
+import com.wolfyscript.utilities.dependency.DependencySource;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.handlers.ResourceLoader;
@@ -60,16 +60,13 @@ import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
 import me.wolfyscript.utilities.api.nms.network.MCByteBuf;
 import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -112,6 +109,7 @@ public abstract class CustomRecipe<C extends CustomRecipe<C>> implements Keyed, 
     protected RecipePriority priority;
     protected Conditions conditions;
     protected String group;
+    @DependencySource
     protected Result result;
 
     /**

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
@@ -101,12 +101,15 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
     private boolean blockRename;
     private boolean blockEnchant;
 
+    @DependencySource
     private RepairTask repairTask;
     private int repairCost;
     private boolean applyRepairCost;
     private RepairCostMode repairCostMode;
 
+    @DependencySource
     private Ingredient base;
+    @DependencySource
     private Ingredient addition;
 
     public CustomRecipeAnvil(NamespacedKey namespacedKey, JsonNode node) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeAnvil.java
@@ -24,9 +24,9 @@ package me.wolfyscript.customcrafting.recipes;
 
 import com.google.common.base.Preconditions;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
-import com.wolfyscript.utilities.validator.ValidationContainer;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
+import com.wolfyscript.utilities.dependency.DependencySource;
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
@@ -39,15 +39,10 @@ import me.wolfyscript.customcrafting.recipes.anvil.RepairTaskResult;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
 import me.wolfyscript.customcrafting.recipes.items.Result;
 import me.wolfyscript.customcrafting.utils.ItemLoader;
-import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
-import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
-import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnore;
-import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
+import me.wolfyscript.lib.com.fasterxml.jackson.annotation.*;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
-import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
@@ -67,32 +62,39 @@ import java.util.List;
 public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
 
     static {
-        final Validator<CustomRecipeAnvil> VALIDATOR = ValidatorBuilder.<CustomRecipeAnvil>object(RecipeType.ANVIL.getNamespacedKey()).def()
+        final Verifier<CustomRecipeAnvil> VERIFIER = VerifierBuilder.<CustomRecipeAnvil>object(RecipeType.ANVIL.getNamespacedKey())
                 .name(container -> "Anvil Recipe" + container.value().map(recipe -> " [" + recipe.getNamespacedKey() + "]").orElse(""))
-                .object(recipe -> recipe, i -> i.def().name(c -> "Ingredients")
-                        .object(recipe -> recipe.base, initStep -> initStep.use(Ingredient.VALIDATOR).name(c -> "Base").optional())
-                        .object(recipe -> recipe.addition, initStep -> initStep.use(Ingredient.VALIDATOR).name(c -> "Addition").optional())
+                .object(recipe -> recipe, builder -> builder
+                        .name(c -> "Ingredients")
+                        .object(recipe -> recipe.base, Ingredient.VERIFIER, override -> override.name(c -> "Base").optional())
+                        .object(recipe -> recipe.addition, Ingredient.VERIFIER, override -> override.name(c -> "Addition").optional())
                         .require(1)
                 )
-                .object(recipe -> recipe.repairTask, initStep -> initStep.def().validate(taskValidationContainer -> {
-                    if (taskValidationContainer.value().isEmpty())
-                        return taskValidationContainer.update().type(ValidationContainer.ResultType.INVALID);
-                    RepairTask repairTask = taskValidationContainer.value().get();
+                .object(recipe -> recipe.repairTask, builder -> builder
+                        .validate(verifierContainer -> {
+                            if (verifierContainer.value().isEmpty()) {
+                                return verifierContainer.update().invalid();
+                            }
+                            RepairTask repairTask = verifierContainer.value().get();
 
-                    if (repairTask instanceof RepairTaskResult repairTaskResult) {
-                        var value = Result.VALIDATOR.validate(repairTaskResult.getResult());
-                        return taskValidationContainer.update().type(value.type());
-                    }
-                    return taskValidationContainer.update().type(ValidationContainer.ResultType.VALID);
-                }))
-                .object(recipe -> recipe.repairCost, initStep -> initStep.def().name(c -> "Repair Cost").validate(repairCostContainer -> {
-                    if (repairCostContainer.value().map(integer -> integer > 0).orElse(false)) {
-                        return repairCostContainer.update().type(ValidationContainer.ResultType.VALID);
-                    }
-                    return repairCostContainer.update().type(ValidationContainer.ResultType.INVALID).fault("Must be greater than 0");
-                }))
+                            if (repairTask instanceof RepairTaskResult repairTaskResult) {
+                                var value = Result.VERIFIER.validate(repairTaskResult.getResult());
+                                return verifierContainer.update().type(value.type());
+                            }
+                            return verifierContainer.update().valid();
+                        })
+                )
+                .object(recipe -> recipe.repairCost, builder -> builder
+                        .name(c -> "Repair Cost")
+                        .validate(repairCostContainer -> {
+                            if (repairCostContainer.value().map(repairCost -> repairCost > 0).orElse(false)) {
+                                return repairCostContainer.update().valid();
+                            }
+                            return repairCostContainer.update().invalid().fault("Must be greater than 0");
+                        })
+                )
                 .build();
-        CustomCrafting.inst().getRegistries().getValidators().register(VALIDATOR);
+        CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
     private boolean blockRepair;
@@ -359,7 +361,8 @@ public class CustomRecipeAnvil extends CustomRecipe<CustomRecipeAnvil> {
         switch (getRepairTask().getMode()) {
             case RESULT -> resultBtn.setVariants(guiHandler, getResult());
             case DURABILITY -> resultBtn.setVariants(guiHandler, inputLeft);
-            case NONE -> resultBtn.setVariants(guiHandler, Collections.singletonList(StackReference.of(new ItemStack(Material.AIR))));
+            case NONE ->
+                    resultBtn.setVariants(guiHandler, Collections.singletonList(StackReference.of(new ItemStack(Material.AIR))));
         }
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBlasting.java
@@ -22,9 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,10 +37,10 @@ import org.bukkit.inventory.BlastingRecipe;
 public class CustomRecipeBlasting extends CustomRecipeCooking<CustomRecipeBlasting, BlastingRecipe> {
 
     static {
-        final Validator<CustomRecipeBlasting> VALIDATOR = ValidatorBuilder.<CustomRecipeBlasting>object(RecipeType.BLAST_FURNACE.getNamespacedKey()).use(CustomRecipeCooking.validator())
+        final Verifier<CustomRecipeBlasting> VERIFIER = VerifierBuilder.<CustomRecipeBlasting>object(RecipeType.BLAST_FURNACE.getNamespacedKey(), CustomRecipeCooking.validator())
                 .name(container -> "Blasting Recipe" + container.value().map(customRecipeSmithing -> " [" + customRecipeSmithing.getNamespacedKey() + "]").orElse(""))
                 .build();
-        CustomCrafting.inst().getRegistries().getValidators().register(VALIDATOR);
+        CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
     public CustomRecipeBlasting(NamespacedKey namespacedKey, JsonNode node) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBrewing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeBrewing.java
@@ -24,6 +24,7 @@ package me.wolfyscript.customcrafting.recipes;
 
 import com.google.common.collect.Streams;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
+import com.wolfyscript.utilities.dependency.DependencySource;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
@@ -44,7 +45,6 @@ import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.type.TypeReference;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
-import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
@@ -74,7 +74,9 @@ public class CustomRecipeBrewing extends CustomRecipe<CustomRecipeBrewing> {
 
     private static final StackReference placeHolderPotion = StackReference.of(new ItemBuilder(Material.POTION).setDisplayName(ChatColor.convert("&6&lAny kind of potion!")).create());
 
+    @DependencySource
     Ingredient allowedItems; //The CustomItems that can be used. Needs to be a potion of course.
+    @DependencySource
     private Ingredient ingredients; //The top ingredient of the recipe. Always required.
     private int fuelCost; //The fuel cost of recipe
     private int brewTime; //The brew time in ticks

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCampfire.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCampfire.java
@@ -22,9 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,10 +38,10 @@ import org.bukkit.inventory.RecipeChoice;
 public class CustomRecipeCampfire extends CustomRecipeCooking<CustomRecipeCampfire, CampfireRecipe> {
 
     static {
-        final Validator<CustomRecipeCampfire> VALIDATOR = ValidatorBuilder.<CustomRecipeCampfire>object(RecipeType.CAMPFIRE.getNamespacedKey()).use(CustomRecipeCooking.validator())
+        final Verifier<CustomRecipeCampfire> VERIFIER = VerifierBuilder.<CustomRecipeCampfire>object(RecipeType.CAMPFIRE.getNamespacedKey(), CustomRecipeCooking.validator())
                 .name(container -> "Campfire Recipe" + container.value().map(customRecipeSmithing -> " [" + customRecipeSmithing.getNamespacedKey() + "]").orElse(""))
                 .build();
-        CustomCrafting.inst().getRegistries().getValidators().register(VALIDATOR);
+        CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
     public CustomRecipeCampfire(NamespacedKey namespacedKey, JsonNode node) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCauldron.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
+import com.wolfyscript.utilities.dependency.DependencySource;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.data.CCPlayerData;
@@ -54,7 +55,6 @@ import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonSetter;
 import me.wolfyscript.lib.com.fasterxml.jackson.core.JsonGenerator;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.lib.com.fasterxml.jackson.databind.SerializerProvider;
-import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.api.inventory.gui.GuiCluster;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.api.inventory.gui.GuiUpdate;
@@ -70,6 +70,7 @@ public class CustomRecipeCauldron extends CustomRecipe<CustomRecipeCauldron> {
 
     private int cookingTime;
     private int xp;
+    @DependencySource
     private Deque<Ingredient> ingredients;
     private Result[] additionalResults;
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
@@ -26,6 +26,9 @@ import com.google.common.base.Preconditions;
 
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackIdentifier;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
+import com.wolfyscript.utilities.dependency.DependencySource;
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.data.CCPlayerData;
@@ -34,8 +37,6 @@ import me.wolfyscript.customcrafting.gui.recipebook.ClusterRecipeBook;
 import me.wolfyscript.customcrafting.recipes.conditions.Condition;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
 import me.wolfyscript.customcrafting.recipes.items.Result;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
 import me.wolfyscript.customcrafting.utils.ItemLoader;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.customcrafting.utils.PlayerUtil;
@@ -58,10 +59,10 @@ import java.util.List;
 
 public abstract class CustomRecipeCooking<C extends CustomRecipeCooking<C, T>, T extends CookingRecipe<?>> extends CustomRecipe<C> implements ICustomVanillaRecipe<T> {
 
-    protected static <RT extends CustomRecipeCooking<?,?>> Validator<RT> validator() {
-        return ValidatorBuilder.<RT>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "abstract_cooking_recipe")).def()
-                .object(recipe -> recipe.result, init -> init.use(Result.VALIDATOR))
-                .object(recipe -> recipe.getSource(), init -> init.use(Ingredient.VALIDATOR))
+    protected static <RT extends CustomRecipeCooking<?,?>> Verifier<RT> validator() {
+        return VerifierBuilder.<RT>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "abstract_cooking_recipe"))
+                .object(recipe -> recipe.result, Result.VERIFIER)
+                .object(recipe -> recipe.getSource(), Ingredient.VERIFIER)
                 .build();
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeCooking.java
@@ -66,6 +66,7 @@ public abstract class CustomRecipeCooking<C extends CustomRecipeCooking<C, T>, T
                 .build();
     }
 
+    @DependencySource
     private Ingredient source;
     private float exp;
     private int cookingTime;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeFurnace.java
@@ -22,9 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,11 +37,10 @@ import org.bukkit.inventory.FurnaceRecipe;
 public class CustomRecipeFurnace extends CustomRecipeCooking<CustomRecipeFurnace, FurnaceRecipe> {
 
     static {
-        final Validator<CustomRecipeFurnace> VALIDATOR = ValidatorBuilder.<CustomRecipeFurnace>object(RecipeType.FURNACE.getNamespacedKey())
-                .use(CustomRecipeCooking.validator())
+        final Verifier<CustomRecipeFurnace> VERIFIER = VerifierBuilder.<CustomRecipeFurnace>object(RecipeType.FURNACE.getNamespacedKey(), CustomRecipeCooking.validator())
                 .name(container -> "Furnace Recipe" + container.value().map(customRecipeSmithing -> " [" + customRecipeSmithing.getNamespacedKey() + "]").orElse(""))
                 .build();
-        CustomCrafting.inst().getRegistries().getValidators().register(VALIDATOR);
+        CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
     public CustomRecipeFurnace(NamespacedKey namespacedKey, JsonNode node) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeGrindstone.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeGrindstone.java
@@ -65,7 +65,9 @@ public class CustomRecipeGrindstone extends CustomRecipe<CustomRecipeGrindstone>
         CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
+    @DependencySource
     private Ingredient inputTop;
+    @DependencySource
     private Ingredient inputBottom;
     private int xp;
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeGrindstone.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeGrindstone.java
@@ -23,8 +23,9 @@
 package me.wolfyscript.customcrafting.recipes;
 
 import com.google.common.base.Preconditions;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
+import com.wolfyscript.utilities.dependency.DependencySource;
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
@@ -52,16 +53,16 @@ import java.io.IOException;
 public class CustomRecipeGrindstone extends CustomRecipe<CustomRecipeGrindstone> {
 
     static {
-        final Validator<CustomRecipeGrindstone> VALIDATOR = ValidatorBuilder.<CustomRecipeGrindstone>object(RecipeType.GRINDSTONE.getNamespacedKey()).def()
+        final Verifier<CustomRecipeGrindstone> VERIFIER = VerifierBuilder.<CustomRecipeGrindstone>object(RecipeType.GRINDSTONE.getNamespacedKey())
                 .name(container -> "Grindstone Recipe" + container.value().map(recipe -> " [" + recipe.getNamespacedKey() + "]").orElse(""))
-                .object(recipe -> recipe, i -> i.def().name(c -> "Ingredients")
-                        .object(recipe -> recipe.inputTop, initStep -> initStep.use(Ingredient.VALIDATOR).name(c -> "Top Ingredient").optional())
-                        .object(recipe -> recipe.inputBottom, initStep -> initStep.use(Ingredient.VALIDATOR).name(c -> "Bottom Ingredient").optional())
+                .object(recipe -> recipe, i -> i.name(c -> "Ingredients")
+                        .object(recipe -> recipe.inputTop, Ingredient.VERIFIER, initStep -> initStep.name(c -> "Top Ingredient").optional())
+                        .object(recipe -> recipe.inputBottom, Ingredient.VERIFIER, initStep -> initStep.name(c -> "Bottom Ingredient").optional())
                         .require(1)
                 )
-                .object(recipe -> recipe.result, initStep -> initStep.use(Result.VALIDATOR))
+                .object(recipe -> recipe.result, Result.VERIFIER)
                 .build();
-        CustomCrafting.inst().getRegistries().getValidators().register(VALIDATOR);
+        CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
     private Ingredient inputTop;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
@@ -108,8 +108,11 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> imp
     public static final int BASE_SLOT = IS_1_20 ? 1 : 0;
     public static final int ADDITION_SLOT = IS_1_20 ? 2 : 1;
 
+    @DependencySource
     private Ingredient template;
+    @DependencySource
     private Ingredient base;
+    @DependencySource
     private Ingredient addition;
 
     private boolean preserveEnchants;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
@@ -22,9 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
-import com.wolfyscript.utilities.validator.ValidationContainer;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
+import com.wolfyscript.utilities.dependency.DependencySource;
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.recipebook.ButtonContainerIngredient;
@@ -64,38 +64,40 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> implements ICustomVanillaRecipe<SmithingRecipe> {
 
     static {
-        final Validator<CustomRecipeSmithing> VALIDATOR = ValidatorBuilder.<CustomRecipeSmithing>object(RecipeType.SMITHING.getNamespacedKey()).def()
-                .name(container -> "Smithing Recipe" + container.value().map(customRecipeSmithing -> " [" + customRecipeSmithing.getNamespacedKey() + "]").orElse(""))
-                .object(recipe -> recipe.result, initStep -> initStep.use(Result.VALIDATOR).name(container -> "Result"))
-                .object(Function.identity(), init -> init.def()
+        final Verifier<CustomRecipeSmithing> VERIFIER = VerifierBuilder.<CustomRecipeSmithing>object(RecipeType.SMITHING.getNamespacedKey())
+                .name(container -> "Smithing Recipe" + container.value().map(recipe -> " [" + recipe.getNamespacedKey() + "]").orElse(""))
+                .object(recipe -> recipe.result, Result.VERIFIER)
+                .object(Function.identity(), builder -> builder
                         .name(container -> "Ingredients")
-                        .object(i -> i.template, step -> step.def().name(container -> "Template")
+                        .object(i -> i.template, Ingredient.VERIFIER, override -> override
+                                .name("Template")
                                 .optional()
-                                .object(Function.identity(), iInit -> iInit.use(Ingredient.VALIDATOR)))
-                        .object(i -> i.base, step -> step.def().name(container -> "Base")
+                        )
+                        .object(i -> i.base, Ingredient.VERIFIER, step -> step
+                                .name("Base")
                                 .optional()
-                                .object(Function.identity(), iInit -> iInit.use(Ingredient.VALIDATOR)))
-                        .object(i -> i.addition, step -> step.def().name(container -> "Addition")
+                        )
+                        .object(i -> i.addition, Ingredient.VERIFIER, step -> step
+                                .name("Addition")
                                 .optional()
-                                .object(Function.identity(), iInit -> iInit.use(Ingredient.VALIDATOR)))
-                        .require(1) // Make sure at least one ingredient is valid/pending
+                        )
+                        .require(1) // Make sure at least one ingredient is valid
                         .validate(container -> {
-                            if (container.type() == ValidationContainer.ResultType.INVALID) {
-                                return container.update().fault("At least one ingredient (Template, Base, or Addition) must be available!");
-                            }
-                            if (container.type() == ValidationContainer.ResultType.PENDING) {
-                                return container.update().fault("At least one ingredient is still pending!");
+                            if (!container.type().isValid()) {
+                                return container.update().fault("At least one ingredient (Template, Base, or Addition) must be valid!");
                             }
                             return container.update();
-                        }))
+                        })
+                )
                 .build();
-        CustomCrafting.inst().getRegistries().getValidators().register(VALIDATOR);
+        CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
     private static final String KEY_BASE = "base";

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmoking.java
@@ -22,9 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes;
 
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JacksonInject;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,10 +37,10 @@ import org.bukkit.inventory.SmokingRecipe;
 public class CustomRecipeSmoking extends CustomRecipeCooking<CustomRecipeSmoking, SmokingRecipe> {
 
     static {
-        final Validator<CustomRecipeSmoking> VALIDATOR = ValidatorBuilder.<CustomRecipeSmoking>object(RecipeType.SMOKER.getNamespacedKey()).use(CustomRecipeCooking.validator())
+        final Verifier<CustomRecipeSmoking> VERIFIER = VerifierBuilder.<CustomRecipeSmoking>object(RecipeType.SMOKER.getNamespacedKey(), CustomRecipeCooking.validator())
                 .name(container -> "Smoking Recipe" + container.value().map(customRecipeSmithing -> " [" + customRecipeSmithing.getNamespacedKey() + "]").orElse(""))
                 .build();
-        CustomCrafting.inst().getRegistries().getValidators().register(VALIDATOR);
+        CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
     public CustomRecipeSmoking(NamespacedKey namespacedKey, JsonNode node) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
@@ -67,6 +67,7 @@ public class CustomRecipeStonecutter extends CustomRecipe<CustomRecipeStonecutte
         CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
+    @DependencySource
     private Ingredient source;
 
     public CustomRecipeStonecutter(NamespacedKey namespacedKey, JsonNode node) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeStonecutter.java
@@ -23,9 +23,9 @@
 package me.wolfyscript.customcrafting.recipes;
 
 import com.google.common.base.Preconditions;
-import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
+import com.wolfyscript.utilities.dependency.DependencySource;
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.gui.main_gui.ClusterMain;
@@ -59,12 +59,12 @@ public class CustomRecipeStonecutter extends CustomRecipe<CustomRecipeStonecutte
     private static final String KEY_SOURCE = "source";
 
     static {
-        final Validator<CustomRecipeStonecutter> VALIDATOR = ValidatorBuilder.<CustomRecipeStonecutter>object(RecipeType.STONECUTTER.getNamespacedKey()).def()
+        final Verifier<CustomRecipeStonecutter> VERIFIER = VerifierBuilder.<CustomRecipeStonecutter>object(RecipeType.STONECUTTER.getNamespacedKey())
                 .name(container -> "Stonecutter Recipe" + container.value().map(customRecipeSmithing -> " [" + customRecipeSmithing.getNamespacedKey() + "]").orElse(""))
-                .object(recipe -> recipe.source, initStep -> initStep.use(Ingredient.VALIDATOR))
-                .object(recipe -> recipe.result, initStep -> initStep.use(Result.VALIDATOR))
+                .object(recipe -> recipe.source, Ingredient.VERIFIER)
+                .object(recipe -> recipe.result, Result.VERIFIER)
                 .build();
-        CustomCrafting.inst().getRegistries().getValidators().register(VALIDATOR);
+        CustomCrafting.inst().getRegistries().getVerifiers().register(VERIFIER);
     }
 
     private Ingredient source;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/anvil/RepairTaskResult.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/anvil/RepairTaskResult.java
@@ -24,11 +24,11 @@ package me.wolfyscript.customcrafting.recipes.anvil;
 
 import com.google.common.base.Preconditions;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
+import com.wolfyscript.utilities.dependency.DependencySource;
 import me.wolfyscript.customcrafting.recipes.CustomRecipeAnvil;
 import me.wolfyscript.customcrafting.recipes.data.AnvilData;
 import me.wolfyscript.customcrafting.recipes.items.Result;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
-import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -41,6 +41,7 @@ public class RepairTaskResult extends RepairTask {
 
     public static final NamespacedKey KEY = new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "result");
 
+    @DependencySource
     private Result result;
 
     public RepairTaskResult() {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/Ingredient.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/Ingredient.java
@@ -23,10 +23,9 @@
 package me.wolfyscript.customcrafting.recipes.items;
 
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
-import com.wolfyscript.utilities.validator.ValidationContainer;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
-import io.r2dbc.spi.Parameter;
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
+import com.wolfyscript.utilities.verification.VerifierContainer;
 import me.wolfyscript.customcrafting.utils.NamespacedKeyUtils;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonCreator;
 import me.wolfyscript.lib.com.fasterxml.jackson.annotation.JsonProperty;
@@ -40,19 +39,21 @@ import java.util.*;
 
 public class Ingredient extends RecipeItemStack {
 
-    public static final Validator<Ingredient> VALIDATOR;
-    public static final Validator<Map.Entry<Character, Ingredient>> ENTRY_VALIDATOR;
+    public static final Verifier<Ingredient> VERIFIER;
+    public static final Verifier<Map.Entry<Character, Ingredient>> ENTRY_VERIFIER;
 
     static {
-        VALIDATOR = ValidatorBuilder.<Ingredient>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "recipe/ingredient")).use(RecipeItemStack.validatorFor()).build();
-        ENTRY_VALIDATOR = ValidatorBuilder.<Map.Entry<Character, Ingredient>>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "recipe/ingredient_entry")).def()
+        VERIFIER = VerifierBuilder.<Ingredient>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "recipe/ingredient"), RecipeItemStack.validatorFor()).build();
+
+        ENTRY_VERIFIER = VerifierBuilder.<Map.Entry<Character, Ingredient>>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "recipe/ingredient_entry"))
                 .name(container -> container.value().map(entry -> "Ingredient [" + entry.getKey() + "]").orElse("Ingredient [Unknown]"))
                 .validate(entryContainer -> entryContainer.value()
                         .map(entry -> {
-                            ValidationContainer<Ingredient> result = VALIDATOR.validate(entry.getValue());
-                            return entryContainer.update().copyFrom(result.update());
+                            VerifierContainer<Ingredient> result = VERIFIER.validate(entry.getValue());
+                            return entryContainer.update().type(result.type());
                         })
-                        .orElseGet(() -> entryContainer.update().type(ValidationContainer.ResultType.INVALID))).build();
+                        .orElseGet(() -> entryContainer.update().invalid())
+                ).build();
     }
 
     private boolean replaceWithRemains = true;

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/RecipeItemStack.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/RecipeItemStack.java
@@ -112,6 +112,7 @@ public abstract class RecipeItemStack {
     @JsonIgnore
     protected final List<CustomItem> oldChoices;
     protected final List<StackReference> choices;
+    @DependencySource
     private List<StackReference> items;
     private Set<NamespacedKey> tags;
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/Result.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/Result.java
@@ -54,9 +54,7 @@ import java.util.stream.Collectors;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Result extends RecipeItemStack {
 
-    public static final Verifier<Result> VERIFIER = VerifierBuilder.<Result>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "recipe/result"))
-            .object(Function.identity(), RecipeItemStack.validatorFor())
-            .build();
+    public static final Verifier<Result> VERIFIER = VerifierBuilder.<Result>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "recipe/result"), RecipeItemStack.validatorFor()).build();
 
     @JsonIgnore
     private final Map<UUID, CustomItem> cachedItems = new HashMap<>();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/items/Result.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/items/Result.java
@@ -22,11 +22,9 @@
 
 package me.wolfyscript.customcrafting.recipes.items;
 
-import com.wolfyscript.utilities.bukkit.world.items.reference.ItemCreateContext;
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
-import com.wolfyscript.utilities.validator.ValidationContainer;
-import com.wolfyscript.utilities.validator.Validator;
-import com.wolfyscript.utilities.validator.ValidatorBuilder;
+import com.wolfyscript.utilities.verification.Verifier;
+import com.wolfyscript.utilities.verification.VerifierBuilder;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.recipes.data.RecipeData;
 import me.wolfyscript.customcrafting.recipes.items.extension.ExecutionType;
@@ -49,17 +47,16 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Result extends RecipeItemStack {
 
-    public static final Validator<Result> VALIDATOR;
-
-    static {
-        VALIDATOR = ValidatorBuilder.<Result>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "recipe/result")).use(RecipeItemStack.validatorFor()).build();
-    }
+    public static final Verifier<Result> VERIFIER = VerifierBuilder.<Result>object(new NamespacedKey(NamespacedKeyUtils.NAMESPACE, "recipe/result"))
+            .object(Function.identity(), RecipeItemStack.validatorFor())
+            .build();
 
     @JsonIgnore
     private final Map<UUID, CustomItem> cachedItems = new HashMap<>();

--- a/src/main/java/me/wolfyscript/customcrafting/registry/CCRegistries.java
+++ b/src/main/java/me/wolfyscript/customcrafting/registry/CCRegistries.java
@@ -22,13 +22,13 @@
 
 package me.wolfyscript.customcrafting.registry;
 
+import com.wolfyscript.utilities.verification.Verifier;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.gui.item_creator.tabs.ItemCreatorTab;
 import me.wolfyscript.customcrafting.recipes.RecipeType;
 import me.wolfyscript.customcrafting.recipes.anvil.RepairTask;
 import me.wolfyscript.customcrafting.recipes.items.extension.ResultExtension;
 import me.wolfyscript.customcrafting.recipes.items.target.MergeAdapter;
-import com.wolfyscript.utilities.validator.Validator;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.registry.*;
 import me.wolfyscript.utilities.util.NamespacedKey;
@@ -38,7 +38,7 @@ public class CCRegistries {
     private final RegistryRecipes recipes;
     private final Registry<ItemCreatorTab> itemCreatorTabs;
     private final Registry<RecipeType<?>> recipeTypes;
-    private final Registry<Validator<?>> validators;
+    private final Registry<Verifier<?>> validators;
     private final TypeRegistryRecipeConditions recipeConditions;
     private final TypeRegistry<MergeAdapter> recipeMergeAdapters;
     private final TypeRegistry<ResultExtension> recipeResultExtensions;
@@ -84,7 +84,7 @@ public class CCRegistries {
         return recipes;
     }
 
-    public Registry<Validator<?>> getValidators() {
+    public Registry<Verifier<?>> getVerifiers() {
         return validators;
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/ChatUtils.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/ChatUtils.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.logging.Level;
+
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.data.CCCache;
 import me.wolfyscript.customcrafting.utils.chat.CollectionEditor;
@@ -298,13 +300,17 @@ public class ChatUtils {
     }
 
     public static void sendRecipeItemLoadingError(String prefix, String namespace, String key, Exception ex) {
-        api.getConsole().warn(prefix + "[Error] Invalid Recipe: \"" + namespace + ":" + key + "\": " + (ex.getMessage() != null ? ex.getMessage() : ""));
+        sendRecipeItemLoadingError(prefix, namespace, key, ex, CustomCrafting.inst().getConfigHandler().getConfig().getDataSettings().printStackTrace());
+    }
+
+    public static void sendRecipeItemLoadingError(String prefix, String namespace, String key, Exception ex, boolean stacktrace) {
+        CustomCrafting.inst().getLogger().warning(prefix + "[Error] Invalid Recipe: \"" + namespace + ":" + key + "\": " + (ex.getMessage() != null ? ex.getMessage() : ""));
         if (ex.getCause() != null) {
-            api.getConsole().warn(prefix + "[Error]   Caused by: " + ex.getCause().getMessage());
+            CustomCrafting.inst().getLogger().warning(prefix + "[Error]   Caused by: " + ex.getCause().getMessage());
         }
-        if (CustomCrafting.inst().getConfigHandler().getConfig().getDataSettings().printStackTrace()) {
-            api.getConsole().warn("------------------[StackTrace]-------------------");
-            ex.printStackTrace();
+        if (stacktrace) {
+            CustomCrafting.inst().getLogger().log(Level.WARNING, "------------------[StackTrace]-------------------");
+            CustomCrafting.inst().getLogger().log(Level.WARNING, "", ex);
         }
     }
 }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/ItemLoader.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/ItemLoader.java
@@ -27,7 +27,8 @@ import java.util.List;
 import java.util.Set;
 
 import com.wolfyscript.utilities.bukkit.world.items.reference.StackReference;
-import com.wolfyscript.utilities.bukkit.world.items.reference.WolfyUtilsStackIdentifier;
+import com.wolfyscript.utilities.json.jackson.MissingDependencyException;
+import com.wolfyscript.utilities.json.jackson.MissingImplementationException;
 import me.wolfyscript.customcrafting.CustomCrafting;
 import me.wolfyscript.customcrafting.handlers.ResourceLoader;
 import me.wolfyscript.customcrafting.recipes.items.Ingredient;
@@ -44,7 +45,6 @@ import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReferen
 import me.wolfyscript.utilities.api.inventory.custom_items.references.VanillaRef;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.WolfyUtilitiesRef;
 import me.wolfyscript.utilities.util.NamespacedKey;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
@@ -167,11 +167,10 @@ public class ItemLoader {
                 Result desResult = null;
                 try {
                     desResult = getObjectMapper().reader(injects).readValue(node, Result.class);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                } finally {
-                    result = desResult;
+                } catch (IOException | MissingImplementationException e) {
+                    throw new RuntimeException(e);
                 }
+                result = desResult;
             }
         }
         if (result != null) {

--- a/src/main/java/me/wolfyscript/customcrafting/utils/chat/CollectionView.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/chat/CollectionView.java
@@ -1,0 +1,164 @@
+/*
+ *       ____ _  _ ____ ___ ____ _  _ ____ ____ ____ ____ ___ _ _  _ ____
+ *       |    |  | [__   |  |  | |\/| |    |__/ |__| |___  |  | |\ | | __
+ *       |___ |__| ___]  |  |__| |  | |___ |  \ |  | |     |  | | \| |__]
+ *
+ *       CustomCrafting Recipe creation and management tool for Minecraft
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.customcrafting.utils.chat;
+
+import me.wolfyscript.lib.net.kyori.adventure.text.Component;
+import me.wolfyscript.lib.net.kyori.adventure.text.format.NamedTextColor;
+import me.wolfyscript.lib.net.kyori.adventure.text.format.TextDecoration;
+import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import me.wolfyscript.lib.net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import me.wolfyscript.utilities.api.chat.Chat;
+import org.bukkit.entity.Player;
+
+import java.util.Collection;
+import java.util.function.BiConsumer;
+
+public class CollectionView<T> {
+
+    protected final Chat chat;
+
+    private int entriesPerPage = 7;
+    private boolean prefix = false;
+
+    protected final SupplyEntryCollection<T> listSupplier;
+    protected final ParseEntryToComponent<T> toComponent;
+    protected BiConsumer<Chat, Player> sendHeader = (chat1, player) -> {
+    };
+    protected BiConsumer<Chat, Player> sendFooter = (chat1, player) -> {
+    };
+
+    public CollectionView(Chat chat, SupplyEntryCollection<T> listSupplier, ParseEntryToComponent<T> toComponent) {
+        this.listSupplier = listSupplier;
+        this.toComponent = toComponent;
+        this.chat = chat;
+    }
+
+    public CollectionView<T> prefix(boolean prefix) {
+        this.prefix = prefix;
+        return this;
+    }
+
+    public CollectionView<T> header(BiConsumer<Chat, Player> sendHeader) {
+        this.sendHeader = sendHeader;
+        return this;
+    }
+
+    public CollectionView<T> footer(BiConsumer<Chat, Player> sendFooter) {
+        this.sendFooter = sendFooter;
+        return this;
+    }
+
+    public CollectionView<T> setEntriesPerPage(int entriesPerPage) {
+        this.entriesPerPage = entriesPerPage;
+        return this;
+    }
+
+    /**
+     * Sends the default state of the chat editor to the specified player.
+     *
+     * @param player The player to send the editor to.
+     */
+    public void send(Player player) {
+        send(player, 0);
+    }
+
+    /**
+     * Sends the chat editor at the specified page.
+     *
+     * @param player The player to open the editor for.
+     * @param page   The page to open.
+     */
+    public void send(Player player, int page) {
+        sendHeader(player);
+        if (listSupplier != null) {
+            Collection<T> list = listSupplier.get(player);
+            if (!list.isEmpty()) {
+                int maxPages = list.size() / entriesPerPage + (list.size() % entriesPerPage > 0 ? 1 : 0);
+                int startPoint = page * entriesPerPage;
+                list = list.stream().skip(startPoint).limit(entriesPerPage).toList();
+                _sendEntries(player, page, startPoint, list);
+                _sendPageButtons(player, maxPages, page);
+            }
+        }
+        sendFooter.accept(chat, player);
+    }
+
+    protected void _sendPageButtons(Player player, int maxPages, int page) {
+        chat.sendMessage(player, prefix, Component.text(" ", NamedTextColor.GRAY));
+        chat.sendMessage(player, prefix, Component.text("  [ ", NamedTextColor.GRAY)
+                .append(Component.text("« ", NamedTextColor.YELLOW, TextDecoration.BOLD).clickEvent(chat.executable(player, true, (wolfyUtilities, player1) -> {
+                    if (page - 1 >= 0) {
+                        send(player1, page - 1);
+                    } else {
+                        send(player1, page);
+                    }
+                })))
+                .append(chat.translated("msg.chat_editor.list_edit.pages",
+                        Placeholder.unparsed("current_page", String.valueOf(page + 1)),
+                        // Add 1 to the actual page to not show the page 0
+                        Placeholder.unparsed("pages", String.valueOf(maxPages))))
+                .append(Component.text(" »", NamedTextColor.YELLOW, TextDecoration.BOLD).clickEvent(chat.executable(player, true, (wolfyUtilities, player1) -> {
+                    Collection<T> currentList = listSupplier.get(player1);
+                    int pages = (currentList.size() / entriesPerPage) + (currentList.size() % entriesPerPage > 0 ? 1 : 0);
+                    if (page + 1 < pages) {
+                        send(player1, page + 1);
+                    } else {
+                        send(player1, page);
+                    }
+                })))
+                .append(Component.text(" ]"))
+        );
+    }
+
+    protected void sendHeader(Player player) {
+        for (int i = 0; i < 15; i++) {
+            player.sendMessage("");
+        }
+        sendHeader.accept(chat, player);
+    }
+
+    protected void _sendEntries(Player player, int page, int indexOffset, Collection<T> list) {
+        int i = indexOffset;
+        for (T listItem : list) {
+            final int finalEntryIndex = i;
+            TagResolver tagResolver = Placeholder.unparsed("list_entry", String.valueOf(finalEntryIndex + 1));
+//            chat.sendMessage(player, prefix, Component.text("│", NamedTextColor.GRAY));
+            Component modifiers = Component.text("  🛈 ", NamedTextColor.DARK_AQUA);
+            chat.sendMessage(player, prefix, modifiers.append(toComponent.parse(player, listItem).colorIfAbsent(NamedTextColor.WHITE)));
+            i++;
+        }
+    }
+
+    public interface SupplyEntryCollection<T> {
+
+        Collection<T> get(Player player);
+
+    }
+
+    public interface ParseEntryToComponent<T> {
+
+        Component parse(Player player, T element);
+
+    }
+
+}


### PR DESCRIPTION
This makes a couple of changes to the whole loading process of custom items and recipes.

If a recipe or custom item uses an item from another plugin, that isn't available, it will fail instantly and will not to attempt to load it any further (like it previously did).

When the plugins it depends on are available, then it makes sure the recipe or custom item is loaded once all its dependencies are available.
Only then it tries to verify the recipe and checks if it is loaded properly.

This should clear up a lot of issues regarding missing recipe ingredients, results, or loading errors.