### PR TITLE
Fix Smithing Recipes: Duplication & Empty Ingredient Issue

### DIFF
--- a/src/main/java/me/wolfyscript/customcrafting/listeners/smithing/SmithingListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/smithing/SmithingListener.java
@@ -196,28 +196,7 @@ public class SmithingListener implements Listener {
                 if (result == null) {
                     return;
                 }
-                // Thanks to Spigot not allowing empty ingredients, we need our own way of collecting the result!
-                // Otherwise, it would just cancel the click, because there is no valid recipe!
-                if (event.getClick().isShiftClick()) {
-                    if (!event.getView().getBottomInventory().addItem(result).isEmpty()) {
-                        return; // No space in inventory! To not mess with dropping items, etc. we just cancel the click
-                    }
-                } else {
-                    if (ItemUtils.isAirOrNull(event.getCursor())) {
-                        Bukkit.getScheduler().runTask(customCrafting, () -> {
-                            event.getView().setCursor(result);
-                        });
-                    } else if (event.getCursor().isSimilar(result)) {
-                        if (event.getCursor().getAmount() + result.getAmount() > event.getCursor().getMaxStackSize()) {
-                            return; // Again instead of doing weird stuff, just cancel
-                        }
-                        Bukkit.getScheduler().runTask(customCrafting, () -> {
-                            event.getView().getCursor().setAmount(event.getCursor().getAmount() + result.getAmount());
-                        });
-                    }
-                }
-
-                player.playSound(player, Sound.BLOCK_SMITHING_TABLE_USE, 1.0F, 1.0F);
+                handleInvalidRecipeClick(result, player, event);
             }
 
             smithingData.getResult().executeExtensions(inventory.getLocation() != null ? inventory.getLocation() : player.getLocation(), inventory.getLocation() != null, player);
@@ -226,6 +205,31 @@ public class SmithingListener implements Listener {
             inventory.setItem(CustomRecipeSmithing.BASE_SLOT, smithingData.base().map(reference -> reference.shrink(baseItem, 1, true, inventory, player, null)).orElse(baseItem));
             inventory.setItem(CustomRecipeSmithing.ADDITION_SLOT, smithingData.addition().map(reference -> reference.shrink(additionItem, 1, true, inventory, player, null)).orElse(additionItem));
         }
