### PR TITLE
Schedule data loading for PluginIntegrations

### DIFF
--- a/spigot/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
+++ b/spigot/src/main/java/me/wolfyscript/customcrafting/handlers/DataHandler.java
@@ -145,12 +145,12 @@ public class DataHandler implements Listener {
 
     @EventHandler
     private void integrationEnable(PluginIntegrationEnableEvent event) {
-        int validatedTotal = 0;
         for (ResourceLoader loader : loaders) {
-            validatedTotal += loader.validatePending(event.getIntegration());
-        }
-        if (validatedTotal > 0) {
-            configHandler.getRecipeBookConfig().index(customCrafting);
+            loader.schedulePluginIntegration(new ScheduledPluginIntegrationTask(event.getIntegration(), (integration, amount) -> {
+                if (amount > 0) {
+                    configHandler.getRecipeBookConfig().index(customCrafting);
+                }
+            }));
         }
     }
 

--- a/spigot/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
+++ b/spigot/src/main/java/me/wolfyscript/customcrafting/handlers/LocalStorageLoader.java
@@ -202,7 +202,7 @@ public class LocalStorageLoader extends ResourceLoader {
     }
 
     @Override
-    public int validatePending(PluginIntegration pluginIntegration) {
+    protected int validatePending(PluginIntegration pluginIntegration) {
         for (CustomRecipe<?> customRecipe : recipeDependencies.keySet()) {
             Collection<Dependency> dependencies = recipeDependencies.get(customRecipe);
 

--- a/spigot/src/main/java/me/wolfyscript/customcrafting/handlers/SQLDatabaseLoader.java
+++ b/spigot/src/main/java/me/wolfyscript/customcrafting/handlers/SQLDatabaseLoader.java
@@ -88,7 +88,7 @@ public class SQLDatabaseLoader extends DatabaseLoader {
     }
 
     @Override
-    public int validatePending(PluginIntegration pluginIntegration) {
+    protected int validatePending(PluginIntegration pluginIntegration) {
         return 0;
     }
 

--- a/spigot/src/main/java/me/wolfyscript/customcrafting/handlers/ScheduledPluginIntegrationTask.java
+++ b/spigot/src/main/java/me/wolfyscript/customcrafting/handlers/ScheduledPluginIntegrationTask.java
@@ -22,50 +22,9 @@
 
 package me.wolfyscript.customcrafting.handlers;
 
-import me.wolfyscript.customcrafting.CustomCrafting;
-import me.wolfyscript.customcrafting.recipes.CustomRecipe;
-import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.compatibility.PluginIntegration;
-import me.wolfyscript.utilities.util.NamespacedKey;
 
-public class ExtensionPackLoader extends ResourceLoader {
+import java.util.function.BiConsumer;
 
-    public ExtensionPackLoader(CustomCrafting customCrafting) {
-        super(customCrafting, new NamespacedKey(customCrafting, "extension_loader"));
-    }
-
-    @Override
-    public void load() {
-
-    }
-
-    @Override
-    protected int validatePending(PluginIntegration pluginIntegration) {
-        return 0;
-    }
-
-    @Override
-    public void save() {
-
-    }
-
-    @Override
-    public boolean save(CustomRecipe<?> recipe) {
-        return false;
-    }
-
-    @Override
-    public boolean save(CustomItem item) {
-        return false;
-    }
-
-    @Override
-    public boolean delete(CustomRecipe<?> recipe) {
-        return false;
-    }
-
-    @Override
-    public boolean delete(CustomItem item) {
-        return false;
-    }
+public record ScheduledPluginIntegrationTask(PluginIntegration integration, BiConsumer<PluginIntegration, Integer> callback) {
 }


### PR DESCRIPTION
This should fix ConcurrentModification Errors when PluginIntegrations (e.g. ItemsAdder) are enabled while CustomCrafting is still loading the initial data.