+    }
+
+    private void handleInvalidRecipeClick(ItemStack result, Player player, InventoryClickEvent event) {
+        // Thanks to Spigot not allowing empty ingredients, we need our own way of collecting the result!
+        // Otherwise, it would just cancel the click, because there is no valid recipe!
+        if (event.getClick().isShiftClick()) {
+            if (!event.getView().getBottomInventory().addItem(result).isEmpty()) {
+                return; // No space in inventory! To not mess with dropping items, etc. we just cancel the click
+            }
+        } else {
+            if (ItemUtils.isAirOrNull(event.getCursor())) {
+                Bukkit.getScheduler().runTask(customCrafting, () -> {
+                    event.getView().setCursor(result);
+                });
+            } else if (event.getCursor().isSimilar(result)) {
+                if (event.getCursor().getAmount() + result.getAmount() > event.getCursor().getMaxStackSize()) {
+                    return; // Again instead of doing weird stuff, just cancel
+                }
+                Bukkit.getScheduler().runTask(customCrafting, () -> {
+                    event.getView().getCursor().setAmount(event.getCursor().getAmount() + result.getAmount());
+                });
+            }
+        }
+
+        player.playSound(player, Sound.BLOCK_SMITHING_TABLE_USE, 1.0F, 1.0F);
     }
 
 }

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/smithing/SmithingListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/smithing/SmithingListener.java
@@ -172,26 +172,7 @@ public class SmithingListener implements Listener {
 
             if (smithingInventory.getRecipe() != null) {
                 // A recipe may be available if none of the ingredients are empty
-                if (event.getClick().isShiftClick()) {
-                    if (possible > 0) {
-                        // Pick a new stack for each result item
-                        RandomCollection<StackReference> results = smithingData.getResult().randomChoices(player);
-                        for (int i = 0; i < possible; i++) {
-                            var reference = results.next();
-                            if (reference != null) {
-                                var item = smithingData.getResult().item(smithingData, reference, player, null);
-                                if (InventoryUtils.hasInventorySpace(player, item)) {
-                                    player.getInventory().addItem(item);
-                                } else {
-                                    var loc = player.getLocation();
-                                    loc.getWorld().dropItem(loc, item);
-                                }
-                            }
-                        }
-                    }
-                    player.playSound(player, Sound.BLOCK_SMITHING_TABLE_USE, 1.0F, 1.0F);
-                    event.setCancelled(true); // Cancel the event to prevent vanilla ingredient consumption
-                }
+                handleValidRecipeClick(possible, smithingData, player, event);
             } else {
                 if (result == null) {
                     return;
@@ -204,6 +185,29 @@ public class SmithingListener implements Listener {
             smithingData.template().ifPresent(reference -> inventory.setItem(0, reference.shrink(templateItem, 1, true, inventory, player, null)));
             inventory.setItem(CustomRecipeSmithing.BASE_SLOT, smithingData.base().map(reference -> reference.shrink(baseItem, 1, true, inventory, player, null)).orElse(baseItem));
             inventory.setItem(CustomRecipeSmithing.ADDITION_SLOT, smithingData.addition().map(reference -> reference.shrink(additionItem, 1, true, inventory, player, null)).orElse(additionItem));
+        }
+    }
+
+    private void handleValidRecipeClick(int possible, SmithingData smithingData, Player player, InventoryClickEvent event) {
+        if (event.getClick().isShiftClick()) {
+            if (possible > 0) {
+                // Pick a new stack for each result item
+                RandomCollection<StackReference> results = smithingData.getResult().randomChoices(player);
+                for (int i = 0; i < possible; i++) {
+                    var reference = results.next();
+                    if (reference != null) {
+                        var item = smithingData.getResult().item(smithingData, reference, player, null);
+                        if (InventoryUtils.hasInventorySpace(player, item)) {
+                            player.getInventory().addItem(item);
+                        } else {
+                            var loc = player.getLocation();
+                            loc.getWorld().dropItem(loc, item);
+                        }
+                    }
+                }
+            }
+            player.playSound(player, Sound.BLOCK_SMITHING_TABLE_USE, 1.0F, 1.0F);
+            event.setCancelled(true); // Cancel the event to prevent vanilla ingredient consumption
         }
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/listeners/smithing/SmithingListener.java
+++ b/src/main/java/me/wolfyscript/customcrafting/listeners/smithing/SmithingListener.java
@@ -147,11 +147,10 @@ public class SmithingListener implements Listener {
         final var inventory = event.getClickedInventory();
         if (event.getSlot() == CustomRecipeSmithing.RESULT_SLOT && !ItemUtils.isAirOrNull(event.getCurrentItem())) {
             if (action == InventoryAction.PLACE_ALL || action == InventoryAction.PLACE_ONE || action == InventoryAction.PLACE_SOME || action == InventoryAction.SWAP_WITH_CURSOR) {
-                return;
+                return; // Ignore ingredient slots
             }
-            //Take out item!
             if (preCraftedRecipes.get(player.getUniqueId()) == null) {
-                //Vanilla Recipe
+                // Vanilla Recipe, so lets stop here
                 return;
             }
 
@@ -175,6 +174,7 @@ public class SmithingListener implements Listener {
                 // A recipe may be available if none of the ingredients are empty
                 if (event.getClick().isShiftClick()) {
                     if (possible > 0) {
+                        // Pick a new stack for each result item
                         RandomCollection<StackReference> results = smithingData.getResult().randomChoices(player);
                         for (int i = 0; i < possible; i++) {
                             var reference = results.next();

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CraftingRecipe.java
@@ -180,19 +180,6 @@ public abstract class CraftingRecipe<C extends CraftingRecipe<C, S>, S extends C
         return matrix;
     }
 
-    public int getAmountCraftable(CraftingData craftingData) {
-        return craftingData.getNonNullIngredients().map(value -> {
-            var item = value.customItem();
-            if (item != null) {
-                var input = value.itemStack();
-                if (input != null) {
-                    return input.getAmount() / item.getAmount();
-                }
-            }
-            return 0;
-        }).min(Comparator.comparingInt(o -> o)).orElse(0);
-    }
-
     @Override
     public void prepareMenu(GuiHandler<CCCache> guiHandler, GuiCluster<CCCache> cluster) {
         if (!ingredients.isEmpty()) {

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/CustomRecipeSmithing.java
@@ -60,10 +60,7 @@ import org.bukkit.inventory.SmithingRecipe;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -346,9 +343,17 @@ public class CustomRecipeSmithing extends CustomRecipe<CustomRecipeSmithing> imp
     }
 
     private static RecipeChoice getRecipeChoiceFor(Ingredient ingredient) {
-        if (ingredient == null || ingredient.isEmpty()) return new RecipeChoice.MaterialChoice(Material.AIR);
+        if (ingredient == null || ingredient.isEmpty()) {
+            // Need a placeholder item to bypass Spigots dumbass Air and emtpy choice check.
+            // Thanks for nothing Spigot... now this needs to be handled by the PrepareSmithingEvent!
+            // Note: Minecraft does support emtpy Ingredients for SmithingRecipes!! Just fucking Spigot doesn't (or at least not anymore for whatever reason)!
+            // Paper has a RecipeChoice.emtpy(), however that would require compilation against Java 21.
+            return new RecipeChoice.MaterialChoice(Material.BARRIER);
+        }
         List<Material> choices = ingredient.choicesStream().map(reference -> reference.referencedStack().getType()).collect(Collectors.toList());
-        if (ingredient.isAllowEmpty()) choices.add(Material.AIR);
+        if (ingredient.isAllowEmpty()) {
+            //choices.add(Material.AIR); // This no longer works due to minecraft not being able to serialize Air stacks
+        }
         return new RecipeChoice.MaterialChoice(choices);
     }
 

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/data/IRecipeData.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/data/IRecipeData.java
@@ -94,4 +94,6 @@ public interface IRecipeData<R extends CustomRecipe<?>> {
      */
     List<IngredientData> getBySlots(int[] slots);
 
+    int getPossibleResultAmount();
+
 }

--- a/src/main/java/me/wolfyscript/customcrafting/recipes/data/RecipeData.java
+++ b/src/main/java/me/wolfyscript/customcrafting/recipes/data/RecipeData.java
@@ -164,4 +164,19 @@ public abstract class RecipeData<R extends CustomRecipe<?>> implements IRecipeDa
         }
         return list;
     }
+
+    @Override
+    public int getPossibleResultAmount() {
+        return getNonNullIngredients().map(value -> {
+            var item = value.reference();
+            if (item != null) {
+                var input = value.itemStack();
+                if (input != null) {
+                    return input.getAmount() / item.amount();
+                }
+            }
+            return 0;
+        }).min(Comparator.comparingInt(o -> o)).orElse(0);
+    }
+
 }

--- a/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
+++ b/src/main/java/me/wolfyscript/customcrafting/utils/CraftManager.java
@@ -163,7 +163,7 @@ public final class CraftManager {
     private int calculateClick(Player player, InventoryClickEvent event, CraftingData craftingData, CraftingRecipe<?, ?> recipe, Result recipeResult) {
         var result = recipeResult.item(craftingData, player, null);
         var inventory = event.getClickedInventory();
-        int possible = event.isShiftClick() ? Math.min(InventoryUtils.getInventorySpace(player.getInventory(), result) / result.getAmount(), recipe.getAmountCraftable(craftingData)) : 1;
+        int possible = event.isShiftClick() ? Math.min(InventoryUtils.getInventorySpace(player.getInventory(), result) / result.getAmount(), craftingData.getPossibleResultAmount()) : 1;
         recipeResult.executeExtensions(inventory.getLocation() == null ? event.getWhoClicked().getLocation() : inventory.getLocation(), inventory.getLocation() != null, (Player) event.getWhoClicked(), possible);
         if (event.isShiftClick()) {
             if (possible > 0) {


### PR DESCRIPTION
Spigot doesn't or no longer allows Smithing Recipes to have emtpy ingredients, a workaround for this stupid API is needed to keep it functioning.
Instead of an empty ingredient, it uses a placeholder item (barrier). This requires custom result collection in the SmithingListener to handle which are now invalid recipes due to empty ingredient slots.

This also fixes a duplication issue when shift-click crafting a stackable item.